### PR TITLE
Makes the Nanotrasen Representative Admin-Only

### DIFF
--- a/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -8,9 +8,9 @@
 	supervisors = "Central Command"
 	minimal_player_age = 14
 	exp_requirements = 600
-	exp_required_type = EXP_TYPE_ADMIN //SPLURT modification : original EXP_TYPE_CREW
-	exp_required_type_department = EXP_TYPE_ADMIN //SPLURT modification : original EXP_TYPE_COMMAND
-	exp_granted_type = EXP_TYPE_CENTRAL_COMMAND //SPLURT modification : original EXP_TYPE_CREW
+	exp_required_type = EXP_TYPE_CREW
+	exp_required_type_department = EXP_TYPE_COMMAND
+	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "NANOTRASEN_CONSULTANT"
 
 	department_for_prefs = /datum/job_department/captain

--- a/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -8,9 +8,9 @@
 	supervisors = "Central Command"
 	minimal_player_age = 14
 	exp_requirements = 600
-	exp_required_type = EXP_TYPE_CREW
-	exp_required_type_department = EXP_TYPE_COMMAND
-	exp_granted_type = EXP_TYPE_CREW
+	exp_required_type = EXP_TYPE_ADMIN //SPLURT modification : original EXP_TYPE_CREW
+	exp_required_type_department = EXP_TYPE_ADMIN //SPLURT modification : original EXP_TYPE_COMMAND
+	exp_granted_type = EXP_TYPE_CENTRAL_COMMAND //SPLURT modification : original EXP_TYPE_CREW
 	config_tag = "NANOTRASEN_CONSULTANT"
 
 	department_for_prefs = /datum/job_department/captain

--- a/modular_zzplurt/code/modules/jobs/job_types/nanotrasen_consultant.dm
+++ b/modular_zzplurt/code/modules/jobs/job_types/nanotrasen_consultant.dm
@@ -1,0 +1,4 @@
+/datum/job/nanotrasen_consultant
+    exp_required_type = EXP_TYPE_ADMIN
+    exp_required_type_department = EXP_TYPE_ADMIN
+    exp_granted_type = EXP_TYPE_CENTRAL_COMMAND

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9694,6 +9694,7 @@
 #include "modular_zzplurt\code\modules\food_and_drinks\recipes\drinks\drinks_alcoholic.dm"
 #include "modular_zzplurt\code\modules\hud\_hud.dm"
 #include "modular_zzplurt\code\modules\hud\screen_objects.dm"
+#include "modular_zzplurt\code\modules\jobs\job_types\nanotrasen_consultant.dm"
 #include "modular_zzplurt\code\modules\language\_language_holder.dm"
 #include "modular_zzplurt\code\modules\language\buzzwords.dm"
 #include "modular_zzplurt\code\modules\lewd\pain.dm"


### PR DESCRIPTION

## About The Pull Request

This change makes the NT Representative / Consultant / Liaison use the "Admin" xp type which effectively makes the role staff only.
## Why It's Good For The Game

Nanotrasen Representatives are currently horridly misused and hard to quality control. This change will turn the role into something more like the Senior Enlisted Advisory from CM, wherein Admins and (in the future) Mentors can act as a direct, in-character link to Central Command.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Changed NT Rep to use *_ADMIN xp type.
/:cl:
