### PR TITLE
Ash Drake offering's clearer purpose

### DIFF
--- a/modular_zubbers/code/game/objects/items/food/meatslab.dm
+++ b/modular_zubbers/code/game/objects/items/food/meatslab.dm
@@ -1,6 +1,6 @@
 /obj/item/food/meat/slab/drakebait
 	name = "Seasoned Goliath Meat"
-	desc = "A slab of goliath meat cooked to a scorching perfection. Offer this to a friendly Ash Drake in exchange for their valuable, sturdy hide."
+	desc = "A slab of goliath meat. It's been blessed somehow, Often seen as an offering for Ash Drakes."
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment/protein = 20,
 		/datum/reagent/toxin = 1,

--- a/modular_zubbers/code/game/objects/items/food/meatslab.dm
+++ b/modular_zubbers/code/game/objects/items/food/meatslab.dm
@@ -1,6 +1,6 @@
 /obj/item/food/meat/slab/drakebait
 	name = "Seasoned Goliath Meat"
-	desc = "A slab of goliath meat. It's been blessed somehow, Often seen as an offering for Ash Drakes."
+	desc = "A slab of goliath meat cooked to a scorching perfection. Offer this to a friendly Ash Drake in exchange for their valuable, sturdy hide."
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment/protein = 20,
 		/datum/reagent/toxin = 1,

--- a/modular_zzplurt/code/game/objects/items/food/meatslab.dm
+++ b/modular_zzplurt/code/game/objects/items/food/meatslab.dm
@@ -1,0 +1,2 @@
+/obj/item/food/meat/slab/drakebait
+	desc = "A slab of goliath meat cooked to a scorching perfection. Offer this to a friendly Ash Drake in exchange for their valuable, sturdy hide."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9607,6 +9607,7 @@
 #include "modular_zzplurt\code\game\objects\items\devices\cyborg_modules\dogborg_sleepers.dm"
 #include "modular_zzplurt\code\game\objects\items\devices\cyborg_modules\general_modules.dm"
 #include "modular_zzplurt\code\game\objects\items\devices\cyborg_modules\inducer.dm"
+#include "modular_zzplurt\code\game\objects\items\food\meatslab.dm"
 #include "modular_zzplurt\code\game\objects\items\implants\implant_disrobe.dm"
 #include "modular_zzplurt\code\game\objects\items\implants\implant_gfluid.dm"
 #include "modular_zzplurt\code\game\objects\items\implants\implant_hide_backpack.dm"


### PR DESCRIPTION
## About The Pull Request

Changes the description of the food item spawned by the ash walker ritual
modular_zubbers/code/game/objects/items/food/meatslab.dm
to make it clear that it should be given to ash drakes in exchange for their hide.

## Why It's Good For The Game

I've seen ashwalker players confused about why the ash drakes are neutral to them. Due to the nature of how buggy lavaland can be and with the existence of a rare bug that made every mob including megafauna neutral, it was kinda quietly accepted that ash drakes not attacking walkers back was some kind of a bug, despite it being a feature

The description of the offering just made it more confusing, as it didn't explicitly state why you would give this food item to them. They're already neutral, after all. So I just made it more clear

## Proof Of Testing

it's just a description change, should work
mosley will do the moduralization cuz he promised

## Changelog
:cl:
spellcheck: Modified the description of seasoned goliath meat to make sure ashies don't murder their friendly drakes
/:cl:
