### PR TITLE
A calm replacement of p_they() in areas they are not supposed to be in

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -347,14 +347,14 @@
 		var/arousal_message
 		switch(arousal)
 			if(AROUSAL_MINIMUM_DETECTABLE to AROUSAL_LOW)
-				arousal_message = span_purple("[p_they()] [p_are()] slightly blushed.") + "\n"
+				arousal_message = span_purple("[p_They()] [p_are()] slightly blushed.") + "\n" // Splurt - Replaces weirdly placed p_they with p_They. This is supposed to be CAPITALIZED
 			if(AROUSAL_LOW to AROUSAL_MEDIUM)
-				arousal_message = span_purple("[p_they()] [p_are()] quite aroused and seems to be stirring up lewd thoughts in [p_their()] head.") + "\n"
+				arousal_message = span_purple("[p_They()] [p_are()] quite aroused and seems to be stirring up lewd thoughts in [p_their()] head.") + "\n" // Splurt - Replaces weirdly placed p_they with p_They. This is supposed to be CAPITALIZED
 			if(AROUSAL_HIGH to AROUSAL_AUTO_CLIMAX_THRESHOLD)
-				arousal_message = span_purple("[p_they()] [p_are()] aroused as hell.") + "\n"
+				arousal_message = span_purple("[p_They()] [p_are()] aroused as hell.") + "\n" // Splurt - Replaces weirdly placed p_they with p_They. This is supposed to be CAPITALIZED
 			if(AROUSAL_AUTO_CLIMAX_THRESHOLD to INFINITY)
-				arousal_message = span_purple("[p_they()] [p_are()] extremely excited, exhausting from entolerable desire.") + "\n"
+				arousal_message = span_purple("[p_They()] [p_are()] extremely excited, exhausting from entolerable desire.") + "\n" // Splurt - Replaces weirdly placed p_they with p_They. This is supposed to be CAPITALIZED
 		if(arousal_message)
 			. += arousal_message
 	else if(arousal > AROUSAL_MINIMUM_DETECTABLE)
-		. += span_purple("[p_they()] [p_are()] slightly blushed.") + "\n"
+		. += span_purple("[p_They()] [p_are()] slightly blushed.") + "\n" // Splurt - Replaces weirdly placed p_they with p_They. This is supposed to be CAPITALIZED


### PR DESCRIPTION

## About The Pull Request
This fixes some capitalization issues that I've noticed whilst playing on Splurt.

Basically it makes the text empaths can see regarding someone's horny level, be capitalized and not uncapitalized.
## Why It's Good For The Game
Capitalization is very good.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![Screenshot 2025-05-14 193445](https://github.com/user-attachments/assets/8c1b94db-431c-4561-97d2-b8b8d6aea962)

</details>

## Changelog
:cl:
spellcheck: Capitalized some uncapitalized sentences.
/:cl:
