### PR TITLE
Broadly nerfs a lot of antag equipment

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -24,7 +24,7 @@
 	light_on = FALSE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	block_chance = 75
+	block_chance = 10 // SPLURT EDIT ANTAG_NERF, ORIGINAL BLOCK_CHANCE: 75
 	block_sound = 'sound/items/weapons/block_blade.ogg'
 	max_integrity = 200
 	armor_type = /datum/armor/item_dualsaber
@@ -162,10 +162,10 @@
 		if(our_projectile.reflectable)
 			final_block_chance = 0 //we handle this via IsReflect(), effectively 75% block
 		else
-			final_block_chance -= 25 //We aren't AS good at blocking physical projectiles, like ballistics and thermals
+			final_block_chance -= 10 //We aren't AS good at blocking physical projectiles, like ballistics and thermals // SPLURT EDIT ANTAG_NERF, ORIGINAL BLOCK_CHANCE: -= 25
 
 	if(attack_type == LEAP_ATTACK)
-		final_block_chance -= 50 //We are particularly bad at blocking someone JUMPING at us..
+		final_block_chance -= 5 //We are particularly bad at blocking someone JUMPING at us.. // SPLURT EDIT ANTAG_NERF, ORIGINAL BLO_CHANCE: 50
 
 	return ..()
 

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -197,8 +197,8 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
-	armour_penetration = 35
-	block_chance = 50
+	armour_penetration = 20 // SPLURT EDIT ANTAG_NERF, ORIGINAL PENETRATION: 35
+	block_chance = 5  // SPLURT EDIT ANTAG_NERF, ORIGINAL BLOCK_CHANCE: 50
 	block_sound = 'sound/items/weapons/block_blade.ogg'
 	embed_type = /datum/embedding/esword
 	var/list/alt_continuous = list("stabs", "pierces", "impales")
@@ -215,7 +215,7 @@
 		return FALSE
 
 	if(attack_type == LEAP_ATTACK)
-		final_block_chance -= 25 //OH GOD GET IT OFF ME
+		final_block_chance -= 5 //OH GOD GET IT OFF ME  // SPLURT EDIT ANTAG_NERF, ORIGINAL FINAL_BLOCK_CHANCE: -= 25
 
 	return ..()
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -203,7 +203,7 @@
 	sharpness = SHARP_EDGED
 	wound_bonus = 10
 	bare_wound_bonus = 10
-	armour_penetration = 35
+	armour_penetration = 15  // SPLURT EDIT ANTAG_NERF, ORIGINAL PENETRATION: 35
 	var/can_drop = FALSE
 	var/fake = FALSE
 	var/list/alt_continuous = list("stabs", "pierces", "impales")

--- a/code/modules/antagonists/heretic/items/hunter_rifle.dm
+++ b/code/modules/antagonists/heretic/items/hunter_rifle.dm
@@ -24,7 +24,7 @@
 	name = "lionhunter rifle internal magazine"
 	ammo_type = /obj/item/ammo_casing/strilka310/lionhunter
 	caliber = CALIBER_STRILKA310
-	armour_penetration = 100
+	armour_penetration = 35  // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 100
 	max_ammo = 3
 	multiload = TRUE
 

--- a/code/modules/antagonists/nightmare/nightmare_equipment.dm
+++ b/code/modules/antagonists/nightmare/nightmare_equipment.dm
@@ -7,8 +7,8 @@
 	icon_state = "arm_blade"
 	inhand_icon_state = "arm_blade"
 	icon_angle = 180
-	force = 25
-	armour_penetration = 35
+	force = 20  // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 25
+	armour_penetration = 15  // SPLURT EDIT ANTAG_NERF, ORIGINAL PENETRATION: 35
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = ABSTRACT | DROPDEL

--- a/code/modules/antagonists/ninja/energy_katana.dm
+++ b/code/modules/antagonists/ninja/energy_katana.dm
@@ -22,8 +22,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 30
 	throwforce = 30
-	block_chance = 50
-	armour_penetration = 50
+	block_chance = 15  // SPLURT EDIT ANTAG_NERF, ORIGINAL BLOCK_CHANCE = 50
+	armour_penetration = 35  // SPLURT EDIT ANTAG_NERF, ORIGINAL PENETRATION: 50
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
 	pickup_sound = 'sound/items/unsheath.ogg'

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -443,7 +443,7 @@
 	return
 
 /mob/living/silicon/rust_heretic_act()
-	adjustBruteLoss(500)
+	adjustBruteLoss(100)   // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 500
 
 /mob/living/silicon/on_floored_start()
 	return // Silicons are always standing by default.

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -17,8 +17,8 @@
 
 /obj/projectile/bullet/c9mm/ap
 	name = "9mm armor-piercing bullet"
-	damage = 27
-	armour_penetration = 40
+	damage = 25  // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 25
+	armour_penetration = 25  // SPLURT EDIT ANTAG_NERF, ORIGINAL PENETRATION: 40
 	embed_type = null
 	shrapnel_type = null
 
@@ -36,16 +36,16 @@
 
 /obj/projectile/bullet/c10mm
 	name = "10mm bullet"
-	damage = 40
+	damage = 35  // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 40
 
 /obj/projectile/bullet/c10mm/ap
 	name = "10mm armor-piercing bullet"
-	damage = 35
-	armour_penetration = 40
+	damage = 25  // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 35
+	armour_penetration = 25  // SPLURT EDIT ANTAG_NERF, ORIGINAL PENETRATION: 40
 
 /obj/projectile/bullet/c10mm/hp
 	name = "10mm hollow-point bullet"
-	damage = 50
+	damage = 45  // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 50
 	weak_against_armour = TRUE
 
 /obj/projectile/bullet/incendiary/c10mm

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -135,20 +135,20 @@
 
 /obj/projectile/bullet/c357
 	name = ".357 bullet"
-	damage = 60
+	damage = 40 // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 60
 	wound_bonus = -30
 
 /obj/projectile/bullet/c357/phasic
 	name = ".357 phasic bullet"
 	icon_state = "gaussphase"
-	damage = 35
+	damage = 30 // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 35
 	armour_penetration = 100
 	projectile_phasing =  PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 
 /obj/projectile/bullet/c357/heartseeker
 	name = ".357 heartseeker bullet"
 	icon_state = "gauss"
-	damage = 50
+	damage = 35  // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 50
 	homing_turn_speed = 120
 
 // admin only really, for ocelot memes

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,8 +1,8 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	icon_state = "pellet"
-	damage = 25
-	armour_penetration = 30
+	damage = 45 // SPLURT EDIT ANTAG_NERF, ORIGINAL DAMAGE: 25 // why did it do less than a .357???
+	armour_penetration = 15  // SPLURT EDIT ANTAG_NERF, ORIGINAL PENETRATION: 30
 	sharpness = SHARP_POINTY
 	wound_bonus = 0
 	bare_wound_bonus = 15
@@ -11,6 +11,7 @@
 	name = "12g shotgun milspec slug"
 	icon_state = "pellet"
 	damage = 50
+	armour_penetration = 30  // SPLURT EDIT ANTAG_NERF, ORIGINAL PENETRATION: 30
 
 /obj/projectile/bullet/shotgun_slug/executioner
 	name = "executioner slug" // admin only, can dismember limbs

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -260,7 +260,7 @@
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
 	progression_minimum = 20 MINUTES
 	item = /obj/item/powersink
-	cost = 11
+	cost = 13  // SPLURT EDIT ANTAG_NERF, ORIGINAL COST: 11
 
 /datum/uplink_item/device_tools/syndicate_contacts
 	name = "Polarized Contact Lenses"

--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -61,15 +61,15 @@
 	name = "Smoke Grenades"
 	desc = "A box that contains five smoke grenades. Useful for vanishing and ninja fans with katana."
 	item = /obj/item/storage/box/syndie_kit/smoke
-	cost = 2
+	cost = 1 // SPLURT EDIT ANTAG_NERF, ORIGINAL COST: 2
 
 /datum/uplink_item/explosives/pizza_bomb
 	name = "Pizza Bomb"
 	desc = "A pizza box with a bomb cunningly attached to the lid. The timer needs to be set by opening the box; afterwards, \
 			opening the box again will trigger the detonation after the timer has elapsed. Comes with free pizza, for you or your target!"
 	item = /obj/item/pizzabox/bomb
-	cost = 6
-	surplus = 8
+	cost = 8 // SPLURT EDIT ANTAG_NERF, ORIGINAL COST: 6
+	surplus = 10
 
 /datum/uplink_item/explosives/syndicate_minibomb
 	name = "Syndicate Minibomb"
@@ -77,7 +77,7 @@
 			in addition to dealing high amounts of damage to nearby personnel."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/grenade/syndieminibomb
-	cost = 6
+	cost = 10 // SPLURT EDIT ANTAG_NERF, ORIGINAL COST: 6
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
 
@@ -85,7 +85,7 @@
 	name = "Syndicate EMP Bomb"
 	desc = "A variation of the syndicate bomb designed to produce a large EMP effect."
 	item = /obj/item/sbeacondrop/emp
-	cost = 7
+	cost = 8 // SPLURT EDIT ANTAG_NERF, ORIGINAL COST: 7
 
 /datum/uplink_item/explosives/syndicate_bomb/emp/New()
 	..()
@@ -102,8 +102,9 @@
 		The bomb core can be pried out and manually detonated with other explosives."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/sbeacondrop/bomb
-	cost = 11
+	cost = 15 // SPLURT EDIT ANTAG_NERF, ORIGINAL COST: 11
 
 /datum/uplink_item/explosives/syndicate_bomb/New()
 	. = ..()
 	desc = replacetext(desc, "%MIN_BOMB_TIMER", SYNDIEBOMB_MIN_TIMER_SECONDS)
+

--- a/modular_zubbers/code/modules/antagonists/traitor/uplink/uplink_items/bundle.dm
+++ b/modular_zubbers/code/modules/antagonists/traitor/uplink/uplink_items/bundle.dm
@@ -5,4 +5,4 @@
 			and spies alike. Includes cameras, records, PDA server access, and a fax machine. \
 			Basic knowledge of communication systems not included. Requires power in area deployed."
 	item = /obj/item/survivalcapsule/plap
-	cost = 10
+	cost = 8  // SPLURT EDIT ANTAG_NERF, ORIGINAL COST: 10

--- a/modular_zubbers/code/modules/antagonists/traitor/uplink/uplink_items/syndimaid/_syndimaid.dm
+++ b/modular_zubbers/code/modules/antagonists/traitor/uplink/uplink_items/syndimaid/_syndimaid.dm
@@ -2,7 +2,7 @@
 	name = "Syndicate Maid Outfit"
 	desc = "A very obvious joke. A standard syndicate maid suit with bulky armor added to it. The added armor prevents you from wearing any extra outerwear"
 	item = /obj/item/storage/box/syndimaid
-	cost = 8 // Same as the redsuit mod. It's worse than it in almost every way but that's by design
+	cost = 5 // Same as the redsuit mod. It's worse than it in almost every way but that's by design  // SPLURT EDIT ANTAG_NERF, ORIGINAL COST: 8
 	cant_discount = TRUE
 	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND
 


### PR DESCRIPTION
## About The Pull Request

Nerfs energy swords, rust grasps on sillycons, ap pistol ammo, .357 magnum ammo, ninja katanas, antagonist armblades, uplink costs and the heretic's lion rifle. Slightly buffs some less-dangerous uplink costs and shotgun ammo (slugs).

## Why It's Good For The Game

Greatly reduces the amount of block_chance in energy swords and increases the cost of explosives from the uplink. Hopefully, this will help cut back on the ease and quantity of antag murderboning that is fairly common. Allows security to peacefully deal with most antag threats by simply shooting them, rather than forcing them to deeply engage with gameplay mechanics. (Shooting is much simpler than fucking about with bolas and throwing batons.)

Armblades from c-lings and d-lings are less good at straight-up fighting and penetrating armor, because ()lings are supposed to be stealthy antagonists, not straight up fighting security.

9mm & 10mm AP ammo does less AP now, 40 damage for handgun ammo is pretty high when PDWs and rifles are about 20-40. Changed .357 ammo to be 40, and buffed shotgun slug damage while reducing AP. No idea why a slug would do 2x less damage than a longer 9mm round.

## Proof Of Testing

The numbers went down and up, but mostly down.

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: nerfs magnum revolver, 9mm & 10mm ammo, nerfs changeling and nightmare armblades, nerfs energy swords, rust grasp on sillycons, changes shotgun slugs, and a few other things.
/:cl:
