### PR TITLE
Fix an Error with Organic to Cyborg interactions

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
@@ -18,6 +18,10 @@
 
 
 /datum/examine_panel/ui_interact(mob/user, datum/tgui/ui)
+	if(!holder)
+		return
+	if(!user.client)
+		return
 	if(!examine_panel_screen)
 		examine_panel_screen = new
 		examine_panel_screen.name = "screen"
@@ -46,6 +50,8 @@
 
 /datum/examine_panel/ui_data(mob/user)
 	var/list/data = list()
+	if(!holder)
+		return data
 
 	var/datum/preferences/preferences = holder.client?.prefs
 

--- a/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
@@ -18,10 +18,10 @@
 
 
 /datum/examine_panel/ui_interact(mob/user, datum/tgui/ui)
-	if(!holder)
+	if(!holder) //Splurt Edit Starts Here
 		return
 	if(!user.client)
-		return
+		return //Splurt Edit Ends Here
 	if(!examine_panel_screen)
 		examine_panel_screen = new
 		examine_panel_screen.name = "screen"
@@ -50,9 +50,10 @@
 
 /datum/examine_panel/ui_data(mob/user)
 	var/list/data = list()
+	//Splurt Edit Start
 	if(!holder)
 		return data
-
+	//Splurt Edit End
 	var/datum/preferences/preferences = holder.client?.prefs
 
 	var/flavor_text

--- a/modular_skyrat/modules/borgs/code/robot_defines.dm
+++ b/modular_skyrat/modules/borgs/code/robot_defines.dm
@@ -1,6 +1,10 @@
 /mob/living/silicon
 	var/datum/examine_panel/examine_panel = new() //create the datum
 
+/mob/living/silicon/Initialize(mapload)
+	. = ..()
+	examine_panel.holder = src // Set the holder during initialization
+
 /mob/living/silicon/robot
 	blocks_emissive = EMISSIVE_BLOCK_NONE
 	var/robot_resting = FALSE

--- a/modular_skyrat/modules/borgs/code/robot_defines.dm
+++ b/modular_skyrat/modules/borgs/code/robot_defines.dm
@@ -1,10 +1,10 @@
 /mob/living/silicon
 	var/datum/examine_panel/examine_panel = new() //create the datum
-
+//Splurt Edit
 /mob/living/silicon/Initialize(mapload)
 	. = ..()
 	examine_panel.holder = src // Set the holder during initialization
-
+//Splurt Edit End
 /mob/living/silicon/robot
 	blocks_emissive = EMISSIVE_BLOCK_NONE
 	var/robot_resting = FALSE


### PR DESCRIPTION

## About The Pull Request

For some reason, borgs were able to interact with other borgs and organics, but organics interacting with borgs was causing a bluescreen. This fixes that by ensuring the panel properly initializes for borgs and adds checks to make sure that `holder` is properly set before attempting to render the panel in TGUI.
## Why It's Good For The Game

Brings parity, fixes a bug, enables the white women to interact with dogborgs once again.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
![f603f284812a025d63fb5b6c234b7a66](https://github.com/user-attachments/assets/c96e8769-3fbd-4702-a77c-3892a79f9bfd)

</details>

## Changelog
:cl:
add: checks for `holder` and `user.client` in examine_tgui
add: an initialize for examine_panel on mapload for silicons
/:cl:
