### PR TITLE
Quick fix - adds a join menu icon to the blacksmith role

### DIFF
--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -10,6 +10,7 @@ const BASEICONS = {
   Bartender: 'cocktail',
   'Bit Avatar': 'code',
   Bitrunner: 'gamepad',
+  Blacksmith: 'hammer',
   Botanist: 'seedling',
   'Bridge Assistant': 'building-shield',
   Captain: 'crown',

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -10,7 +10,7 @@ const BASEICONS = {
   Bartender: 'cocktail',
   'Bit Avatar': 'code',
   Bitrunner: 'gamepad',
-  Blacksmith: 'hammer',
+  Blacksmith: 'hammer', // SPLURT EDIT - Added an icon to Blacksmith
   Botanist: 'seedling',
   'Bridge Assistant': 'building-shield',
   Captain: 'crown',


### PR DESCRIPTION
## About The Pull Request

the title says it all - nothing complex

## Why It's Good For The Game

duh? every role needs an icon, we have to be consistent with tgui's style

## Proof Of Testing

![image](https://github.com/user-attachments/assets/80bf8488-2b56-489e-979b-108e406a4e03)
alas, there is no anvil icon, so I think the hammer is the most fitting 

## Changelog

:cl:
fix: Added a join menu icon for the blacksmith
/:cl:
