### PR TITLE
Razor Claw Nerf

### DIFF
--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -61,16 +61,16 @@
 	lefthand_file = 'modular_skyrat/modules/implants/icons/razorclaws_lefthand.dmi'
 	icon_state = "wolverine"
 	inhand_icon_state = "wolverine"
-	var/knife_force = 15 //Splurt Edit
+	var/knife_force = 7.5 //Splurt Edit
 	w_class = WEIGHT_CLASS_BULKY
-	var/knife_wound_bonus = 5
+	var/knife_wound_bonus = 2
 	var/cutter_force = CUTTER_FORCE
 	var/cutter_wound_bonus = CUTTER_WOUND_BONUS
 	var/cutter_bare_wound_bonus = CUTTER_WOUND_BONUS
 	tool_behaviour = TOOL_KNIFE
-	toolspeed = 1
-	attack_speed = 6
-	force = 15 //Splurt Edit/Addition
+	toolspeed = 4
+	attack_speed = 10
+	force = 7.5 //Splurt Edit/Addition
 	item_flags = NEEDS_PERMIT //Beepers gets angry if you get caught with this.
 
 /obj/item/knife/razor_claws/attack_self(mob/user)
@@ -93,7 +93,7 @@
 		to_chat(user, span_notice("You shift [src] into Killing mode, for slicing."))
 		icon_state = "wolverine"
 		inhand_icon_state = "wolverine"
-		force = 15 //Splurt Edit
+		force = 7.5 //Splurt Edit
 		sharpness = KNIFE_SHARPNESS
 		wound_bonus = knife_wound_bonus
 		bare_wound_bonus = KNIFE_BARE_WOUND_BONUS


### PR DESCRIPTION
This is a long time coming.

Basically razorclaws are already cheesed. The broken quirk system gives people dual blade, 15 force+wound buffs and a free knife+wirecutter tool in hand. This is a nerf until the point system is fixed, as this is being abused by prisoners and multiple other greytiders as a free greytiding tool. 

What does this do?

Halves the damage overall. And makes tool use much slower (being able to fully gut someone at the same speed as a combat knife is ridiculous)