### PR TITLE
hope this a good approach

### DIFF
--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/concubus.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/concubus.dm
@@ -28,12 +28,14 @@
 	// Increase hunger rate
 	quirk_mob.physiology.hunger_mod *= QUIRK_HUNGER_CONCUBUS
 
+	/* REWORK
 	// Prevent consuming normal food
 	ADD_TRAIT(quirk_mob, TRAIT_LIVERLESS_METABOLISM, TRAIT_CONCUBUS)
 	//ADD_TRAIT(quirk_mob,TRAIT_NOTHIRST,QUIRK_TRAIT) // Thirst not yet implemented
 
 	// Register special reagent interactions
 	RegisterSignals(quirk_holder, list(COMSIG_REAGENT_ADD_CUM, COMSIG_REAGENT_ADD_BREASTMILK), PROC_REF(handle_fluids))
+	*/
 
 /datum/quirk/concubus/remove()
 	// Define quirk holder
@@ -46,6 +48,7 @@
 	// Revert hunger rate change
 	quirk_mob.physiology.hunger_mod /= QUIRK_HUNGER_CONCUBUS
 
+	/* REWORK
 	// Revert quirk traits
 	REMOVE_TRAIT(quirk_mob, TRAIT_LIVERLESS_METABOLISM, TRAIT_CONCUBUS)
 	//REMOVE_TRAIT(quirk_mob,TRAIT_NOTHIRST,QUIRK_TRAIT) // Thirst not yet implemented
@@ -53,7 +56,9 @@
 	// Unregister special reagent interactions
 	UnregisterSignal(quirk_holder, COMSIG_REAGENT_ADD_CUM)
 	UnregisterSignal(quirk_holder, COMSIG_REAGENT_ADD_BREASTMILK)
+	*/
 
+/* REWORK
 /// Proc to handle reagent interactions with bodily fluids
 /datum/quirk/concubus/proc/handle_fluids(mob/living/target, datum/reagent/handled_reagent, amount)
 	SIGNAL_HANDLER
@@ -65,5 +70,6 @@
 
 	// Add Notriment
 	quirk_holder.reagents.add_reagent(/datum/reagent/consumable/notriment, amount)
+*/
 
 #undef QUIRK_HUNGER_CONCUBUS

--- a/modular_zzplurt/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/modular_zzplurt/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -17,3 +17,21 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	taste_description = "sweetness"
+
+#define CONCUBUS_FLUIDS list(/datum/reagent/consumable/cum,\
+							/datum/reagent/consumable/femcum,\
+							/datum/reagent/consumable/milk)
+
+/datum/reagent/consumable/get_nutriment_factor(mob/living/carbon/eater)
+	var/nutriment_factor = 8
+	if (eater.has_quirk(/datum/quirk/concubus))
+		return (src.type in CONCUBUS_FLUIDS) ? (nutriment_factor * REAGENTS_METABOLISM * purity * 2) : 0
+	return ..()
+
+/datum/reagent/consumable/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
+	if(exposed_mob.has_quirk(/datum/quirk/concubus))
+		return
+	else
+		return ..()
+
+#undef CONCUBUS_FLUIDS

--- a/modular_zzplurt/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/modular_zzplurt/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -1,3 +1,7 @@
+#define CONCUBUS_FLUIDS list(/datum/reagent/consumable/cum,\
+							/datum/reagent/consumable/femcum,\
+							/datum/reagent/consumable/milk)
+
 // Reagent process: Salt
 /datum/reagent/consumable/salt/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -18,10 +22,6 @@
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	taste_description = "sweetness"
 
-#define CONCUBUS_FLUIDS list(/datum/reagent/consumable/cum,\
-							/datum/reagent/consumable/femcum,\
-							/datum/reagent/consumable/milk)
-
 /datum/reagent/consumable/get_nutriment_factor(mob/living/carbon/eater)
 	var/nutriment_factor = 8
 	if (eater.has_quirk(/datum/quirk/concubus))
@@ -31,7 +31,6 @@
 /datum/reagent/consumable/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	if(exposed_mob.has_quirk(/datum/quirk/concubus))
 		return
-	else
-		return ..()
+	return ..()
 
 #undef CONCUBUS_FLUIDS


### PR DESCRIPTION
## About The Pull Request
Trying a new approach for the Concubus quirk, modifying the nutritional value itself when the user has said quirk, instead of giving them the liverless traits, preventing them from metabolizing healing meds.
Not belittling the previous implementation, I just want to give this one a try!
## Why It's Good For The Game
I really think "Incubi" and "Succubi" should have a proper metabolism, there's not a mention about that in the quirk description.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_kD5mRr4uWZ](https://github.com/user-attachments/assets/0ecbbd06-dfd1-42dd-9576-670f2e61e633)

It does metabolize now, just doesn't raise the nutrition of the eater.
</details>


## Changelog
:cl:
refactor: refactored the Concubus quirk code
/:cl:
