### PR TITLE
Syndie-Cat Nerf

### DIFF
--- a/modular_zubbers/code/modules/mob/living/basic/pets/cat/super_cat.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/pets/cat/super_cat.dm
@@ -94,7 +94,7 @@
 /mob/living/basic/pet/cat/syndicat/super
 	name = "Super Syndie Cat"
 	desc = "OH GOD! RUN!! IT CAN SMELL THE DISK!"
-	speed = 0.3 // Slightly slower than a normal super cat since they have a suit
+	speed = 0.6 // Slightly slower than a normal super cat since they have a suit
 	health = SYNDIE_SUPER_KITTY_HEALTH
 	maxHealth = SYNDIE_SUPER_KITTY_HEALTH
 

--- a/modular_zubbers/code/modules/spells/spell_types/shapeshift/kittyform.dm
+++ b/modular_zubbers/code/modules/spells/spell_types/shapeshift/kittyform.dm
@@ -3,7 +3,7 @@
 	name = "KITTY POWER!!"
 	desc = "Take on the shape of a kitty cat! Gain their powers at a loss of vitality."
 
-	cooldown_time = 20 SECONDS
+	cooldown_time = 120 SECONDS
 	invocation = "MRR MRRRW!!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC


### PR DESCRIPTION

## About The Pull Request / Why It's Good For The Game
SyndieCat is currently dominating Syndie meta for VERY obvious reasons, and being abused to score cheap wins.
This increases the cost to force devotion, as well as making a 2 minute cooldown on form change so they need to have a backup to escape a terrible situation. Cat form is also slowed further, hence they will have to change into cat form when /at/ the vent, making it more reactable by Sec. ((Those fuckers need to learn to grab people out of jumping into vents.))
## Changelog
:cl:
balance: rebalanced something
:cl/:
