### PR TITLE
Raw Meatpizza Recipe Fix

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
@@ -15,7 +15,7 @@
 	)
 	result = /obj/item/food/pizza/margherita/raw
 
-/datum/crafting_recipe/food/meatpizza
+/datum/crafting_recipe/food/pizza/meat       // SPLURT EDIT - Shows up in crafting menu otherwise
 	reqs = list(
 		/obj/item/food/flatdough = 1,
 		/obj/item/food/meat/rawcutlet = 4,


### PR DESCRIPTION
## About The Pull Request

Fixes raw meatpizza showing up in crafting rather than cooking part of crafting menu due to a messy recipe path.

## Why It's Good For The Game

So I don't get confused why I can't make raw meatpizza only to codedive and see its in the crafting menu compared to every other pizza.

## Proof Of Testing
<details>

<summary>Before</summary>

![image](https://github.com/user-attachments/assets/1ad3fec7-a867-46ac-8014-d31f7608f3f0)

</details>
<details>

<summary>After</summary>

![image](https://github.com/user-attachments/assets/14245fcd-4a75-4540-8340-574284f5a252)

</details>

## Changelog

:cl:
fix: Raw Meatpizza now shows in the cooking menu rather than crafting.
/:cl:
