### PR TITLE
[ADMIN] Improves admin logging for hypnosis

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifsofts/hypnosis.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts/hypnosis.dm
@@ -60,6 +60,12 @@
 		var/input_text = tgui_input_text(user, "What would you like to suggest?", "Hypnotic Suggestion")
 		to_chat(user, span_purple("You whisper into [target_human]'s ears in a soothing voice."))
 		to_chat(target_human, span_hypnophrase("[input_text]"))
+
+		// SPLURT EDIT START: Add logging
+		message_admins("[ADMIN_LOOKUPFLW(user)] gave [ADMIN_LOOKUPFLW(target_human)] a hypnotic suggestion: '[input_text]'.")
+		user.log_message("gave [key_name(target_human)] a hypnotic suggestion: '[input_text]'", LOG_GAME)
+		// SPLURT EDIT END
+
 		secondary_choice = tgui_alert(user, "Would you like to give [target_human] an additional hypnotic suggestion or release them?", "Hypnosis", list("Suggestion", "Release"))
 
 	user.visible_message(span_purple("You wake up from your deep, hypnotic slumber. The suggestions from [user] now settled into your mind."), span_purple("[target_human] wakes up from their slumber."))

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/hypnotic_gaze.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/hypnotic_gaze.dm
@@ -412,6 +412,11 @@
 
 	// Remove sleep, then return
 	action_target.SetSleeping(0)
+
+	// Add logging
+	message_admins("[ADMIN_LOOKUPFLW(action_owner)] hypnotized [ADMIN_LOOKUPFLW(action_target)] with the suggestion '[input_suggestion]'.")
+	owner.log_message("hypnotized [key_name(action_target)] with the suggestion '[input_suggestion]'", LOG_GAME)
+
 	return
 
 #undef HYPNOEYES_COOLDOWN_NORMAL

--- a/modular_zzplurt/code/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
+++ b/modular_zzplurt/code/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
@@ -1,0 +1,12 @@
+// Overrides the logging behavior of induced hypnosis
+// from modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
+
+/datum/brain_trauma/very_special/induced_hypnosis/on_gain()
+	message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
+	owner.log_message("was hypnotized with the phrase '[hypnotic_phrase]'.", LOG_GAME)
+	return ..()
+
+/datum/brain_trauma/very_special/induced_hypnosis/on_lose()
+	message_admins("[ADMIN_LOOKUPFLW(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
+	owner.log_message("is no longer hypnotized with the phrase '[hypnotic_phrase]'.", LOG_GAME)
+	..()

--- a/modular_zzplurt/code/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
+++ b/modular_zzplurt/code/modules/modular_items/lewd_items/code/lewd_clothing/hypnogoggles.dm
@@ -9,4 +9,4 @@
 /datum/brain_trauma/very_special/induced_hypnosis/on_lose()
 	message_admins("[ADMIN_LOOKUPFLW(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
 	owner.log_message("is no longer hypnotized with the phrase '[hypnotic_phrase]'.", LOG_GAME)
-	..()
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10088,6 +10088,7 @@
 #include "modular_zzplurt\code\modules\modular_items\lewd_items\code\lewd_chemistry\reagents\cum.dm"
 #include "modular_zzplurt\code\modules\modular_items\lewd_items\code\lewd_clothing\bdsm_mask.dm"
 #include "modular_zzplurt\code\modules\modular_items\lewd_items\code\lewd_clothing\deprivation_helmet.dm"
+#include "modular_zzplurt\code\modules\modular_items\lewd_items\code\lewd_clothing\hypnogoggles.dm"
 #include "modular_zzplurt\code\modules\modular_items\misc\handmirror.dm"
 #include "modular_zzplurt\code\modules\modular_items\misc\lipsticks.dm"
 #include "modular_zzplurt\code\modules\modular_items\misc\nailpolish.dm"


### PR DESCRIPTION

## About The Pull Request
Logging is done in game.log, similar to standard non-modular hypnosis.
## Why It's Good For The Game
This change helps administrators better monitor hypnosis interactions 
## Proof Of Testing
I've tested all the logging functions locally
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/600dbdda-4a7d-4de2-adf2-ba0029e70fb2)
![image](https://github.com/user-attachments/assets/f39aeb48-aa90-467c-929d-7776f14f0de1)

</details>

## Changelog
:cl:
Admin: Added missing logging for hypnosis interactions
/:cl:
