### PR TITLE
You can see cigarettes attached to your gas mask filter slot

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -91,6 +91,9 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 		if(ismob(loc))
 			var/mob/wearer = loc
 			wearer.update_worn_mask()
+		// SPLURT EDIT ADDITION BEGIN - Smokin' fat darts
+		update_appearance(UPDATE_ICON)
+		// SPLURT EDIT ADDITION END
 
 /obj/item/clothing/mask/gas/attackby(obj/item/tool, mob/user)
 	var/valid_wearer = ismob(loc)
@@ -112,6 +115,9 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 		cig.forceMove(src)
 		if(valid_wearer)
 			wearer.update_worn_mask()
+		// SPLURT EDIT ADDITION BEGIN - Smokin' fat darts
+		update_appearance(UPDATE_ICON)
+		// SPLURT EDIT ADDITION END
 		return TRUE
 
 	if(cig)
@@ -136,6 +142,9 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 		if(ismob(loc))
 			var/mob/wearer = loc
 			wearer.update_worn_mask()
+		// SPLURT EDIT ADDITION BEGIN - Smokin' fat darts
+		update_appearance(UPDATE_ICON)
+		// SPLURT EDIT ADDITION END
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(!has_filter || !max_filters)
 		return SECONDARY_ATTACK_CONTINUE_CHAIN

--- a/modular_zzplurt/code/modules/clothing/masks/gasmask.dm
+++ b/modular_zzplurt/code/modules/clothing/masks/gasmask.dm
@@ -1,3 +1,17 @@
+// If you have a dart in your mask, an overlay is shown on it
+/obj/item/clothing/mask/gas
+
+/obj/item/clothing/mask/gas/update_overlays()
+	. = ..()
+	if(cig)
+		var/mutable_appearance/dart_appearance = new /mutable_appearance(cig)
+		dart_appearance.plane = FLOAT_PLANE
+		dart_appearance.layer = FLOAT_LAYER
+		dart_appearance.pixel_x = -ICON_SIZE_X/8
+		dart_appearance.pixel_y = -ICON_SIZE_Y/8
+		dart_appearance.transform *= 0.5
+		. += dart_appearance
+
 /obj/item/clothing/mask/gas/cosmetic
 	name = "aesthetic gas mask"
 	desc = "A face-covering mask that resembles a traditional gas mask, but without the breathing functionality."


### PR DESCRIPTION
## About The Pull Request

Just makes them visible in the inventory as an overlay

## Why It's Good For The Game

Visual feedback, works with any mask

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/84205144-6e31-4d81-962f-71031a475294)

![image](https://github.com/user-attachments/assets/f02080f1-de33-4311-a508-260199369a1b)

</details>

## Changelog

:cl:
qol: You can now see cigarettes attached to your mask on your inventory
/:cl:
