### PR TITLE
Slime puddles can't pass through doors

### DIFF
--- a/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -82,6 +82,7 @@
 
 				original_pass_flags = H.pass_flags
 				H.pass_flags |= PASSMOB
+				H.pass_flags |= PASSTABLE
 				H.layer = 3
 				squeak = H.AddComponent(/datum/component/squeak, list('sound/effects/blob/blobattack.ogg'))
 

--- a/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -82,8 +82,6 @@
 
 				original_pass_flags = H.pass_flags
 				H.pass_flags |= PASSMOB
-				H.pass_flags |= PASSTABLE
-				H.pass_flags |= PASSDOORS
 				H.layer = 3
 				squeak = H.AddComponent(/datum/component/squeak, list('sound/effects/blob/blobattack.ogg'))
 


### PR DESCRIPTION
## About The Pull Request

What the title says

## Why It's Good For The Game

It's pretty overpowered to be able to walk through any door with a round start race.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
Trust me bro
</details>

## Changelog
:cl:
del: Removed puddle transform's door and table passthrough
/:cl:
