### PR TITLE
[READY] Re-enables the body morpher quirk

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -70,7 +70,7 @@
 	button_icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi'
 	background_icon_state = "bg_alien"
 	/// Do you need to be a slime-person to use this ability?
-	var/slime_restricted = TRUE
+	var/slime_restricted = FALSE // splurt edit: original = TRUE
 	///Is the person using this ability oversized?
 	var/oversized_user = FALSE
 	///What text is shown to others when the person uses the ability?

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm
@@ -11,7 +11,6 @@
 	mail_goodies = list (
 		/obj/item/toy/foamblade = 1 // Fake changeling
 	)
-	hidden_quirk = TRUE
 
 /datum/quirk/body_morpher/add(client/client_source)
 	// Define quirk mob

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm
@@ -11,7 +11,6 @@
 	mail_goodies = list (
 		/obj/item/toy/foamblade = 1 // Fake changeling
 	)
-	// hidden_quirk = TRUE // splurt edit
 /datum/quirk/body_morpher/add(client/client_source)
 	// Define quirk mob
 	var/mob/living/carbon/human/quirk_mob = quirk_holder

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm
@@ -11,7 +11,7 @@
 	mail_goodies = list (
 		/obj/item/toy/foamblade = 1 // Fake changeling
 	)
-
+	// hidden_quirk = TRUE // splurt edit
 /datum/quirk/body_morpher/add(client/client_source)
 	// Define quirk mob
 	var/mob/living/carbon/human/quirk_mob = quirk_holder


### PR DESCRIPTION

## About The Pull Request

By request, re-enables the Body Morpher quirk.

## Why It's Good For The Game

It's an incredibly popular quirk among players here at Splurt, and it being locked behind a NIF removes a lot of character uniqueness (natural shapeshifters, ghost role enthusiasts, shapeshifters that just hate technology) from the pool.

## Proof Of Testing

I went insane. Isn't that proof enough?

![2e9d1220f47b593571274e247bffac7b](https://github.com/user-attachments/assets/d359d0fc-dab0-425d-aac2-c359fa70f51a)

## Changelog
:cl:
change: set `hidden_quirk` for `quirk/body_morpher` to not existing.
change: set `slime_restricted` for `innate/alter_form` to false.
/:cl:
