### PR TITLE
[FIX]  Remove barricade rotation verb

### DIFF
--- a/modular_skyrat/modules/barricades/code/barricade.dm
+++ b/modular_skyrat/modules/barricades/code/barricade.dm
@@ -202,6 +202,8 @@
 		else
 			. += image('modular_skyrat/modules/barricades/icons/barricade.dmi', icon_state = "[barricade_type]_closed_wire")
 
+// SPLURT EDIT START: REMOVE CRASHING VERBS
+/*
 /obj/structure/deployable_barricade/verb/rotate()
 	set name = "Rotate barricade counterclockwise <"
 	set category = "Object"
@@ -223,7 +225,8 @@
 		return FALSE
 
 	setDir(turn(dir, 270))
-
+*/
+// SPLURT EDIT END: REMOVE CRASHING VERBS
 
 /obj/structure/deployable_barricade/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()

--- a/modular_skyrat/modules/inflatables/code/inflatable.dm
+++ b/modular_skyrat/modules/inflatables/code/inflatable.dm
@@ -85,6 +85,7 @@
 		new deflated_type(get_turf(src))
 	qdel(src)
 
+// SPLURT EDIT START: REMOVE CRASHING VERBS
 /*
 /obj/structure/inflatable/verb/hand_deflate()
 	set name = "Deflate"
@@ -95,6 +96,7 @@
 		return
 	deflate(FALSE)
 */
+// SPLURT EDIT END: REMOVE CRASHING VERBS
 
 /obj/structure/inflatable/door
 	name = "inflatable door"


### PR DESCRIPTION

## About The Pull Request
- Temporarily comments out barricade rotation verbs to fix client crashes on BYOND 515
- Adds comments to inflatablewall code for better documentation
## Why It's Good For The Game
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Temporarily disabled barricade rotation to prevent client crashes
/:cl:
