### PR TITLE
Makes the size examine information have the initial word be Capitalized

### DIFF
--- a/modular_zzplurt/code/modules/mob/living/carbon/examine.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/examine.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/proc/get_size_examine_info(mob/living/user)
 	. = list()
 
-	var/t_He = p_they()
+	var/t_He = p_They()
 
 	//Approximate character height based on current sprite scale
 	var/dispSize = round(12*get_size(src)) // gets the character's sprite size percent and converts it to the nearest half foot


### PR DESCRIPTION

## About The Pull Request
This PR changes the size examine text starter word from not being capitalized to being capitalized.
That's literally it.
## Why It's Good For The Game
Lowers the amount of spelling mistakes being shown to the players.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
Before the change

![Screenshot 2025-05-10 091118](https://github.com/user-attachments/assets/7999d5bb-fe29-40c6-a4c6-90810c7d8a19)

After the change

![Screenshot 2025-05-10 091836](https://github.com/user-attachments/assets/edbc5963-fbd1-4fb5-9096-7dbc0b99034e)

</details>

## Changelog
:cl:
spellcheck: The size examine text starts with a capitalized word now.
/:cl:
