### PR TITLE
Remove meteor pens from maints loot

### DIFF
--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
@@ -4,7 +4,6 @@ GLOBAL_LIST_INIT(one_of_a_kind_loot, list(
 	/obj/item/melee/energy/sword/bananium,
 	/obj/item/dice/d20/teleporting_die_of_fate,
 	/obj/item/modular_computer/pda/clear,
-	/obj/item/gun/energy/meteorgun/pen,
 	/obj/item/hot_potato,
 	/obj/item/clothing/shoes/gunboots/disabler,
 	/obj/item/spear/grey_tide,

--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_INIT(one_of_a_kind_loot, list(
 	/obj/item/melee/energy/sword/bananium,
 	/obj/item/dice/d20/teleporting_die_of_fate,
 	/obj/item/modular_computer/pda/clear,
+	//obj/item/gun/energy/meteorgun/pen, -splurt remove
 	/obj/item/hot_potato,
 	/obj/item/clothing/shoes/gunboots/disabler,
 	/obj/item/spear/grey_tide,


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin. Removes the meteor gun pen from bubber's loot pool in maints, because why is that even in there.
## Why It's Good For The Game

One-shot gibbing memes in maints does not fit our server.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
removed: meteor pen from maints loot
/:cl:
