### PR TITLE
[Ready for Review]  Examine, Sizecode, Veteran Removal

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -446,6 +446,9 @@
 			. += span_warning("<B>[t_His] eyes are glowing with an unnatural red aura!</B>")
 		else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES))
 			. += span_warning("<B>[t_His] eyes are bloodshot!</B>")
+	//ears
+	if(ears && !(obscured & ITEM_SLOT_EARS) && !(ears.item_flags & EXAMINE_SKIP))
+		. += "[t_He] [t_has] [ears.examine_title_worn(user)] on [t_his] ears."
 // BUBBER EDIT END
 
 // Yes there's a lot of copypasta here, we can improve this later when carbons are less dumb in general

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -51,6 +51,12 @@
 	if (length(status_examines))
 		. += status_examines
 
+	// SPLURT EDIT START: - Sizecode
+	var/list/size_examines = get_size_examine_info(user)
+	if (length(size_examines))
+		. += size_examines
+	// SPLURT EDIT END
+
 	if(get_bodypart(BODY_ZONE_HEAD) && !get_organ_by_type(/obj/item/organ/internal/brain))
 		. += span_deadsay("It appears that [t_his] brain is missing...")
 
@@ -440,9 +446,6 @@
 			. += span_warning("<B>[t_His] eyes are glowing with an unnatural red aura!</B>")
 		else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES))
 			. += span_warning("<B>[t_His] eyes are bloodshot!</B>")
-	//ears
-	if(ears && !(obscured & ITEM_SLOT_EARS) && !(ears.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [ears.examine_title_worn(user)] on [t_his] ears."
 // BUBBER EDIT END
 
 // Yes there's a lot of copypasta here, we can improve this later when carbons are less dumb in general
@@ -467,9 +470,21 @@
 				accessory_message = " with [english_list(accessories)] attached"
 
 		. += "[t_He] [t_is] wearing [w_uniform.examine_title_worn(user)][accessory_message]."
+	// SPLURT EDIT - shirt
+	if(w_shirt && !undershirt_hidden() && !(w_shirt.item_flags & EXAMINE_SKIP))
+		. += "[t_He] [t_is] wearing [w_shirt.examine_title_worn(user)]."
+	// SPLURT EDIT - bra
+	if(w_bra && !bra_hidden() && !(w_bra.item_flags & EXAMINE_SKIP))
+		. += "[t_He] [t_is] wearing [w_bra.examine_title_worn(user)]."
+	// SPLURT EDIT - underwear
+	if(w_underwear && !underwear_hidden() && !(w_underwear.item_flags & EXAMINE_SKIP))
+		. += "[t_He] [t_is] wearing [w_underwear.examine_title_worn(user)]."
 	//head
 	if(head && !(obscured & ITEM_SLOT_HEAD) && !(head.item_flags & EXAMINE_SKIP))
 		. += "[t_He] [t_is] wearing [head.examine_title_worn(user)] on [t_his] head."
+	// SPLURT EDIT - socks
+	if(w_socks && !socks_hidden() && !(w_socks.item_flags & EXAMINE_SKIP))
+		. += "[t_He] [t_is] wearing [w_socks.examine_title_worn(user)] on [t_his] feet."
 	//mask
 	if(wear_mask && !(obscured & ITEM_SLOT_MASK)  && !(wear_mask.item_flags & EXAMINE_SKIP))
 		. += "[t_He] [t_has] [wear_mask.examine_title_worn(user)] on [t_his] face."
@@ -485,8 +500,19 @@
 		else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES))
 			. += span_warning("<B>[t_His] eyes are bloodshot!</B>")
 	//ears
-	if(ears && !(obscured & ITEM_SLOT_EARS) && !(ears.item_flags & EXAMINE_SKIP))
-		. += "[t_He] [t_has] [ears.examine_title_worn(user)] on [t_his] ears."
+	if(ears && !(obscured & ITEM_SLOT_EARS_LEFT) && !(ears.item_flags & EXAMINE_SKIP))
+		. += "[t_He] [t_has] [ears.examine_title_worn(user)] on [t_his] left ear." // extra inventory
+
+	// SPLURT EDIT - ears extra
+	if(ears_extra && !(obscured & ITEM_SLOT_EARS_RIGHT) && !(ears_extra.item_flags & EXAMINE_SKIP))
+		. += "[t_He] [t_has] [ears_extra.examine_title_worn(user)] on [t_his] right ear."
+
+	// SPLURT EDIT - ears extra
+	//wearing two ear items makes you look like an idiot
+	if((istype(ears, /obj/item/radio/headset) && !(obscured & ITEM_SLOT_EARS_LEFT) && !(ears.item_flags & EXAMINE_SKIP)) && (istype(ears_extra, /obj/item/radio/headset) && !(obscured & ITEM_SLOT_EARS_RIGHT) && !(ears_extra.item_flags & EXAMINE_SKIP)))
+		. += span_warning("[t_He] looks quite tacky wearing both \an [ears.name] and \an [ears_extra.name] on [t_his] head.")
+
+	//
 	//suit/armor
 	if(wear_suit && !(wear_suit.item_flags & EXAMINE_SKIP))
 		. += "[t_He] [t_is] wearing [wear_suit.examine_title_worn(user)]."
@@ -516,6 +542,9 @@
 	else if(GET_ATOM_BLOOD_DNA_LENGTH(src) || blood_in_hands)
 		if(num_hands)
 			. += span_warning("[t_He] [t_has] [num_hands > 1 ? "" : "a "]blood-stained hand[num_hands > 1 ? "s" : ""]!")
+	// SPLURT EDIT - wrists
+	if(wrists && !wrists_hidden() && !(wrists.item_flags & EXAMINE_SKIP))
+		. += "[t_He] [t_is] wearing [wrists.examine_title_worn(user)]."
 	//handcuffed?
 	if(handcuffed)
 		var/cables_or_cuffs = istype(handcuffed, /obj/item/restraints/handcuffs/cable) ? "restrained with cable" : "handcuffed"

--- a/modular_zzplurt/code/modules/admin/player_panel.dm
+++ b/modular_zzplurt/code/modules/admin/player_panel.dm
@@ -93,8 +93,10 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 			player_ranks += "Donator"
 		if(SSplayer_ranks.is_mentor(targetClient, admin_bypass = FALSE))
 			player_ranks += "Mentor"
-		if(SSplayer_ranks.is_veteran(targetClient, admin_bypass = FALSE))
-			player_ranks += "Veteran"
+		// SPLURT EDIT: Remove Veteran. Veteran cut from the Bubberstation build.
+		// if(SSplayer_ranks.is_veteran(targetClient, admin_bypass = FALSE))
+		//	player_ranks += "Veteran"
+		//
 		if(SSplayer_ranks.is_vetted(targetClient, admin_bypass = FALSE))
 			player_ranks |= "Vetted"
 		.["ranks"] = length(player_ranks) ? player_ranks.Join(", ") : null

--- a/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/hemophage_species.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/hemophage_species.dm
@@ -10,7 +10,7 @@
 	mutantlungs = /datum/species::mutantlungs
 
 	// Disable veteran restriction
-	veteran_only = FALSE
+	// /veteran_only = FALSE Veteran cut from the Bubberstation build.
 
 	// Return original
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Restored the examine functionality and height display.
Removed code references to the Veteran role due to its deprecation on Bubber.
## Why It's Good For The Game
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Restored the examine functionality and height display.
/:cl:
