### PR TITLE
fixed missed inheritance with modular limbs quirk changes

### DIFF
--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/modularlimbs.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/modularlimbs.dm
@@ -54,6 +54,10 @@
 	// More descriptive text, with warning
 	name = "Eject a random limb"
 	desc = "Eject a random limb from your body."
+	button_icon_state = "autotomy"
+
+	cooldown_time = 1 SECONDS
+	spell_requirements = NONE
 
 	// Default ability background
 	background_icon = 'icons/mob/actions/backgrounds.dmi'


### PR DESCRIPTION

## About The Pull Request
I missed the spell requirements inheritance since I didn't have an easy way to test it or log on
## Why It's Good For The Game
spell should work

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: makes modular limbs spell work
/:cl:
