### PR TITLE
Adds toolbox to blacklist on persistence

### DIFF
--- a/modular_skyrat/master_files/code/modules/loadout/categories/inhands.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/inhands.dm
@@ -26,7 +26,7 @@
 /datum/loadout_item/inhand/toolbox
 	name = "Full Toolbox"
 	item_path = /obj/item/storage/toolbox/mechanical
-	blacklisted_roles = list(JOB_PRISONER)
+	blacklisted_roles = list(JOB_PRISONER, ROLE_PERSISTENCE)
 
 /datum/loadout_item/inhand/bouquet_mixed
 	name = "Mixed Bouquet"


### PR DESCRIPTION
Toolboxes are spawning in with hostages on persistence. This shouldn't be allowed for obvious reasons.