### PR TITLE
Temporary fix for inflatables

### DIFF
--- a/modular_skyrat/modules/inflatables/code/inflatable.dm
+++ b/modular_skyrat/modules/inflatables/code/inflatable.dm
@@ -85,6 +85,7 @@
 		new deflated_type(get_turf(src))
 	qdel(src)
 
+/*
 /obj/structure/inflatable/verb/hand_deflate()
 	set name = "Deflate"
 	set category = "Object"
@@ -93,7 +94,7 @@
 	if(usr.stat || usr.can_interact())
 		return
 	deflate(FALSE)
-
+*/
 
 /obj/structure/inflatable/door
 	name = "inflatable door"


### PR DESCRIPTION
## About The Pull Request
For some reason inflatable objects make the client crash when seen, this is a temporary fix until a proper fix to the issue is found. Thanks to the people in byond discord for helping with this

## Why It's Good For The Game
Less random client crashes

## Proof Of Testing
It no longer crashes

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: makes clients not crash when seeing an inflatable object (temporary fix)
/:cl:

