### PR TITLE
I hate cron

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,8 @@
 name: PR Labeling
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  pull_request:
+    types: [synchronize]
+
 jobs:
   labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION

## About The Pull Request
Makes labeler run whenever a new commit is pushed to a pr, rather than every few (...).
## Why It's Good For The Game
Has no in-game effect.
## Proof Of Testing
I can surely get proof on something that happens on the github.
## Changelog
Makes labeler run on synchronize rather than cron.
:cl:
/:cl:
