### PR TITLE
Fixing a space ruin messing with integration tests

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/shuttle8532.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/shuttle8532.dmm
@@ -2446,7 +2446,6 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "ZK" = (
-/obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/dim/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -143,7 +143,7 @@
 	)
 
 /obj/effect/decal/cleanable/cobweb
-	SET_BASE_PIXEL(0, 24)
+	// SET_BASE_PIXEL(0, 24)	// SPLURT EDIT - why was this here in the first place??
 	name = "cobweb"
 	desc = "Somebody should remove that."
 	gender = NEUTER


### PR DESCRIPTION
## About The Pull Request

From time to time, a skyrat ruin would spawn near the station, which had a cobweb decal on a space tile. For some reason it's never been caught by tests, so here we go. Also cobwebs were oddly misaligned by 24px vertically (skyrat's thing).

## Why It's Good For The Game

This caused almost all prs to fail the integration tests

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
![image](https://github.com/user-attachments/assets/b6c1840a-aa70-4782-a8eb-6e9cf70eda9c)
</details>

## Changelog

:cl:
fix: Minor "Shuttle 8532" tweaks to not trigger tests
/:cl: