### PR TITLE
Temporarily Removes Space Dragon From Rotation

### DIFF
--- a/code/modules/events/ghost_role/space_dragon.dm
+++ b/code/modules/events/ghost_role/space_dragon.dm
@@ -34,3 +34,4 @@
 	dragon.log_message("was spawned as a Space Dragon by an event.", LOG_GAME)
 	spawned_mobs += dragon
 	return SUCCESSFUL_SPAWN
+*/

--- a/code/modules/events/ghost_role/space_dragon.dm
+++ b/code/modules/events/ghost_role/space_dragon.dm
@@ -1,3 +1,4 @@
+/* Removed pending rework - Splurt
 /datum/round_event_control/space_dragon
 	name = "Spawn Space Dragon"
 	typepath = /datum/round_event/ghost_role/space_dragon

--- a/modular_skyrat/modules/oneclickantag/code/oneclickantag.dm
+++ b/modular_skyrat/modules/oneclickantag/code/oneclickantag.dm
@@ -186,9 +186,10 @@ If anyone can figure out how to get Obsessed to work I would be very appreciativ
 		if(ROLE_REVENANT)
 			new /datum/round_event/ghost_role/revenant(TRUE, TRUE)
 			return TRUE
-		if(ROLE_SPACE_DRAGON)
-			new /datum/round_event/ghost_role/space_dragon()
-			return TRUE
+// Removed pending SPLURT rework
+//		if(ROLE_SPACE_DRAGON)
+//			new /datum/round_event/ghost_role/space_dragon()
+//			return TRUE
 	return FALSE
 
 /datum/admins/proc/make_wizard()


### PR DESCRIPTION

## About The Pull Request

Comments out Space Dragon from spawning as an antagonist until we can properly balance it to storyteller and adjust it's features.
## Why It's Good For The Game

Space dragon killing the entire crew in a manner of 15 minutes is not good gameplay for our station demographic.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
Commented out Space Dragon related spawning mechanics.
/:cl:
