### PR TITLE
Lavaland Seedvault Improvements

### DIFF
--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -1,253 +1,38 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ae" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"ao" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe/ghost_cafe{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"aU" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"bl" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"bt" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"bR" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"ca" = (
-/obj/effect/mob_spawn/ghost_role/human/seed_vault,
-/turf/open/floor/plating/kudzu,
-/area/ruin/powered/seedvault)
-"cr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/plantgenes{
-	pixel_y = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"cF" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"dl" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/chair/pew/left,
+"au" = (
+/obj/machinery/light/floor,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"dw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"dD" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"dM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"el" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wideplating_new/corner,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"ev" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"ez" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"eE" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	name = "Server Vent"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"fh" = (
-/obj/machinery/vending/hydronutrients{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"fl" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"fr" = (
-/obj/machinery/light/directional/west,
-/obj/structure/hedge,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"fy" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"fI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"fM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"fW" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"gf" = (
+"br" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"gt" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"gy" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"hb" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"hg" = (
-/obj/machinery/computer/terminal{
-	dir = 8;
-	name = "Old Terminal";
-	desc = "A dusty, nonfunctioning terminal left by your creators. The screen is on but nothing you press does anything."
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"hu" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"hX" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"id" = (
-/obj/machinery/door/airlock/multi_tile/public/glass,
+"cq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/vault,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/freezer,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"ij" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"ir" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"cr" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"cs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"iP" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"jv" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+"cF" = (
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"jz" = (
-/obj/structure/flora/bush/grassy/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"jK" = (
+"cG" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
@@ -260,181 +45,161 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"jM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/sand/volcanic,
-/obj/machinery/door/poddoor{
-	id = "bunkerexterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"jP" = (
-/obj/machinery/light/floor,
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner{
-	dir = 4
-	},
-/area/ruin/powered/seedvault)
-"jT" = (
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"kt" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"kV" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"lb" = (
-/obj/structure/chair/pew,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"ld" = (
-/obj/structure/table/wood,
-/obj/structure/towel_bin,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"lh" = (
-/obj/structure/flora/bush/sunny/style_3,
+"cQ" = (
+/obj/structure/sink/directional/east,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"lL" = (
-/obj/machinery/door/poddoor{
-	id = "bunkerinterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"mG" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
+"dc" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"mN" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"mT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"nx" = (
-/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
-"nE" = (
+"dn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"dp" = (
 /obj/structure/closet/secure_closet/personal/wall{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
+/turf/open/floor/wood/stairs/left,
 /area/ruin/powered/seedvault)
-"oo" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+"dv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5;
+	pixel_x = -3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"oq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"oL" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
-/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/item/construction/plumbing,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"oP" = (
-/obj/machinery/light/floor,
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner{
+"dw" = (
+/obj/structure/chair/pew,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"dL" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"dU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"ef" = (
+/obj/structure/chair/pew/right,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"eg" = (
+/obj/machinery/computer/terminal{
+	dir = 8;
+	name = "Old Terminal";
+	desc = "A dusty, nonfunctioning terminal left by your creators. The screen is on but nothing you press does anything."
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"ej" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"oR" = (
+"eC" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"eH" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"pg" = (
+"eI" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"pG" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"pM" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/soap/homemade,
-/obj/item/soap/homemade,
-/obj/item/soap/homemade,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
-"pU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"eX" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"pZ" = (
+"eZ" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"fe" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"qp" = (
+"fC" = (
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/biogenerator,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"fE" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"fG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"fW" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"gv" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/seedling,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"gx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
 	external_pressure_bound = 140;
@@ -446,211 +211,165 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"rp" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/south,
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"rW" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"rZ" = (
-/obj/machinery/atmospherics/components/binary/volume_pump/on,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"sy" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
+"gI" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"sI" = (
+"hR" = (
+/obj/machinery/vending/hydronutrients{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"im" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light/directional/west{
+	pixel_y = -15
+	},
+/obj/machinery/mining_weather_monitor/directional/west,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"in" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"iA" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"iJ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"iQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"tg" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/clothing/neck/stethoscope,
-/obj/machinery/light/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"tk" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"tv" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"tW" = (
-/obj/machinery/light/floor,
+"iV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"jw" = (
+/obj/machinery/chem_master,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"jJ" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"ud" = (
+"jO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"ui" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bunkershutter"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/seedvault)
-"uq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/west{
-	id = "bunkerinterior";
-	name = "interior blast door access";
-	req_access = list("away_general")
-	},
-/obj/machinery/button/door/directional/west{
-	id = "bunkershutter";
-	name = "hallway shutter toggle";
-	pixel_y = 8;
-	req_access = list("away_general")
-	},
-/obj/machinery/button/door/directional/west{
-	id = "bunkerexterior";
-	name = "exterior blast door access";
-	pixel_y = -8;
-	req_access = list("away_general")
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"uM" = (
-/obj/structure/sauna_oven,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"wb" = (
-/obj/structure/flora/bush/grassy/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 1
 	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"jW" = (
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"kk" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"kB" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"kF" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"kR" = (
+/obj/structure/sink/directional/west,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"we" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
+"kX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"lF" = (
+/obj/machinery/light/floor,
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
 	dir = 4
 	},
+/area/ruin/powered/seedvault)
+"lN" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 8
+	},
+/area/ruin/powered/seedvault)
+"lO" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"wn" = (
-/obj/structure/water_source/puddle{
-	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
-	base_icon_state = "water_basin";
-	icon_state = "water_basin";
-	name = "filled water basin"
-	},
+"lP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/wood,
 /area/ruin/powered/seedvault)
-"wp" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"wx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"wD" = (
-/obj/structure/closet/secure_closet/personal/wall{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"wX" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"wZ" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"xo" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"yo" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"yt" = (
+"lX" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"yB" = (
+"mv" = (
+/obj/structure/flora/bush/sunny/style_3,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"mA" = (
+/obj/structure/flora/bush/sunny,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"mJ" = (
 /obj/machinery/door/airlock/vault,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -661,81 +380,37 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"yL" = (
-/obj/structure/flora/bush/generic/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"zf" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/structure/loom,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"zl" = (
-/obj/structure/sink/directional/east,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"zn" = (
-/obj/machinery/door/window,
-/obj/machinery/door/window{
+"mY" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/machinery/biogenerator,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"zr" = (
-/obj/structure/flora/bush/generic/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"zz" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
+"ni" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"zB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+"nq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"ns" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"zK" = (
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"zP" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/seedling,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"zS" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Bd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Bm" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"BM" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"CC" = (
+"nv" = (
 /obj/machinery/light/floor,
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -743,21 +418,381 @@
 	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"CI" = (
+"nT" = (
+/obj/machinery/light/floor,
 /obj/effect/mist,
 /obj/effect/spawner/liquids_spawner/shoulders,
 /turf/open/floor/iron/pool/cobble/corner{
-	dir = 8
+	dir = 1
 	},
 /area/ruin/powered/seedvault)
-"CJ" = (
+"oa" = (
+/obj/machinery/vending/hydroseeds{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"ou" = (
+/obj/effect/mob_spawn/ghost_role/human/seed_vault,
+/turf/open/floor/plating/kudzu,
+/area/ruin/powered/seedvault)
+"oZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"pi" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"pv" = (
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"pR" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"pY" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"qe" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"qn" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"qw" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"qA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/sand/volcanic,
+/obj/machinery/door/poddoor{
+	id = "bunkerexterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"qD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"qG" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"qN" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"qX" = (
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"qY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"ra" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/seedvault)
+"rb" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"rf" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"rn" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"rs" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 4
+	},
+/area/ruin/powered/seedvault)
+"rI" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"rS" = (
+/obj/structure/closet/secure_closet/personal/wall{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"si" = (
+/obj/machinery/door/airlock/multi_tile/public/glass,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"sF" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"sT" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"sU" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"tA" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"tU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"ua" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ur" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	invisibility = 100;
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"uu" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"uB" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"uD" = (
+/obj/structure/sauna_oven,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"uE" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"uX" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"DE" = (
+"ve" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"vQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"vR" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"vU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"wH" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"wN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"wS" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"wT" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"xo" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"xB" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"xE" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"xP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"xR" = (
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ym" = (
+/obj/machinery/vending/clothing{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"yN" = (
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"zb" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/flatpacked_machine,
 /obj/item/stack/sheet/iron/fifty,
@@ -783,57 +818,651 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
-"DY" = (
+"zw" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"zI" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"zJ" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"AB" = (
+/obj/machinery/light/floor,
 /obj/structure/flora/bush/sparsegrass/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"AD" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"By" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"BR" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"BV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"CJ" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"CS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Da" = (
+/obj/structure/hedge,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"Dv" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Dx" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"DM" = (
+/obj/structure/flora/tree/jungle/style_3,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"DZ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/plantgenes{
+	pixel_y = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"EU" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Fm" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"FP" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner,
+/area/ruin/powered/seedvault)
+"FS" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"GB" = (
+/obj/structure/table/wood,
+/obj/structure/towel_bin,
+/obj/machinery/light/directional/west,
+/obj/structure/railing{
+	invisibility = 100;
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"GY" = (
+/obj/structure/water_source/puddle{
+	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
+	base_icon_state = "water_basin";
+	icon_state = "water_basin";
+	name = "filled water basin"
+	},
+/obj/item/reagent_containers/cup/bucket/wooden,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"HB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"HQ" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/item/seeds/surik,
+/obj/item/seeds/surik,
+/obj/item/seeds/vaporsac,
+/obj/item/seeds/vaporsac,
+/obj/item/seeds/amauri,
+/obj/item/seeds/amauri,
+/obj/item/seeds/gelthi,
+/obj/item/seeds/gelthi,
+/obj/item/seeds/jurlmah,
+/obj/item/seeds/jurlmah,
+/obj/item/seeds/nofruit,
+/obj/item/seeds/nofruit,
+/obj/item/seeds/shand,
+/obj/item/seeds/shand,
+/obj/item/seeds/telriis,
+/obj/item/seeds/telriis,
+/obj/item/seeds/thaadra,
+/obj/item/seeds/thaadra,
+/obj/item/seeds/vale,
+/obj/item/seeds/vale,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"HR" = (
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ic" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"IL" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"Ea" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
+"IY" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
 	},
-/obj/machinery/autolathe,
-/obj/item/storage/toolbox/syndicate,
-/turf/open/floor/iron/dark,
+/turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"Eu" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"EA" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
+"Jq" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"EK" = (
+"Jr" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"JE" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	name = "Server Vent"
-	},
-/turf/open/floor/iron/freezer,
+/obj/structure/safe/abovetilefloor,
+/obj/item/seeds/kudzu,
+/obj/item/paperwork/service,
+/obj/item/lighter/royal,
+/obj/item/clothing/neck/cowboylea,
+/obj/item/food/grown/poppy/geranium,
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"EZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+"JI" = (
+/obj/structure/closet/secure_closet/personal/wall{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"JP" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Ks" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Fl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+"KD" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe/ghost_cafe{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"KQ" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"KX" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/melee/flyswatter,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/queen_bee/bought,
+/obj/item/bee_smoker,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Lk" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"LI" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"LM" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"LV" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"MZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/seedvault)
+"Nh" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Nr" = (
+/obj/structure/table/wood,
+/obj/machinery/light/directional/east,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"NH" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Oa" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/machinery/light/directional/north,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Op" = (
+/obj/machinery/smartfridge,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"Fu" = (
+"OF" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"OZ" = (
+/obj/structure/table/wood,
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Pg" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Pq" = (
+/obj/structure/beebox,
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"PB" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"PF" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"PR" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"PY" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Qg" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"QS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Rj" = (
+/obj/machinery/smartfridge,
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"Rl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Rt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"RG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"RP" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"RX" = (
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Sa" = (
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"Sd" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/chair/pew/left,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Tb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/corner,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"Tt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/west{
+	id = "bunkerinterior";
+	name = "interior blast door access";
+	req_access = list("away_general")
+	},
+/obj/machinery/button/door/directional/west{
+	id = "bunkershutter";
+	name = "hallway shutter toggle";
+	pixel_y = 8;
+	req_access = list("away_general")
+	},
+/obj/machinery/button/door/directional/west{
+	id = "bunkerexterior";
+	name = "exterior blast door access";
+	pixel_y = -8;
+	req_access = list("away_general")
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"TD" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"TO" = (
+/obj/machinery/atmospherics/components/binary/volume_pump/on,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"TV" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Uo" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Up" = (
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"UD" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"UI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"Vn" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"VR" = (
+/obj/machinery/light/directional/west,
+/obj/structure/hedge,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"VS" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/light/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"WL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/stairs/left,
+/area/ruin/powered/seedvault)
+"WM" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Xg" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Xn" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"XT" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
@@ -862,1330 +1491,722 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"FT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"FV" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"Gf" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Gx" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"GK" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Hd" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"Hh" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Hl" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 8
-	},
-/area/ruin/powered/seedvault)
-"Id" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/melee/flyswatter,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/queen_bee/bought,
-/obj/item/bee_smoker,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"Ij" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"IM" = (
-/obj/structure/flora/tree/jungle/style_3,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Jj" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"JE" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Kb" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Kk" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Ko" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"KY" = (
-/obj/structure/chair/pew/right,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"Lk" = (
-/obj/structure/flora/bush/sunny,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"LB" = (
-/obj/structure/table/wood,
-/obj/machinery/light/directional/east,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"LU" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"LZ" = (
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"Mb" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Mz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"MF" = (
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"MY" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner,
-/area/ruin/powered/seedvault)
-"Nf" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Nq" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"Nz" = (
-/obj/machinery/smartfridge,
-/obj/machinery/door/window,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"NS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/door/poddoor{
-	id = "bunkerinterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Oe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"Oj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/light/directional/west{
-	pixel_y = -15
-	},
-/obj/machinery/mining_weather_monitor/directional/west,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Ow" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"OB" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"OE" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"OV" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"Pa" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Pk" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 4
-	},
-/area/ruin/powered/seedvault)
-"Pl" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Pz" = (
-/obj/machinery/smartfridge,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"PM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"PP" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"PU" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
+"XY" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 9
 	},
+/obj/structure/loom,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Ql" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 4
-	},
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"Qo" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+"Ya" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Qq" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Rc" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"RJ" = (
-/obj/machinery/chem_master,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"RP" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Sc" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"Sf" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
-"Sk" = (
-/obj/structure/beebox,
-/obj/effect/turf_decal/siding/thinplating/dark/end,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Sm" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Sv" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
+"Yh" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/side{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"SU" = (
+"YI" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
+	dir = 1
 	},
+/obj/machinery/autolathe,
+/obj/item/storage/toolbox/syndicate,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Tn" = (
-/obj/structure/reagent_dispensers/watertank/high,
+"Zc" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Tq" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Tw" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"TF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"TI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"TP" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"TS" = (
-/obj/machinery/vending/hydroseeds{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"TX" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/item/seeds/surik,
-/obj/item/seeds/surik,
-/obj/item/seeds/vaporsac,
-/obj/item/seeds/vaporsac,
-/obj/item/seeds/amauri,
-/obj/item/seeds/amauri,
-/obj/item/seeds/gelthi,
-/obj/item/seeds/gelthi,
-/obj/item/seeds/jurlmah,
-/obj/item/seeds/jurlmah,
-/obj/item/seeds/nofruit,
-/obj/item/seeds/nofruit,
-/obj/item/seeds/shand,
-/obj/item/seeds/shand,
-/obj/item/seeds/telriis,
-/obj/item/seeds/telriis,
-/obj/item/seeds/thaadra,
-/obj/item/seeds/thaadra,
-/obj/item/seeds/vale,
-/obj/item/seeds/vale,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"Uf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bunkershutter"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/seedvault)
-"Un" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Up" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"Ur" = (
-/obj/machinery/vending/clothing{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"UC" = (
+"Zq" = (
 /obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"UJ" = (
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"UK" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"UR" = (
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"UY" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Vc" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/machinery/light/directional/north,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"VD" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"We" = (
-/obj/structure/hedge,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"WE" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"WJ" = (
-/obj/structure/sink/directional/west,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"WW" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/obj/structure/safe/abovetilefloor,
-/obj/item/seeds/kudzu,
-/obj/item/paperwork/service,
-/obj/item/lighter/royal,
-/obj/item/clothing/neck/cowboylea,
-/obj/item/food/grown/poppy/geranium,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Xg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Xn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"XK" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Yo" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	name = "Server Vent"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Yv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5;
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/item/construction/plumbing,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"YZ" = (
+"ZU" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"Zf" = (
-/obj/structure/table/wood,
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Zl" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"Zs" = (
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 
 (1,1,1) = {"
-hX
-Bm
-Bm
-Bm
-Bm
-LZ
-Bm
-Bm
-LZ
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-LZ
-LZ
-LZ
-Bm
-Bm
-Bm
-Bm
-Bm
+iA
+HR
+HR
+HR
+HR
+qX
+HR
+HR
+qX
+HR
+HR
+HR
+HR
+HR
+HR
+qX
+qX
+qX
+HR
+HR
+HR
+HR
+HR
 "}
 (2,1,1) = {"
-Bm
-Bm
-Bm
-Bm
-LZ
-LZ
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-LZ
-LZ
+HR
+HR
+HR
+HR
+qX
+qX
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+qX
+qX
 "}
 (3,1,1) = {"
-LZ
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-UR
-UR
-UR
-UR
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-LZ
+qX
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+Sa
+Sa
+Sa
+Sa
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+qX
 "}
 (4,1,1) = {"
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-UR
-UR
-UR
-UR
-wp
-Hh
-UR
-UR
-UR
-UR
-UR
-UR
-LZ
-Bm
-LZ
-LZ
-LZ
+HR
+HR
+HR
+HR
+HR
+HR
+Sa
+Sa
+Sa
+Sa
+dL
+WM
+Sa
+Sa
+Sa
+Sa
+Sa
+Sa
+qX
+HR
+qX
+qX
+qX
 "}
 (5,1,1) = {"
-Bm
-Bm
-Bm
-Bm
-Bm
-LZ
-UR
-Ur
-tv
-UR
-mN
-aU
-lL
-PU
-Oj
-zB
-yB
-jM
-LZ
-LZ
-LZ
-Bm
-LZ
+HR
+HR
+HR
+HR
+HR
+qX
+Sa
+ym
+uE
+Sa
+eX
+kk
+jW
+Vn
+im
+iQ
+mJ
+qA
+qX
+qX
+qX
+HR
+qX
 "}
 (6,1,1) = {"
-Bm
-Bm
-Bm
-UR
-UR
-UR
-UR
-Zf
-jv
-UR
-Bd
-aU
-NS
-Jj
-dM
-ir
-Zs
-jM
-LZ
-LZ
-Bm
-Bm
-Bm
+HR
+HR
+HR
+Sa
+Sa
+Sa
+Sa
+OZ
+pY
+Sa
+oZ
+kk
+jO
+qw
+RG
+iV
+PF
+qA
+qX
+qX
+HR
+HR
+HR
 "}
 (7,1,1) = {"
-Bm
-Bm
-Bm
-UR
-ca
-Sf
-UR
-ao
-Gf
-UR
-we
-jK
-UR
-UR
-Uf
-ui
-UR
-UR
-UR
-LZ
-LZ
-LZ
-Bm
+HR
+HR
+HR
+Sa
+ou
+wH
+Sa
+KD
+eC
+Sa
+vR
+cG
+Sa
+Sa
+MZ
+ra
+Sa
+Sa
+Sa
+qX
+qX
+qX
+HR
 "}
 (8,1,1) = {"
-LZ
-Bm
-Bm
-UR
-ca
-EK
-id
-Tq
-VD
-Un
-sy
-GK
-UR
-uq
+qX
+HR
+HR
+Sa
+ou
+qe
+si
+LI
 Xg
-Xg
-wX
-rZ
-fM
-Hd
-LZ
-LZ
-LZ
+PB
+Jr
+xo
+Sa
+Tt
+Rt
+Rt
+UD
+TO
+kX
+uu
+qX
+qX
+qX
 "}
 (9,1,1) = {"
-LZ
-Bm
-Bm
-UR
-ca
-gy
-wx
-LU
-Kk
-rW
-Qo
-xo
-FT
-pU
-ud
-EZ
-TI
-bl
-UR
-Bm
-LZ
-Bm
-Bm
+qX
+HR
+HR
+Sa
+ou
+Xn
+Ya
+Qg
+Ic
+AB
+AD
+OF
+cq
+Rl
+vU
+cs
+ni
+cF
+Sa
+HR
+qX
+HR
+HR
 "}
 (10,1,1) = {"
-Bm
-Bm
-Bm
-UR
-ca
-Up
-UR
-LU
-yL
-XK
-zS
-oo
-UR
-LB
-hg
-UR
-UR
-UR
-UR
-UR
-UR
-Bm
-Bm
+HR
+HR
+HR
+Sa
+ou
+dc
+Sa
+Qg
+pv
+PR
+jJ
+mY
+Sa
+Nr
+eg
+Sa
+Sa
+Sa
+Sa
+Sa
+Sa
+HR
+HR
 "}
 (11,1,1) = {"
-Bm
-Bm
-Bm
-UR
-UR
-UR
-UR
-LU
-gt
-jz
-lh
-oo
-UR
-UR
-UR
-UR
-EA
-Sc
-Sc
-EA
-UR
-UR
-Bm
+HR
+HR
+HR
+Sa
+Sa
+Sa
+Sa
+Qg
+CJ
+xR
+mv
+mY
+Sa
+Sa
+Sa
+Sa
+iJ
+uB
+uB
+iJ
+Sa
+Sa
+HR
 "}
 (12,1,1) = {"
-Bm
-Bm
-UR
-UR
-wZ
-tg
-UR
-iP
-dD
-IM
-TP
-Gx
-UR
-RJ
-oL
-Yv
-hu
-WE
-DY
-OB
-dw
-UR
-Bm
+HR
+HR
+Sa
+Sa
+Pg
+VS
+Sa
+gI
+wT
+DM
+xE
+qn
+Sa
+jw
+Fm
+dv
+IY
+IL
+rf
+zI
+ZU
+Sa
+HR
 "}
 (13,1,1) = {"
-Bm
-Bm
-UR
-pM
-eE
-Kb
-UR
-LU
-Lk
-Pl
-zK
-Qq
-Nz
-ev
-bR
-qp
-wb
-WJ
-jz
-OE
-FV
-UR
-Bm
+HR
+HR
+Sa
+Nh
+eZ
+KQ
+Sa
+Qg
+mA
+Zq
+Up
+CS
+Rj
+rb
+in
+gx
+BR
+kR
+xR
+JP
+cr
+Sa
+HR
 "}
 (14,1,1) = {"
-Bm
-Bm
-UR
-Vc
-WW
-Xn
-MF
-LU
-UC
-jz
-zr
-Qq
-MF
-Xn
-fI
-fI
-fW
-Pz
-zP
-pG
-Sk
-UR
-Bm
+HR
+HR
+Sa
+Oa
+JE
+tU
+eI
+Qg
+sT
+xR
+RX
+CS
+eI
+tU
+qD
+qD
+ua
+Op
+gv
+tA
+Pq
+Sa
+HR
 "}
 (15,1,1) = {"
-Bm
-Bm
-UR
-TX
-fy
-Mb
-UR
-LU
-Pa
-tW
-Mz
-oo
-zn
-Fl
-Sv
-Rc
-Sm
-zl
-XK
-UJ
-FV
-UR
-Bm
+HR
+HR
+Sa
+HQ
+Zc
+lO
+Sa
+Qg
+TV
+LM
+vQ
+mY
+fC
+ns
+qG
+eH
+Dv
+cQ
+PR
+rn
+cr
+Sa
+HR
 "}
 (16,1,1) = {"
-Bm
-Bm
-UR
-UR
-Id
-DE
-UR
-kt
-yo
-yt
-pZ
-UK
-UR
-Eu
+HR
+HR
+Sa
+Sa
+KX
+zb
+Sa
+pR
+fe
+lX
+sF
+ej
+Sa
+zw
+DZ
+xB
+sU
+fE
+fW
+nv
 cr
-Tw
-BM
-RP
-tk
-CC
-FV
-UR
-Bm
+Sa
+HR
 "}
 (17,1,1) = {"
-Bm
-Bm
-Bm
-UR
-UR
-UR
-UR
-UY
-bt
-UR
-Zl
-UR
-UR
-UR
-UR
-Ko
-fl
-YZ
-YZ
-YZ
-UR
-UR
-Bm
+HR
+HR
+HR
+Sa
+Sa
+Sa
+Sa
+NH
+QS
+Sa
+wS
+Sa
+Sa
+Sa
+Sa
+UI
+LV
+kB
+kB
+kB
+Sa
+Sa
+HR
 "}
 (18,1,1) = {"
-Bm
-Bm
-Bm
-UR
-zf
-Yo
-Fu
-CJ
-oR
-UR
-pg
-ld
-wn
-uM
-ij
-TF
-ae
-ae
-nx
-UR
-UR
-Bm
-Bm
+HR
+HR
+HR
+Sa
+XY
+rI
+XT
+uX
+ve
+Sa
+WL
+GB
+GY
+uD
+kF
+dU
+xP
+xP
+nq
+Sa
+Sa
+HR
+HR
 "}
 (19,1,1) = {"
-Bm
-Bm
-Bm
-UR
-mG
-PP
-PP
-PP
-zz
-UR
-nE
-Ow
-Ow
-jT
-Ow
-fr
-We
-UR
-kV
-LZ
-LZ
-LZ
-Bm
+HR
+HR
+HR
+Sa
+Dx
+Lk
+Lk
+Lk
+Ks
+Sa
+dp
+ur
+wN
+yN
+wN
+VR
+Da
+Sa
+RP
+qX
+qX
+qX
+HR
 "}
 (20,1,1) = {"
-LZ
-Bm
-Bm
-UR
-Ea
-PP
-PP
-PM
-JE
-UR
-nE
-oq
-oq
-el
-Ql
-mT
-Ql
-UR
-LZ
-LZ
-Bm
-LZ
-Bm
+qX
+HR
+HR
+Sa
+YI
+Lk
+Lk
+By
+pi
+Sa
+JI
+lP
+lP
+Tb
+HB
+BV
+HB
+Sa
+qX
+qX
+HR
+qX
+HR
 "}
 (21,1,1) = {"
-LZ
-LZ
-Bm
-UR
-Tn
-Nf
-hb
-sI
-SU
-UR
-wD
-jT
-ez
-cF
-oP
-Hl
-CI
-UR
-Bm
-Bm
-Bm
-LZ
-LZ
+qX
+qX
+HR
+Sa
+EU
+TD
+qN
+zJ
+Uo
+Sa
+rS
+yN
+qY
+fG
+nT
+Yh
+lN
+Sa
+HR
+HR
+HR
+qX
+qX
 "}
 (22,1,1) = {"
-LZ
-Bm
-Bm
-UR
-UR
-UR
-UR
-TS
-fh
-UR
-dl
-OV
-rp
-cF
-MY
-Pk
-jP
-UR
-Bm
-Bm
-LZ
-LZ
-Bm
+qX
+HR
+HR
+Sa
+Sa
+Sa
+Sa
+oa
+hR
+Sa
+Sd
+Jq
+FS
+fG
+FP
+rs
+lF
+Sa
+HR
+HR
+qX
+qX
+HR
 "}
 (23,1,1) = {"
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-UR
-UR
-UR
-UR
-lb
-Oe
-Ij
-UR
-UR
-UR
-UR
-UR
-Bm
-Bm
-LZ
-LZ
-Bm
+HR
+HR
+HR
+HR
+HR
+HR
+Sa
+Sa
+Sa
+Sa
+dw
+dn
+PY
+Sa
+Sa
+Sa
+Sa
+Sa
+HR
+HR
+qX
+qX
+HR
 "}
 (24,1,1) = {"
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-UR
-KY
-Nq
-gf
-UR
-Bm
-Bm
-Bm
-LZ
-Bm
-Bm
-Bm
-Bm
-Bm
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+Sa
+ef
+au
+br
+Sa
+HR
+HR
+HR
+qX
+HR
+HR
+HR
+HR
+HR
 "}
 (25,1,1) = {"
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-UR
-UR
-UR
-UR
-UR
-Bm
-Bm
-Bm
-Bm
-Bm
-LZ
-Bm
-Bm
-Bm
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+Sa
+Sa
+Sa
+Sa
+Sa
+HR
+HR
+HR
+HR
+HR
+qX
+HR
+HR
+HR
 "}
 (26,1,1) = {"
-Bm
-Bm
-Bm
-Bm
-Bm
-LZ
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-LZ
-Bm
-Bm
-Bm
+HR
+HR
+HR
+HR
+HR
+qX
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+qX
+HR
+HR
+HR
 "}
 (27,1,1) = {"
-LZ
-LZ
-Bm
-Bm
-LZ
-LZ
-LZ
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-Bm
-LZ
-LZ
-LZ
-LZ
-Bm
-Bm
+qX
+qX
+HR
+HR
+qX
+qX
+qX
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+HR
+qX
+qX
+qX
+qX
+HR
+HR
 "}

--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -1,0 +1,2190 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light/directional/west{
+	pixel_y = -15
+	},
+/obj/machinery/mining_weather_monitor/directional/west,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"ai" = (
+/obj/structure/sink/directional/east,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"aI" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"aP" = (
+/obj/machinery/smartfridge,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"bm" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"bu" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"bW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/seedvault)
+"cm" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"cq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/seedvault)
+"cH" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"cT" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"cU" = (
+/obj/machinery/light/floor,
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 4
+	},
+/area/ruin/powered/seedvault)
+"dg" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"dq" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"dr" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"dC" = (
+/obj/structure/water_source/puddle{
+	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
+	base_icon_state = "water_basin";
+	icon_state = "water_basin";
+	name = "filled water basin"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"dI" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/item/seeds/surik,
+/obj/item/seeds/surik,
+/obj/item/seeds/vaporsac,
+/obj/item/seeds/vaporsac,
+/obj/item/seeds/amauri,
+/obj/item/seeds/amauri,
+/obj/item/seeds/gelthi,
+/obj/item/seeds/gelthi,
+/obj/item/seeds/jurlmah,
+/obj/item/seeds/jurlmah,
+/obj/item/seeds/nofruit,
+/obj/item/seeds/nofruit,
+/obj/item/seeds/shand,
+/obj/item/seeds/shand,
+/obj/item/seeds/telriis,
+/obj/item/seeds/telriis,
+/obj/item/seeds/thaadra,
+/obj/item/seeds/thaadra,
+/obj/item/seeds/vale,
+/obj/item/seeds/vale,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"dP" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"dY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"eh" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/seedling,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"ek" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"ep" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"es" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"et" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"eV" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"eW" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"fb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"fD" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"fF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"fN" = (
+/obj/structure/flora/bush/sunny,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ga" = (
+/obj/structure/flora/bush/sunny/style_3,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"gF" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"gZ" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"ht" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"hL" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"hO" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"hW" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ie" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"iu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"jb" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"jc" = (
+/obj/structure/chair/pew/right,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"jn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"jt" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"kg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"kM" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/structure/loom,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"kZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"lP" = (
+/obj/machinery/chem_master,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"me" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"mk" = (
+/obj/structure/chair/pew,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"ms" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/chair/pew/left,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"my" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"mL" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"mV" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"mW" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"mX" = (
+/obj/machinery/smartfridge,
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"ne" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"nm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"np" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"nH" = (
+/obj/structure/sink/directional/west,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"nL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"oW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"pi" = (
+/obj/machinery/light/directional/west,
+/obj/structure/hedge,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"pj" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"qe" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/structure/safe/abovetilefloor,
+/obj/item/seeds/kudzu,
+/obj/item/paperwork/service,
+/obj/item/lighter/royal,
+/obj/item/clothing/neck/cowboylea,
+/obj/item/food/grown/poppy/geranium,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"qY" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"rt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"rD" = (
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"rL" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/lighter,
+/obj/item/lighter,
+/obj/item/lighter,
+/obj/item/lighter,
+/obj/item/lighter,
+/obj/item/bong/lungbuster{
+	pixel_y = 8;
+	pixel_x = -9
+	},
+/obj/item/bong/lungbuster{
+	pixel_y = 8;
+	pixel_x = 9
+	},
+/obj/item/bong{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/bong{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"sb" = (
+/obj/structure/closet/secure_closet/personal/wall{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"sg" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"sm" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"sr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"tj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"tp" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"tQ" = (
+/obj/machinery/atmospherics/components/binary/volume_pump/on,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"ua" = (
+/obj/machinery/light/floor,
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 1
+	},
+/area/ruin/powered/seedvault)
+"uu" = (
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"uF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"uK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"ve" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"vp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"vC" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"vH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"vU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"wp" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"wN" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"wP" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"wX" = (
+/obj/structure/closet/secure_closet/personal/wall{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"xa" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/light/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"xf" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"xg" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"xG" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"xO" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"xZ" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ye" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"yg" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"yC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"yL" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"yN" = (
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zf" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"zg" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zw" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"zE" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"zF" = (
+/obj/machinery/vending/hydronutrients{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zN" = (
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/biogenerator,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"zQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"As" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"BD" = (
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"BT" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Cj" = (
+/obj/structure/beebox,
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Cm" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Cq" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"CC" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"CQ" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/melee/flyswatter,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/queen_bee/bought,
+/obj/item/bee_smoker,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"CX" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Dt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"DR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"DT" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/machinery/autolathe,
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Ee" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Ei" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Eo" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Ew" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Ex" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"EE" = (
+/obj/structure/table/wood,
+/obj/structure/towel_bin,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"EI" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Fi" = (
+/obj/effect/mob_spawn/ghost_role/human/seed_vault,
+/turf/open/floor/plating/kudzu,
+/area/ruin/powered/seedvault)
+"Fs" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Gx" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"GE" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"Hs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"Hw" = (
+/obj/machinery/door/airlock/multi_tile/public/glass,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"HP" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"HV" = (
+/obj/structure/sauna_oven,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"Iq" = (
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ID" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"IN" = (
+/obj/machinery/vending/hydroseeds{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Jk" = (
+/obj/structure/hedge,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"JC" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Ke" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Kf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"Kw" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"KD" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 8
+	},
+/area/ruin/powered/seedvault)
+"KL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"KZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"Ld" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"LF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"LI" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Mj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Ni" = (
+/obj/structure/flora/tree/jungle/style_3,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"NU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/plantgenes{
+	pixel_y = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"Ob" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Oq" = (
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"OW" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"OY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Pd" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Pw" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"PM" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/machinery/light/directional/north,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"PV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/corner,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"QK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/sand/volcanic,
+/obj/machinery/door/poddoor{
+	id = "bunkerexterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"QL" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"QW" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"QX" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Rj" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Rm" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Sd" = (
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"Se" = (
+/obj/structure/table/wood,
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Sq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"SB" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 8
+	},
+/area/ruin/powered/seedvault)
+"SH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"SO" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"SR" = (
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"SS" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"ST" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Tk" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Tl" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"TL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"TT" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"TW" = (
+/obj/machinery/computer/terminal{
+	dir = 8;
+	name = "Old Terminal";
+	desc = "A dusty, nonfunctioning terminal left by your creators. The screen is on but nothing you press does anything."
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"UD" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"UP" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"US" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"VE" = (
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"VQ" = (
+/obj/structure/table/wood,
+/obj/machinery/light/directional/east,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"VR" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 4
+	},
+/area/ruin/powered/seedvault)
+"VW" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"WA" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"WI" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe/ghost_cafe{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"WU" = (
+/obj/machinery/vending/clothing{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"WZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/west{
+	id = "bunkerinterior";
+	name = "interior blast door access";
+	req_access = list("away_general")
+	},
+/obj/machinery/button/door/directional/west{
+	id = "bunkershutter";
+	name = "hallway shutter toggle";
+	pixel_y = 8;
+	req_access = list("away_general")
+	},
+/obj/machinery/button/door/directional/west{
+	id = "bunkerexterior";
+	name = "exterior blast door access";
+	pixel_y = -8;
+	req_access = list("away_general")
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Xq" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"XK" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner,
+/area/ruin/powered/seedvault)
+"XZ" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Ye" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Yu" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"YJ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Ze" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Zf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"Zl" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"Zo" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/flatpacked_machine,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/silver{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/titanium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium/half{
+	amount = 20
+	},
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 15
+	},
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 25
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+
+(1,1,1) = {"
+zE
+SR
+SR
+SR
+SR
+BD
+SR
+SR
+BD
+SR
+SR
+SR
+SR
+SR
+SR
+BD
+BD
+BD
+SR
+SR
+SR
+SR
+SR
+"}
+(2,1,1) = {"
+SR
+SR
+SR
+SR
+BD
+BD
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+BD
+BD
+"}
+(3,1,1) = {"
+BD
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+Sd
+Sd
+Sd
+Sd
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+BD
+"}
+(4,1,1) = {"
+SR
+SR
+SR
+SR
+SR
+SR
+Sd
+Sd
+Sd
+Sd
+CX
+cH
+Sd
+Sd
+Sd
+Sd
+Sd
+Sd
+BD
+SR
+BD
+BD
+BD
+"}
+(5,1,1) = {"
+SR
+SR
+SR
+SR
+SR
+BD
+Sd
+WU
+Cq
+Sd
+es
+US
+yN
+wp
+ac
+fF
+XZ
+QK
+BD
+BD
+BD
+SR
+BD
+"}
+(6,1,1) = {"
+SR
+SR
+SR
+Sd
+Sd
+Sd
+Sd
+Se
+zg
+Sd
+yC
+US
+Sq
+me
+nm
+fb
+JC
+QK
+BD
+BD
+SR
+SR
+SR
+"}
+(7,1,1) = {"
+SR
+SR
+SR
+Sd
+Fi
+HP
+Sd
+WI
+cT
+Sd
+BT
+Cm
+Sd
+Sd
+cq
+bW
+Sd
+Sd
+Sd
+BD
+BD
+BD
+SR
+"}
+(8,1,1) = {"
+BD
+SR
+SR
+Sd
+Fi
+SS
+Hw
+dP
+hL
+Ei
+sm
+LI
+Sd
+WZ
+ep
+ep
+QX
+tQ
+LF
+ie
+BD
+BD
+BD
+"}
+(9,1,1) = {"
+BD
+SR
+SR
+Sd
+Fi
+gZ
+jn
+mV
+cm
+Xq
+hW
+sg
+tj
+SH
+OY
+uK
+nL
+xO
+Sd
+SR
+BD
+SR
+SR
+"}
+(10,1,1) = {"
+SR
+SR
+SR
+Sd
+Fi
+aI
+Sd
+mV
+Iq
+QW
+wN
+Kw
+Sd
+VQ
+TW
+Sd
+Sd
+Sd
+Sd
+Sd
+Sd
+SR
+SR
+"}
+(11,1,1) = {"
+SR
+SR
+SR
+Sd
+Sd
+Sd
+Sd
+mV
+dr
+rD
+ga
+Kw
+Sd
+Sd
+Sd
+Sd
+xg
+mW
+mW
+xg
+Sd
+Sd
+SR
+"}
+(12,1,1) = {"
+SR
+SR
+Sd
+Sd
+As
+xa
+Sd
+Ye
+Fs
+Ni
+Ob
+ID
+Sd
+lP
+mL
+iu
+xG
+Ee
+vC
+xZ
+jb
+Sd
+SR
+"}
+(13,1,1) = {"
+SR
+SR
+Sd
+Ew
+CC
+wP
+Sd
+mV
+fN
+Tl
+uu
+dg
+mX
+Ld
+eW
+DR
+zw
+nH
+rD
+UP
+Zl
+Sd
+SR
+"}
+(14,1,1) = {"
+SR
+SR
+Sd
+PM
+qe
+Mj
+tp
+mV
+yg
+rD
+VE
+dg
+tp
+Mj
+dY
+dY
+ne
+aP
+eh
+zf
+Cj
+Sd
+SR
+"}
+(15,1,1) = {"
+SR
+SR
+Sd
+dI
+ek
+QL
+Sd
+mV
+UD
+SO
+KL
+Kw
+zN
+KZ
+ye
+Ex
+WA
+ai
+QW
+qY
+Zl
+Sd
+SR
+"}
+(16,1,1) = {"
+SR
+SR
+Sd
+Sd
+CQ
+Zo
+Sd
+kZ
+zQ
+Eo
+OW
+bm
+Sd
+et
+NU
+np
+ve
+ST
+fD
+dq
+Zl
+Sd
+SR
+"}
+(17,1,1) = {"
+SR
+SR
+SR
+Sd
+Sd
+Sd
+Sd
+YJ
+Rj
+Sd
+GE
+Sd
+Sd
+Sd
+Sd
+oW
+pj
+xf
+xf
+xf
+Sd
+Sd
+SR
+"}
+(18,1,1) = {"
+SR
+SR
+SR
+Sd
+kM
+Ke
+rL
+Tk
+TT
+Sd
+vU
+EE
+dC
+HV
+jt
+Kf
+Zf
+Zf
+vH
+Sd
+Sd
+SR
+SR
+"}
+(19,1,1) = {"
+SR
+SR
+SR
+Sd
+EI
+bu
+bu
+bu
+Pd
+Sd
+wX
+ht
+ht
+Oq
+ht
+pi
+Jk
+Sd
+Yu
+BD
+BD
+BD
+SR
+"}
+(20,1,1) = {"
+BD
+SR
+SR
+Sd
+DT
+bu
+bu
+sr
+hO
+Sd
+wX
+Dt
+Dt
+PV
+uF
+TL
+uF
+Sd
+BD
+BD
+SR
+BD
+SR
+"}
+(21,1,1) = {"
+BD
+BD
+SR
+Sd
+Rm
+gF
+my
+Pw
+yL
+Sd
+sb
+Oq
+vp
+Hs
+ua
+SB
+KD
+Sd
+SR
+SR
+SR
+BD
+BD
+"}
+(22,1,1) = {"
+BD
+SR
+SR
+Sd
+Sd
+Sd
+Sd
+IN
+zF
+Sd
+ms
+kg
+eV
+Hs
+XK
+VR
+cU
+Sd
+SR
+SR
+BD
+BD
+SR
+"}
+(23,1,1) = {"
+SR
+SR
+SR
+SR
+SR
+SR
+Sd
+Sd
+Sd
+Sd
+mk
+rt
+VW
+Sd
+Sd
+Sd
+Sd
+Sd
+SR
+SR
+BD
+BD
+SR
+"}
+(24,1,1) = {"
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+Sd
+jc
+Gx
+Ze
+Sd
+SR
+SR
+SR
+BD
+SR
+SR
+SR
+SR
+SR
+"}
+(25,1,1) = {"
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+Sd
+Sd
+Sd
+Sd
+Sd
+SR
+SR
+SR
+SR
+SR
+BD
+SR
+SR
+SR
+"}
+(26,1,1) = {"
+SR
+SR
+SR
+SR
+SR
+BD
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+BD
+SR
+SR
+SR
+"}
+(27,1,1) = {"
+BD
+BD
+SR
+SR
+BD
+BD
+BD
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+SR
+BD
+BD
+BD
+BD
+SR
+SR
+"}

--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -1,83 +1,69 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ab" = (
-/obj/structure/beebox,
-/obj/effect/turf_decal/siding/thinplating/dark/end,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"aR" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/seedling,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"aT" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"aU" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"bc" = (
+"ae" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/powered/seedvault)
-"br" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
+"ao" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe/ghost_cafe{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"bO" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"bX" = (
+"aU" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/grass,
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"ch" = (
-/obj/machinery/hydroponics/constructable,
+"bl" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"bt" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"cj" = (
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"ct" = (
-/obj/machinery/chem_master,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"cW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"de" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
+"bR" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"dj" = (
+"ca" = (
+/obj/effect/mob_spawn/ghost_role/human/seed_vault,
+/turf/open/floor/plating/kudzu,
+/area/ruin/powered/seedvault)
+"cr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/plantgenes{
+	pixel_y = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"cF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -85,126 +71,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/terracotta/herringbone,
 /area/ruin/powered/seedvault)
-"dB" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"dR" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"dV" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"dY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/door/poddoor{
-	id = "bunkerinterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"dZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"ef" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/melee/flyswatter,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/queen_bee/bought,
-/obj/item/bee_smoker,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"eh" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ep" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ew" = (
-/obj/structure/flora/bush/grassy/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ez" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"eN" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"eR" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"eX" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"fa" = (
-/obj/machinery/light/floor,
+"dl" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/chair/pew/left,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"fE" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
+"dw" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"dD" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"fK" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"fM" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"fW" = (
+"dM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
 	},
@@ -214,22 +95,669 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"fY" = (
+"el" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/corner,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"ev" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"ez" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"eE" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"fh" = (
+/obj/machinery/vending/hydronutrients{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"fl" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"fr" = (
+/obj/machinery/light/directional/west,
+/obj/structure/hedge,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"fy" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"fI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"fM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"fW" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"gf" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"gt" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"gy" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"hb" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"hg" = (
+/obj/machinery/computer/terminal{
+	dir = 8;
+	name = "Old Terminal";
+	desc = "A dusty, nonfunctioning terminal left by your creators. The screen is on but nothing you press does anything."
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"hu" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"hX" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"id" = (
+/obj/machinery/door/airlock/multi_tile/public/glass,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"ij" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"ir" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"iP" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"jv" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"jz" = (
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"jK" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"jM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/sand/volcanic,
+/obj/machinery/door/poddoor{
+	id = "bunkerexterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"jP" = (
+/obj/machinery/light/floor,
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 4
+	},
+/area/ruin/powered/seedvault)
+"jT" = (
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"kt" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"gH" = (
-/obj/structure/chair/pew/right,
+"kV" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"lb" = (
+/obj/structure/chair/pew,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"gJ" = (
+"ld" = (
+/obj/structure/table/wood,
+/obj/structure/towel_bin,
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/ruin/powered/seedvault)
-"gN" = (
+"lh" = (
+/obj/structure/flora/bush/sunny/style_3,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"lL" = (
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"mG" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"mN" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"mT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"nx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"nE" = (
+/obj/structure/closet/secure_closet/personal/wall{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"oo" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"oq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"oL" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"oP" = (
+/obj/machinery/light/floor,
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 1
+	},
+/area/ruin/powered/seedvault)
+"oR" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"pg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"pG" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"pM" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"pU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"pZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"qp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"rp" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"rW" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"rZ" = (
+/obj/machinery/atmospherics/components/binary/volume_pump/on,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"sy" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"sI" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"tg" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/light/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"tk" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"tv" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"tW" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ud" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"ui" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/seedvault)
+"uq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/west{
+	id = "bunkerinterior";
+	name = "interior blast door access";
+	req_access = list("away_general")
+	},
+/obj/machinery/button/door/directional/west{
+	id = "bunkershutter";
+	name = "hallway shutter toggle";
+	pixel_y = 8;
+	req_access = list("away_general")
+	},
+/obj/machinery/button/door/directional/west{
+	id = "bunkerexterior";
+	name = "exterior blast door access";
+	pixel_y = -8;
+	req_access = list("away_general")
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"uM" = (
+/obj/structure/sauna_oven,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"wb" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"we" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"wn" = (
+/obj/structure/water_source/puddle{
+	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
+	base_icon_state = "water_basin";
+	icon_state = "water_basin";
+	name = "filled water basin"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"wp" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"wx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"wD" = (
+/obj/structure/closet/secure_closet/personal/wall{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"wX" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"wZ" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"xo" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"yo" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"yt" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"yB" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"yL" = (
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"zf" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/structure/loom,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zl" = (
+/obj/structure/sink/directional/east,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"zn" = (
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/biogenerator,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"zr" = (
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"zz" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zK" = (
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"zP" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/seedling,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"zS" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Bd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Bm" = (
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"BM" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"CC" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"CI" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 8
+	},
+/area/ruin/powered/seedvault)
+"CJ" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"DE" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/flatpacked_machine,
 /obj/item/stack/sheet/iron/fifty,
@@ -255,835 +783,57 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
-"gQ" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"gU" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"hG" = (
+"DY" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"hI" = (
-/obj/machinery/smartfridge,
-/obj/machinery/door/window,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"ic" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/soap/homemade,
-/obj/item/soap/homemade,
-/obj/item/soap/homemade,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"ii" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"iE" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"iU" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"je" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/machinery/light/directional/north,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"jg" = (
-/obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"jN" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe/ghost_cafe{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"jW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"kp" = (
-/obj/structure/flora/bush/generic/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"kw" = (
+"Ea" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	name = "Server Vent"
-	},
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"kG" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/item/seeds/surik,
-/obj/item/seeds/surik,
-/obj/item/seeds/vaporsac,
-/obj/item/seeds/vaporsac,
-/obj/item/seeds/amauri,
-/obj/item/seeds/amauri,
-/obj/item/seeds/gelthi,
-/obj/item/seeds/gelthi,
-/obj/item/seeds/jurlmah,
-/obj/item/seeds/jurlmah,
-/obj/item/seeds/nofruit,
-/obj/item/seeds/nofruit,
-/obj/item/seeds/shand,
-/obj/item/seeds/shand,
-/obj/item/seeds/telriis,
-/obj/item/seeds/telriis,
-/obj/item/seeds/thaadra,
-/obj/item/seeds/thaadra,
-/obj/item/seeds/vale,
-/obj/item/seeds/vale,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"lj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"lm" = (
-/obj/structure/flora/bush/sunny/style_3,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ln" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
+/obj/machinery/autolathe,
+/obj/item/storage/toolbox/syndicate,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"lx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"lB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bunkershutter"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/seedvault)
-"lZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/sand/volcanic,
-/obj/machinery/door/poddoor{
-	id = "bunkerexterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"mk" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"mo" = (
-/obj/machinery/door/poddoor{
-	id = "bunkerinterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"mp" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"ms" = (
-/obj/machinery/door/airlock/multi_tile/public/glass,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"nt" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"nA" = (
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"nF" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"nK" = (
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"nP" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"oo" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 8
-	},
-/area/ruin/powered/seedvault)
-"oG" = (
-/obj/effect/mob_spawn/ghost_role/human/seed_vault,
-/turf/open/floor/plating/kudzu,
-/area/ruin/powered/seedvault)
-"oI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"oJ" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"oP" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ps" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"pT" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/obj/structure/safe/abovetilefloor,
-/obj/item/seeds/kudzu,
-/obj/item/paperwork/service,
-/obj/item/lighter/royal,
-/obj/item/clothing/neck/cowboylea,
-/obj/item/food/grown/poppy/geranium,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"pU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"pY" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"qd" = (
+"Eu" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"rd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"rw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"rR" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"rX" = (
-/obj/machinery/light/floor,
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner{
-	dir = 1
-	},
-/area/ruin/powered/seedvault)
-"so" = (
-/obj/structure/water_source/puddle{
-	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
-	base_icon_state = "water_basin";
-	icon_state = "water_basin";
-	name = "filled water basin"
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"sw" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"sL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"ti" = (
-/obj/structure/sink/directional/east,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"tw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"tK" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"tQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"tS" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"uH" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"uK" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"uM" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"uW" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ve" = (
-/obj/machinery/atmospherics/components/binary/volume_pump/on,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"vf" = (
-/obj/machinery/vending/hydroseeds{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"vg" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"vk" = (
+"EA" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"vn" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"vQ" = (
-/obj/structure/hedge,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"wl" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"wv" = (
-/obj/structure/flora/tree/jungle/style_3,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"wB" = (
-/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/structure/disposaloutlet,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"wH" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"xk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
+"EK" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"xq" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"xr" = (
-/obj/machinery/vending/hydronutrients{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"xA" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"xJ" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"xQ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wideplating_new/corner,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"xW" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"yt" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"yw" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/structure/loom,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"yA" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
-/obj/machinery/light/directional/west,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"yK" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"zd" = (
-/obj/machinery/computer/terminal{
-	dir = 8;
-	name = "Old Terminal";
-	desc = "A dusty, nonfunctioning terminal left by your creators. The screen is on but nothing you press does anything."
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"zg" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"zj" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"zx" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"Aa" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"AF" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	name = "Server Vent"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"AG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"AV" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/chair/pew/left,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"Bd" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
-	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
-"BF" = (
-/obj/machinery/vending/clothing{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Co" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Cq" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Dr" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"DF" = (
-/obj/structure/closet/secure_closet/personal/wall{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"DY" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Ec" = (
-/obj/structure/table/wood,
-/obj/structure/towel_bin,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"Ex" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner{
-	dir = 8
-	},
-/area/ruin/powered/seedvault)
-"Fg" = (
+"EZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Fl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "Fu" = (
-/obj/structure/flora/bush/sunny,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"FU" = (
-/obj/machinery/door/window,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/obj/machinery/biogenerator,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"Gl" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/clothing/neck/stethoscope,
-/obj/machinery/light/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"Go" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 4
-	},
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"GP" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Ha" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	name = "Server Vent"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Hc" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Hy" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/south,
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"HW" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Is" = (
-/obj/structure/table/wood,
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Iu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Iv" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
@@ -1112,98 +862,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"IA" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"IZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"Jj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Jv" = (
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"JF" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Kl" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Kt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"KG" = (
-/obj/machinery/light/directional/west,
-/obj/structure/hedge,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"KK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"KY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5;
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/item/construction/plumbing,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"La" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"Lh" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"LV" = (
-/obj/machinery/smartfridge,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"Md" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Mk" = (
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ME" = (
+"FT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/vault,
@@ -1211,156 +870,80 @@
 /obj/effect/mapping_helpers/airlock/access/all/away/general,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"MJ" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"MW" = (
-/obj/structure/closet/secure_closet/personal/wall{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"Og" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bunkershutter"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/seedvault)
-"Op" = (
-/obj/machinery/light/floor,
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner{
-	dir = 4
-	},
-/area/ruin/powered/seedvault)
-"OA" = (
+"FV" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"Pq" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"Pv" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
+"Gf" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Py" = (
+"Gx" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"GK" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Hd" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"Hh" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/warning/corner,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"PT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/west{
-	id = "bunkerinterior";
-	name = "interior blast door access";
-	req_access = list("away_general")
-	},
-/obj/machinery/button/door/directional/west{
-	id = "bunkershutter";
-	name = "hallway shutter toggle";
-	pixel_y = 8;
-	req_access = list("away_general")
-	},
-/obj/machinery/button/door/directional/west{
-	id = "bunkerexterior";
-	name = "exterior blast door access";
-	pixel_y = -8;
-	req_access = list("away_general")
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
+"Hl" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/side{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Qj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
+"Id" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/melee/flyswatter,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/queen_bee/bought,
+/obj/item/bee_smoker,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
-"Qo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"Qp" = (
-/obj/structure/flora/bush/grassy/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
+"Ij" = (
+/obj/structure/chair/pew{
 	dir = 1
 	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"QH" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"QQ" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"QW" = (
-/obj/structure/table/wood,
-/obj/machinery/light/directional/east,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Rf" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/light/floor,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"Rz" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"IM" = (
+/obj/structure/flora/tree/jungle/style_3,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"SX" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"TA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"Ui" = (
+"Jj" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
@@ -1371,91 +954,118 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Uk" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Uz" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"UP" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+"JE" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"UW" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 4
-	},
-/area/ruin/powered/seedvault)
-"Vc" = (
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Vk" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Vp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/plantgenes{
-	pixel_y = 8
+"Kb" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Vy" = (
+"Kk" = (
 /obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"VK" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"WU" = (
-/obj/structure/chair/pew,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"WW" = (
-/obj/structure/sauna_oven,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"Xm" = (
-/obj/structure/flora/bush/generic/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"Xr" = (
+"Ko" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/powered/seedvault)
-"Yi" = (
+"KY" = (
+/obj/structure/chair/pew/right,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Lk" = (
+/obj/structure/flora/bush/sunny,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"LB" = (
+/obj/structure/table/wood,
+/obj/machinery/light/directional/east,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"LU" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"LZ" = (
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Mb" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Mz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"MF" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"MY" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner,
+/area/ruin/powered/seedvault)
+"Nf" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Nq" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Nz" = (
+/obj/machinery/smartfridge,
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"NS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Oe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Oj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -1468,724 +1078,1114 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Yu" = (
+"Ow" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"OB" = (
+/obj/machinery/light/floor,
 /obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"OE" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"OV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Pa" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Pk" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/side{
 	dir = 4
+	},
+/area/ruin/powered/seedvault)
+"Pl" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Pz" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"PM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"PP" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"PU" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Ql" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"Qo" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Qq" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"YB" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner,
+"Rc" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"Zq" = (
+"RJ" = (
+/obj/machinery/chem_master,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"RP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Sc" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"Sf" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"Sk" = (
+/obj/structure/beebox,
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Sm" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Sv" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"SU" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Tn" = (
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Tq" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Tw" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"TF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"TI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"TP" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"TS" = (
+/obj/machinery/vending/hydroseeds{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"TX" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/item/seeds/surik,
+/obj/item/seeds/surik,
+/obj/item/seeds/vaporsac,
+/obj/item/seeds/vaporsac,
+/obj/item/seeds/amauri,
+/obj/item/seeds/amauri,
+/obj/item/seeds/gelthi,
+/obj/item/seeds/gelthi,
+/obj/item/seeds/jurlmah,
+/obj/item/seeds/jurlmah,
+/obj/item/seeds/nofruit,
+/obj/item/seeds/nofruit,
+/obj/item/seeds/shand,
+/obj/item/seeds/shand,
+/obj/item/seeds/telriis,
+/obj/item/seeds/telriis,
+/obj/item/seeds/thaadra,
+/obj/item/seeds/thaadra,
+/obj/item/seeds/vale,
+/obj/item/seeds/vale,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Uf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/seedvault)
+"Un" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Up" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"Ur" = (
+/obj/machinery/vending/clothing{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"UC" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"UJ" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"UK" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"UR" = (
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"UY" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Zx" = (
+"Vc" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/machinery/light/directional/north,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"VD" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"We" = (
+/obj/structure/hedge,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"WE" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"WJ" = (
+/obj/structure/sink/directional/west,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"WW" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/structure/safe/abovetilefloor,
+/obj/item/seeds/kudzu,
+/obj/item/paperwork/service,
+/obj/item/lighter/royal,
+/obj/item/clothing/neck/cowboylea,
+/obj/item/food/grown/poppy/geranium,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Xg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Xn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"XK" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Yo" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Yv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/item/construction/plumbing,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"YZ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"Zf" = (
+/obj/structure/table/wood,
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Zl" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"Zs" = (
 /obj/machinery/door/airlock/vault,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"ZB" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/obj/machinery/autolathe,
-/obj/item/storage/toolbox/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"ZM" = (
-/obj/structure/sink/directional/west,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
 /area/ruin/powered/seedvault)
 
 (1,1,1) = {"
-zx
-Pq
-Pq
-Pq
-Pq
-cj
-Pq
-Pq
-cj
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-cj
-cj
-cj
-Pq
-Pq
-Pq
-Pq
-Pq
+hX
+Bm
+Bm
+Bm
+Bm
+LZ
+Bm
+Bm
+LZ
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+LZ
+LZ
+LZ
+Bm
+Bm
+Bm
+Bm
+Bm
 "}
 (2,1,1) = {"
-Pq
-Pq
-Pq
-Pq
-cj
-cj
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-cj
-cj
+Bm
+Bm
+Bm
+Bm
+LZ
+LZ
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+LZ
+LZ
 "}
 (3,1,1) = {"
-cj
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Jv
-Jv
-Jv
-Jv
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-cj
+LZ
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+UR
+UR
+UR
+UR
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+LZ
 "}
 (4,1,1) = {"
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Jv
-Jv
-Jv
-Jv
-rR
-Py
-Jv
-Jv
-Jv
-Jv
-Jv
-Jv
-cj
-Pq
-cj
-cj
-cj
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+UR
+UR
+UR
+UR
+wp
+Hh
+UR
+UR
+UR
+UR
+UR
+UR
+LZ
+Bm
+LZ
+LZ
+LZ
 "}
 (5,1,1) = {"
-Pq
-Pq
-Pq
-Pq
-Pq
-cj
-Jv
-BF
-xq
-Jv
-iU
-Uk
-mo
-br
-Yi
-Jj
-Zx
-lZ
-cj
-cj
-cj
-Pq
-cj
+Bm
+Bm
+Bm
+Bm
+Bm
+LZ
+UR
+Ur
+tv
+UR
+mN
+aU
+lL
+PU
+Oj
+zB
+yB
+jM
+LZ
+LZ
+LZ
+Bm
+LZ
 "}
 (6,1,1) = {"
-Pq
-Pq
-Pq
-Jv
-Jv
-Jv
-Jv
-Is
-uK
-Jv
-pU
-Uk
-dY
-Ui
-fW
-Iu
-Vc
-lZ
-cj
-cj
-Pq
-Pq
-Pq
+Bm
+Bm
+Bm
+UR
+UR
+UR
+UR
+Zf
+jv
+UR
+Bd
+aU
+NS
+Jj
+dM
+ir
+Zs
+jM
+LZ
+LZ
+Bm
+Bm
+Bm
 "}
 (7,1,1) = {"
-Pq
-Pq
-Pq
-Jv
-oG
-SX
-Jv
-jN
-vn
-Jv
-dR
-HW
-Jv
-Jv
-Og
-lB
-Jv
-Jv
-Jv
-cj
-cj
-cj
-Pq
+Bm
+Bm
+Bm
+UR
+ca
+Sf
+UR
+ao
+Gf
+UR
+we
+jK
+UR
+UR
+Uf
+ui
+UR
+UR
+UR
+LZ
+LZ
+LZ
+Bm
 "}
 (8,1,1) = {"
-cj
-Pq
-Pq
-Jv
-oG
-kw
-ms
-xA
-nP
-Hc
-Yu
-uH
-Jv
-PT
-ln
-ln
-Aa
-ve
-dZ
-dV
-cj
-cj
-cj
+LZ
+Bm
+Bm
+UR
+ca
+EK
+id
+Tq
+VD
+Un
+sy
+GK
+UR
+uq
+Xg
+Xg
+wX
+rZ
+fM
+Hd
+LZ
+LZ
+LZ
 "}
 (9,1,1) = {"
-cj
-Pq
-Pq
-Jv
-oG
-MJ
-tw
-wl
-Rz
-Vk
-hG
-ps
-ME
-Fg
-tQ
-Kt
-cW
-aT
-Jv
-Pq
-cj
-Pq
-Pq
+LZ
+Bm
+Bm
+UR
+ca
+gy
+wx
+LU
+Kk
+rW
+Qo
+xo
+FT
+pU
+ud
+EZ
+TI
+bl
+UR
+Bm
+LZ
+Bm
+Bm
 "}
 (10,1,1) = {"
-Pq
-Pq
-Pq
-Jv
-oG
-Bd
-Jv
-wl
-kp
-Kl
-yK
-mp
-Jv
-QW
-zd
-Jv
-Jv
-Jv
-Jv
-Jv
-Jv
-Pq
-Pq
+Bm
+Bm
+Bm
+UR
+ca
+Up
+UR
+LU
+yL
+XK
+zS
+oo
+UR
+LB
+hg
+UR
+UR
+UR
+UR
+UR
+UR
+Bm
+Bm
 "}
 (11,1,1) = {"
-Pq
-Pq
-Pq
-Jv
-Jv
-Jv
-Jv
-wl
-uM
-ew
-lm
-mp
-Jv
-Jv
-Jv
-Jv
-ch
-La
-La
-ch
-Jv
-Jv
-Pq
+Bm
+Bm
+Bm
+UR
+UR
+UR
+UR
+LU
+gt
+jz
+lh
+oo
+UR
+UR
+UR
+UR
+EA
+Sc
+Sc
+EA
+UR
+UR
+Bm
 "}
 (12,1,1) = {"
-Pq
-Pq
-Jv
-Jv
-bO
-Gl
-Jv
-ii
-Uz
-wv
-IA
-UP
-Jv
-ct
-yA
-KY
-de
-jg
-eR
-ep
-Dr
-Jv
-Pq
+Bm
+Bm
+UR
+UR
+wZ
+tg
+UR
+iP
+dD
+IM
+TP
+Gx
+UR
+RJ
+oL
+Yv
+hu
+WE
+DY
+OB
+dw
+UR
+Bm
 "}
 (13,1,1) = {"
-Pq
-Pq
-Jv
-ic
-Ha
-pY
-Jv
-wl
-Fu
-fE
-nK
-fY
-hI
-tK
-aU
-AG
-Qp
-ZM
-ew
-oJ
-xW
-Jv
-Pq
+Bm
+Bm
+UR
+pM
+eE
+Kb
+UR
+LU
+Lk
+Pl
+zK
+Qq
+Nz
+ev
+bR
+qp
+wb
+WJ
+jz
+OE
+FV
+UR
+Bm
 "}
 (14,1,1) = {"
-Pq
-Pq
-Jv
-je
-pT
-oI
-nA
-wl
-nt
-ew
-Xm
-fY
-nA
-oI
-sL
-sL
-GP
-LV
-aR
-oP
-ab
-Jv
-Pq
+Bm
+Bm
+UR
+Vc
+WW
+Xn
+MF
+LU
+UC
+jz
+zr
+Qq
+MF
+Xn
+fI
+fI
+fW
+Pz
+zP
+pG
+Sk
+UR
+Bm
 "}
 (15,1,1) = {"
-Pq
-Pq
-Jv
-kG
-Pv
-VK
-Jv
-wl
-DY
-eh
-bX
-mp
-FU
-jW
-iE
-dB
-Lh
-ti
-Kl
-Mk
-xW
-Jv
-Pq
+Bm
+Bm
+UR
+TX
+fy
+Mb
+UR
+LU
+Pa
+tW
+Mz
+oo
+zn
+Fl
+Sv
+Rc
+Sm
+zl
+XK
+UJ
+FV
+UR
+Bm
 "}
 (16,1,1) = {"
-Pq
-Pq
-Jv
-Jv
-ef
-gN
-Jv
-Co
-fM
-eN
-eX
-mk
-Jv
-qd
-Vp
-gU
-uW
-sw
-Vy
-JF
-xW
-Jv
-Pq
+Bm
+Bm
+UR
+UR
+Id
+DE
+UR
+kt
+yo
+yt
+pZ
+UK
+UR
+Eu
+cr
+Tw
+BM
+RP
+tk
+CC
+FV
+UR
+Bm
 "}
 (17,1,1) = {"
-Pq
-Pq
-Pq
-Jv
-Jv
-Jv
-Jv
-tS
-gQ
-Jv
-fK
-Jv
-Jv
-Jv
-Jv
-lx
-vk
-OA
-OA
-OA
-Jv
-Jv
-Pq
+Bm
+Bm
+Bm
+UR
+UR
+UR
+UR
+UY
+bt
+UR
+Zl
+UR
+UR
+UR
+UR
+Ko
+fl
+YZ
+YZ
+YZ
+UR
+UR
+Bm
 "}
 (18,1,1) = {"
-Pq
-Pq
-Pq
-Jv
-yw
-AF
-Iv
-zg
-QQ
-Jv
-Qj
-Ec
-so
-WW
-yt
-Qo
-bc
-bc
-Xr
-Jv
-Jv
-Pq
-Pq
+Bm
+Bm
+Bm
+UR
+zf
+Yo
+Fu
+CJ
+oR
+UR
+pg
+ld
+wn
+uM
+ij
+TF
+ae
+ae
+nx
+UR
+UR
+Bm
+Bm
 "}
 (19,1,1) = {"
-Pq
-Pq
-Pq
-Jv
-xk
-ez
-ez
-ez
-QH
-Jv
-MW
-IZ
-IZ
-gJ
-IZ
-KG
-vQ
-Jv
-wB
-cj
-cj
-cj
-Pq
+Bm
+Bm
+Bm
+UR
+mG
+PP
+PP
+PP
+zz
+UR
+nE
+Ow
+Ow
+jT
+Ow
+fr
+We
+UR
+kV
+LZ
+LZ
+LZ
+Bm
 "}
 (20,1,1) = {"
-cj
-Pq
-Pq
-Jv
-ZB
-ez
-ez
-rd
-Md
-Jv
-MW
-KK
-KK
-xQ
-Go
-TA
-Go
-Jv
-cj
-cj
-Pq
-cj
-Pq
+LZ
+Bm
+Bm
+UR
+Ea
+PP
+PP
+PM
+JE
+UR
+nE
+oq
+oq
+el
+Ql
+mT
+Ql
+UR
+LZ
+LZ
+Bm
+LZ
+Bm
 "}
 (21,1,1) = {"
-cj
-cj
-Pq
-Jv
-xJ
-Zq
-zj
-vg
-Cq
-Jv
-DF
-gJ
-rw
-dj
-rX
-oo
-Ex
-Jv
-Pq
-Pq
-Pq
-cj
-cj
+LZ
+LZ
+Bm
+UR
+Tn
+Nf
+hb
+sI
+SU
+UR
+wD
+jT
+ez
+cF
+oP
+Hl
+CI
+UR
+Bm
+Bm
+Bm
+LZ
+LZ
 "}
 (22,1,1) = {"
-cj
-Pq
-Pq
-Jv
-Jv
-Jv
-Jv
-vf
-xr
-Jv
-AV
-Rf
-Hy
-dj
-YB
-UW
-Op
-Jv
-Pq
-Pq
-cj
-cj
-Pq
+LZ
+Bm
+Bm
+UR
+UR
+UR
+UR
+TS
+fh
+UR
+dl
+OV
+rp
+cF
+MY
+Pk
+jP
+UR
+Bm
+Bm
+LZ
+LZ
+Bm
 "}
 (23,1,1) = {"
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Jv
-Jv
-Jv
-Jv
-WU
-lj
-wH
-Jv
-Jv
-Jv
-Jv
-Jv
-Pq
-Pq
-cj
-cj
-Pq
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+UR
+UR
+UR
+UR
+lb
+Oe
+Ij
+UR
+UR
+UR
+UR
+UR
+Bm
+Bm
+LZ
+LZ
+Bm
 "}
 (24,1,1) = {"
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Jv
-gH
-fa
-nF
-Jv
-Pq
-Pq
-Pq
-cj
-Pq
-Pq
-Pq
-Pq
-Pq
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+UR
+KY
+Nq
+gf
+UR
+Bm
+Bm
+Bm
+LZ
+Bm
+Bm
+Bm
+Bm
+Bm
 "}
 (25,1,1) = {"
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Jv
-Jv
-Jv
-Jv
-Jv
-Pq
-Pq
-Pq
-Pq
-Pq
-cj
-Pq
-Pq
-Pq
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+UR
+UR
+UR
+UR
+UR
+Bm
+Bm
+Bm
+Bm
+Bm
+LZ
+Bm
+Bm
+Bm
 "}
 (26,1,1) = {"
-Pq
-Pq
-Pq
-Pq
-Pq
-cj
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-cj
-Pq
-Pq
-Pq
+Bm
+Bm
+Bm
+Bm
+Bm
+LZ
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+LZ
+Bm
+Bm
+Bm
 "}
 (27,1,1) = {"
-cj
-cj
-Pq
-Pq
-cj
-cj
-cj
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-Pq
-cj
-cj
-cj
-cj
-Pq
-Pq
+LZ
+LZ
+Bm
+Bm
+LZ
+LZ
+LZ
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+Bm
+LZ
+LZ
+LZ
+LZ
+Bm
+Bm
 "}

--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -19,8 +19,10 @@
 /area/ruin/powered/seedvault)
 "cr" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "cs" = (
@@ -430,10 +432,10 @@
 /area/ruin/powered/seedvault)
 "nS" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
 /obj/structure/spacevine,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "nT" = (
@@ -751,10 +753,10 @@
 /area/ruin/powered/seedvault)
 "wu" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
 /obj/structure/spacevine,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "wH" = (
@@ -782,7 +784,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "wT" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -1168,10 +1170,10 @@
 /area/ruin/powered/seedvault)
 "LV" = (
 /obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "MZ" = (
@@ -1208,17 +1210,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/spacevine,
+/obj/structure/fake_stairs/directional/west{
+	color = "#5c5c5c"
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "Oa" = (
@@ -1342,16 +1338,10 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/fake_stairs/directional/west{
+	color = "#5c5c5c"
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "Rj" = (
@@ -1489,11 +1479,11 @@
 /area/ruin/powered/seedvault)
 "UE" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "UI" = (
@@ -1629,7 +1619,9 @@
 /area/ruin/powered/seedvault)
 "ZU" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 
@@ -1902,8 +1894,8 @@ Sa
 Sa
 nS
 UE
-uB
-iJ
+LV
+kB
 Sa
 Sa
 HR
@@ -2050,9 +2042,9 @@ Sa
 Sa
 Sa
 UI
-LV
-kB
-kB
+uB
+iJ
+iJ
 wu
 Sa
 Sa

--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "au" = (
-/obj/machinery/light/floor,
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
 "br" = (
@@ -59,15 +59,13 @@
 /area/ruin/powered/seedvault)
 "dn" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/drain,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
 "dp" = (
-/obj/structure/closet/secure_closet/personal/wall{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/stairs/left,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/obj/effect/mist,
+/turf/open/floor/iron/pool/cobble/side,
 /area/ruin/powered/seedvault)
 "dv" = (
 /obj/structure/table/reinforced,
@@ -170,7 +168,7 @@
 	dir = 1
 	},
 /obj/machinery/biogenerator,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "fE" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -197,17 +195,14 @@
 "gv" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/seedling,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/grass,
 /area/ruin/powered/seedvault)
 "gx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
@@ -277,6 +272,7 @@
 /area/ruin/powered/seedvault)
 "jw" = (
 /obj/machinery/chem_master,
+/obj/structure/spacevine,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "jJ" = (
@@ -315,9 +311,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "kF" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/wood,
+/obj/item/wallframe/closet{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "kR" = (
 /obj/structure/sink/directional/west,
@@ -352,17 +353,19 @@
 /area/ruin/powered/seedvault)
 "lP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "lX" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/spacevine,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "mv" = (
 /obj/structure/flora/bush/sunny/style_3,
+/obj/structure/spacevine,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
 "mA" = (
@@ -433,6 +436,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
+/obj/structure/spacevine,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "ou" = (
@@ -486,6 +490,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/light/directional/south,
+/obj/structure/spacevine,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "qw" = (
@@ -522,11 +527,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "qN" = (
-/obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "qX" = (
@@ -536,14 +541,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "ra" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bunkershutter"
 	},
+/obj/structure/window/green_glass_pane,
 /turf/open/floor/plating,
 /area/ruin/powered/seedvault)
 "rb" = (
@@ -551,6 +556,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "rf" = (
@@ -584,16 +590,17 @@
 	name = "Server Vent"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "rS" = (
-/obj/structure/closet/secure_closet/personal/wall{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/item/wallframe/closet{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "si" = (
 /obj/machinery/door/airlock/multi_tile/public/glass,
@@ -622,6 +629,11 @@
 	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
+"tt" = (
+/obj/effect/mob_spawn/ghost_role/human/seed_vault,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/kudzu,
+/area/ruin/powered/seedvault)
 "tA" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -647,7 +659,7 @@
 	invisibility = 100;
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "uu" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
@@ -664,9 +676,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "uD" = (
-/obj/structure/sauna_oven,
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood,
+/obj/item/wallframe/closet{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "uE" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -704,6 +721,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/spacevine,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "vU" = (
@@ -719,11 +737,12 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine,
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "wN" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "wS" = (
 /obj/structure/fans/tiny,
@@ -790,7 +809,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "yN" = (
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "zb" = (
 /obj/structure/closet/crate/hydroponics,
@@ -885,8 +904,14 @@
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "Da" = (
-/obj/structure/hedge,
-/turf/open/floor/wood,
+/obj/structure/water_source/puddle{
+	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
+	base_icon_state = "water_basin";
+	icon_state = "water_basin";
+	name = "filled water basin"
+	},
+/obj/item/reagent_containers/cup/bucket/wooden,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "Dv" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -951,17 +976,24 @@
 	invisibility = 100;
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "GY" = (
-/obj/structure/water_source/puddle{
-	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
-	base_icon_state = "water_basin";
-	icon_state = "water_basin";
-	name = "filled water basin"
+/obj/item/wallframe/closet{
+	pixel_x = -32
 	},
-/obj/item/reagent_containers/cup/bucket/wooden,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Hj" = (
+/obj/effect/spawner/liquids_spawner/shoulders,
+/obj/effect/mist,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 1
+	},
 /area/ruin/powered/seedvault)
 "HB" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1040,7 +1072,10 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
-/obj/structure/safe/abovetilefloor,
+/obj/structure/safe/abovetilefloor{
+	name = "old floor safe";
+	desc = "A large, floor embedded safe. Looks old and worn."
+	},
 /obj/item/seeds/kudzu,
 /obj/item/paperwork/service,
 /obj/item/lighter/royal,
@@ -1049,17 +1084,25 @@
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "JI" = (
-/obj/structure/closet/secure_closet/personal/wall{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
+/obj/item/wallframe/closet{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "JP" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Kh" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "Ks" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
@@ -1080,6 +1123,7 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 1
 	},
+/obj/structure/spacevine,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "KQ" = (
@@ -1103,6 +1147,13 @@
 "Lk" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
+"LH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
 "LI" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1122,11 +1173,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
+"Ma" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
 "MZ" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bunkershutter"
 	},
+/obj/structure/window/green_glass_pane,
 /turf/open/floor/plating,
 /area/ruin/powered/seedvault)
 "Nh" = (
@@ -1140,7 +1198,16 @@
 /obj/item/soap/homemade,
 /obj/item/soap/homemade,
 /obj/item/soap/homemade,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Nm" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/spacevine,
+/turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "Nr" = (
 /obj/structure/table/wood,
@@ -1150,6 +1217,15 @@
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Nu" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "NH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1165,6 +1241,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/spacevine,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "Oa" = (
@@ -1184,7 +1261,7 @@
 /area/ruin/powered/seedvault)
 "Op" = (
 /obj/machinery/smartfridge,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/grass,
 /area/ruin/powered/seedvault)
 "OF" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1223,6 +1300,18 @@
 /obj/item/storage/bag/plants,
 /obj/item/storage/bag/plants,
 /obj/item/storage/bag/plants,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/hatchet,
+/obj/item/hatchet,
+/obj/item/hatchet,
+/obj/item/hatchet,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/cultivator,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
 "Pq" = (
@@ -1235,6 +1324,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/spacevine,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "PF" = (
@@ -1256,6 +1346,7 @@
 /obj/structure/chair/pew{
 	dir = 1
 	},
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
 "Qg" = (
@@ -1263,6 +1354,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Qw" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/structure/spacevine,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "QS" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1281,12 +1380,8 @@
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "Rj" = (
-/obj/machinery/smartfridge,
-/obj/machinery/door/window,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/obj/structure/window/green_glass_pane,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
@@ -1332,11 +1427,17 @@
 /obj/structure/chair/pew/left,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
+"Sq" = (
+/obj/effect/spawner/liquids_spawner/shoulders,
+/obj/effect/mist,
+/turf/open/floor/iron/pool/cobble,
+/area/ruin/powered/seedvault)
 "Tb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /obj/effect/turf_decal/siding/wideplating_new/corner,
+/obj/structure/drain,
 /turf/open/floor/iron/terracotta/herringbone,
 /area/ruin/powered/seedvault)
 "Tt" = (
@@ -1387,9 +1488,11 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 6
 	},
+/obj/structure/spacevine,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "Up" = (
+/obj/structure/spacevine,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
 "UD" = (
@@ -1418,8 +1521,9 @@
 /area/ruin/powered/seedvault)
 "VR" = (
 /obj/machinery/light/directional/west,
-/obj/structure/hedge,
-/turf/open/floor/wood,
+/obj/structure/sauna_oven,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "VS" = (
 /obj/structure/closet/crate/hydroponics,
@@ -1460,6 +1564,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/spacevine,
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "XT" = (
@@ -1503,11 +1608,17 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "Yh" = (
-/obj/effect/mist,
 /obj/effect/spawner/liquids_spawner/shoulders,
+/obj/effect/mist,
 /turf/open/floor/iron/pool/cobble/side{
 	dir = 8
 	},
+/area/ruin/powered/seedvault)
+"Yv" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "YI" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -1672,7 +1783,7 @@ OZ
 pY
 Sa
 oZ
-kk
+Yv
 jO
 qw
 RG
@@ -1765,14 +1876,14 @@ HR
 HR
 HR
 Sa
-ou
+tt
 dc
 Sa
 Qg
 pv
 PR
 jJ
-mY
+Nm
 Sa
 Nr
 eg
@@ -1802,8 +1913,8 @@ Sa
 Sa
 Sa
 Sa
-iJ
-uB
+Qw
+Nu
 uB
 iJ
 Sa
@@ -1893,7 +2004,7 @@ HQ
 Zc
 lO
 Sa
-Qg
+Ma
 TV
 LM
 vQ
@@ -1955,7 +2066,7 @@ UI
 LV
 kB
 kB
-kB
+Kh
 Sa
 Sa
 HR
@@ -1996,7 +2107,7 @@ Lk
 Lk
 Ks
 Sa
-dp
+WL
 ur
 wN
 yN
@@ -2075,9 +2186,9 @@ Sd
 Jq
 FS
 fG
-FP
-rs
-lF
+Hj
+Sq
+dp
 Sa
 HR
 HR
@@ -2099,10 +2210,10 @@ Sa
 dw
 dn
 PY
-Sa
-Sa
-Sa
-Sa
+LH
+FP
+rs
+lF
 Sa
 HR
 HR
@@ -2125,10 +2236,10 @@ ef
 au
 br
 Sa
-HR
-HR
-HR
-qX
+Sa
+Sa
+Sa
+Sa
 HR
 HR
 HR

--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -1,92 +1,220 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ac" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/light/directional/west{
-	pixel_y = -15
-	},
-/obj/machinery/mining_weather_monitor/directional/west,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"ai" = (
-/obj/structure/sink/directional/east,
-/obj/structure/flora/bush/flowers_pp/style_random,
+"ab" = (
+/obj/structure/beebox,
+/obj/effect/turf_decal/siding/thinplating/dark/end,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"aI" = (
+"aR" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/seedling,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"aT" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"aU" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"aP" = (
-/obj/machinery/smartfridge,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"bm" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
+"bc" = (
+/obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"br" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
 	},
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"bu" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"bW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bunkershutter"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/seedvault)
-"cm" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"cq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bunkershutter"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/seedvault)
-"cH" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"cT" = (
+"bO" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"bX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ch" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"cj" = (
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ct" = (
+/obj/machinery/chem_master,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"cW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"de" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"dj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"dB" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"dR" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"cU" = (
+"dV" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"dY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"dZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"ef" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/melee/flyswatter,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/queen_bee/bought,
+/obj/item/bee_smoker,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"eh" = (
 /obj/machinery/light/floor,
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner{
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ep" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ew" = (
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ez" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"eN" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"eR" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"eX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"fa" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"fE" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"fK" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"fM" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"fW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"dg" = (
+"fY" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
@@ -94,28 +222,170 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"dq" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/turf/open/floor/grass,
+"gH" = (
+/obj/structure/chair/pew/right,
+/turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"dr" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"dC" = (
-/obj/structure/water_source/puddle{
-	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
-	base_icon_state = "water_basin";
-	icon_state = "water_basin";
-	name = "filled water basin"
-	},
+"gJ" = (
 /turf/open/floor/wood,
 /area/ruin/powered/seedvault)
-"dI" = (
+"gN" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/flatpacked_machine,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/silver{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/titanium{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/uranium/half{
+	amount = 20
+	},
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 15
+	},
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 25
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"gQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"gU" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"hG" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"hI" = (
+/obj/machinery/smartfridge,
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"ic" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"ii" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"iE" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"iU" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"je" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/effect/spawner/random/food_or_drink/seed_vault,
+/obj/machinery/light/directional/north,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"jg" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"jN" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe/ghost_cafe{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"jW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"kp" = (
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"kw" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"kG" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/item/seeds/surik,
@@ -140,309 +410,145 @@
 /obj/item/seeds/vale,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
-"dP" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"dY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"eh" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/seedling,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"ek" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"ep" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"lj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"es" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"et" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"eV" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/south,
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"eW" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"fb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"fD" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"fF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"fN" = (
-/obj/structure/flora/bush/sunny,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ga" = (
+"lm" = (
 /obj/structure/flora/bush/sunny/style_3,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"gF" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"gZ" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"ht" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"hL" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"hO" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/machinery/light/directional/south,
+"ln" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"hW" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ie" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"iu" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5;
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"jb" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"jc" = (
-/obj/structure/chair/pew/right,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"jn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"jt" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"kg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"kM" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/structure/loom,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"kZ" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"lP" = (
-/obj/machinery/chem_master,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"me" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"mk" = (
-/obj/structure/chair/pew,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"ms" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/chair/pew/left,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"my" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"mL" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
-/obj/machinery/light/directional/west,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"mV" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"mW" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"mX" = (
-/obj/machinery/smartfridge,
-/obj/machinery/door/window,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"ne" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"nm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"np" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"nH" = (
-/obj/structure/sink/directional/west,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"nL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"oW" = (
+"lx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/powered/seedvault)
-"pi" = (
-/obj/machinery/light/directional/west,
-/obj/structure/hedge,
-/turf/open/floor/wood,
+"lB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter"
+	},
+/turf/open/floor/plating,
 /area/ruin/powered/seedvault)
-"pj" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
+"lZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/sand/volcanic,
+/obj/machinery/door/poddoor{
+	id = "bunkerexterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"mk" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"mo" = (
+/obj/machinery/door/poddoor{
+	id = "bunkerinterior"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"mp" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"ms" = (
+/obj/machinery/door/airlock/multi_tile/public/glass,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"nt" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"nA" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"nF" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"nK" = (
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"nP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"qe" = (
+"oo" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 8
+	},
+/area/ruin/powered/seedvault)
+"oG" = (
+/obj/effect/mob_spawn/ghost_role/human/seed_vault,
+/turf/open/floor/plating/kudzu,
+/area/ruin/powered/seedvault)
+"oI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"oJ" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"oP" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ps" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"pT" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
 	},
@@ -454,22 +560,530 @@
 /obj/item/food/grown/poppy/geranium,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"qY" = (
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark,
+"pU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"pY" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"qd" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"rd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"rw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"rR" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"rX" = (
+/obj/machinery/light/floor,
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 1
+	},
+/area/ruin/powered/seedvault)
+"so" = (
+/obj/structure/water_source/puddle{
+	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_structures.dmi';
+	base_icon_state = "water_basin";
+	icon_state = "water_basin";
+	name = "filled water basin"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"sw" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"rt" = (
+"sL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"ti" = (
+/obj/structure/sink/directional/east,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"tw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"tK" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"tQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"tS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"uH" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"uK" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"uM" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"uW" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ve" = (
+/obj/machinery/atmospherics/components/binary/volume_pump/on,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"vf" = (
+/obj/machinery/vending/hydroseeds{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"vg" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"vk" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"vn" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"vQ" = (
+/obj/structure/hedge,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"wl" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"wv" = (
+/obj/structure/flora/tree/jungle/style_3,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"wB" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"wH" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"rD" = (
-/obj/structure/flora/bush/grassy/style_random,
+"xk" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"xq" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"xr" = (
+/obj/machinery/vending/hydronutrients{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"xA" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"xJ" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"xQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/corner,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"xW" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"yt" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"yw" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/structure/loom,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"yA" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"yK" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"rL" = (
+"zd" = (
+/obj/machinery/computer/terminal{
+	dir = 8;
+	name = "Old Terminal";
+	desc = "A dusty, nonfunctioning terminal left by your creators. The screen is on but nothing you press does anything."
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zg" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zj" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"zx" = (
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Aa" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"AF" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"AG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"AV" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/chair/pew/left,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Bd" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"BF" = (
+/obj/machinery/vending/clothing{
+	all_products_free = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Co" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Cq" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Dr" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"DF" = (
+/obj/structure/closet/secure_closet/personal/wall{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"DY" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Ec" = (
+/obj/structure/table/wood,
+/obj/structure/towel_bin,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"Ex" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 8
+	},
+/area/ruin/powered/seedvault)
+"Fg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Fu" = (
+/obj/structure/flora/bush/sunny,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"FU" = (
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/machinery/biogenerator,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"Gl" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/gun/energy/floragun,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/geneshears,
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/light/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Go" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"GP" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Ha" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	name = "Server Vent"
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Hc" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"Hy" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"HW" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Is" = (
+/obj/structure/table/wood,
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/item/card/id/away/deep_storage{
+	name = "Seed Vault Access ID"
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Iu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Iv" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
@@ -498,901 +1112,160 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"sb" = (
-/obj/structure/closet/secure_closet/personal/wall{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+"IA" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"IZ" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/powered/seedvault)
-"sg" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"sm" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
+"Jj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"sr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"tj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"tp" = (
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"tQ" = (
-/obj/machinery/atmospherics/components/binary/volume_pump/on,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"ua" = (
-/obj/machinery/light/floor,
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner{
-	dir = 1
-	},
-/area/ruin/powered/seedvault)
-"uu" = (
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"uF" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 4
-	},
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"uK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"ve" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"vp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"vC" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"vH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+"Jv" = (
 /turf/closed/wall/r_wall,
 /area/ruin/powered/seedvault)
-"vU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"wp" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/mapping_helpers/airlock/access/all/away/general,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"wN" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"wP" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"wX" = (
-/obj/structure/closet/secure_closet/personal/wall{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"xa" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/gun/energy/floragun,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/geneshears,
-/obj/item/clothing/neck/stethoscope,
-/obj/machinery/light/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"xf" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"xg" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"xG" = (
+"JF" = (
 /obj/machinery/light/floor,
-/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"xO" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"xZ" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ye" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"yg" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"yC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"yL" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"yN" = (
-/obj/machinery/door/poddoor{
-	id = "bunkerinterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"zf" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"zg" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"zw" = (
-/obj/structure/flora/bush/grassy/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
+"Kl" = (
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"zE" = (
-/obj/effect/baseturf_helper/lava_land/surface,
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"zF" = (
-/obj/machinery/vending/hydronutrients{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"zN" = (
-/obj/machinery/door/window,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/obj/machinery/biogenerator,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/seedvault)
-"zQ" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"Kt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"As" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"BD" = (
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"BT" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Cj" = (
-/obj/structure/beebox,
-/obj/effect/turf_decal/siding/thinplating/dark/end,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Cm" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Cq" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"CC" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	name = "Server Vent"
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"CQ" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/melee/flyswatter,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/queen_bee/bought,
-/obj/item/bee_smoker,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"CX" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Dt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"DR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"DT" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/obj/machinery/autolathe,
-/obj/item/storage/toolbox/syndicate,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Ee" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Ei" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Eo" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Ew" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydroseeds,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/vending_refill/hydronutrients,
-/obj/item/soap/homemade,
-/obj/item/soap/homemade,
-/obj/item/soap/homemade,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"Ex" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"EE" = (
-/obj/structure/table/wood,
-/obj/structure/towel_bin,
+"KG" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"EI" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Fi" = (
-/obj/effect/mob_spawn/ghost_role/human/seed_vault,
-/turf/open/floor/plating/kudzu,
-/area/ruin/powered/seedvault)
-"Fs" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Gx" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"GE" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/survival_pod{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"Hs" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"Hw" = (
-/obj/machinery/door/airlock/multi_tile/public/glass,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"HP" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 9
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"HV" = (
-/obj/structure/sauna_oven,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/ruin/powered/seedvault)
-"Iq" = (
-/obj/structure/flora/bush/generic/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"ID" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"IN" = (
-/obj/machinery/vending/hydroseeds{
-	all_products_free = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Jk" = (
 /obj/structure/hedge,
 /turf/open/floor/wood,
 /area/ruin/powered/seedvault)
-"JC" = (
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Ke" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	name = "Server Vent"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Kf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"Kw" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
+"KK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"KD" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/corner{
-	dir = 8
-	},
-/area/ruin/powered/seedvault)
-"KL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"KZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"Ld" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"LF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"LI" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Mj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"Ni" = (
-/obj/structure/flora/tree/jungle/style_3,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"NU" = (
-/obj/structure/table/reinforced,
-/obj/machinery/plantgenes{
-	pixel_y = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"Ob" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Oq" = (
 /turf/open/floor/wood,
 /area/ruin/powered/seedvault)
-"OW" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
+"KY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5;
+	pixel_x = -3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"OY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Pd" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/item/construction/plumbing,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"Pw" = (
+"La" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"PM" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/effect/spawner/random/food_or_drink/seed_vault,
-/obj/machinery/light/directional/north,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/powered/seedvault)
-"PV" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wideplating_new/corner,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"QK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/sand/volcanic,
-/obj/machinery/door/poddoor{
-	id = "bunkerexterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"QL" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"QW" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"QX" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Rj" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Rm" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Sd" = (
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"Se" = (
-/obj/structure/table/wood,
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/item/card/id/away/deep_storage{
-	name = "Seed Vault Access ID"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Sq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/door/poddoor{
-	id = "bunkerinterior"
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"SB" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 8
-	},
-/area/ruin/powered/seedvault)
-"SH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"SO" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"SR" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"SS" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	name = "Server Vent"
-	},
-/turf/open/floor/iron/freezer,
-/area/ruin/powered/seedvault)
-"ST" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"Tk" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Tl" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"TL" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
-"TT" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"TW" = (
-/obj/machinery/computer/terminal{
-	dir = 8;
-	name = "Old Terminal";
-	desc = "A dusty, nonfunctioning terminal left by your creators. The screen is on but nothing you press does anything."
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"UD" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"UP" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"US" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"VE" = (
-/obj/structure/flora/bush/generic/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"VQ" = (
-/obj/structure/table/wood,
-/obj/machinery/light/directional/east,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"VR" = (
-/obj/effect/mist,
-/obj/effect/spawner/liquids_spawner/shoulders,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 4
-	},
-/area/ruin/powered/seedvault)
-"VW" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"WA" = (
+"Lh" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"WI" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe/ghost_cafe{
-	all_products_free = 1
+"LV" = (
+/obj/machinery/smartfridge,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/seedvault)
+"Md" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Mk" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"ME" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"MJ" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"MW" = (
+/obj/structure/closet/secure_closet/personal/wall{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"Og" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bunkershutter"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/seedvault)
+"Op" = (
+/obj/machinery/light/floor,
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/corner{
 	dir = 4
 	},
+/area/ruin/powered/seedvault)
+"OA" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
-"WU" = (
-/obj/machinery/vending/clothing{
-	all_products_free = 1
-	},
+"Pq" = (
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Pv" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
+	dir = 5
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/filled/warning{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"WZ" = (
+"Py" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/filled/warning/corner,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"PT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/west{
 	id = "bunkerinterior";
@@ -1416,18 +1289,207 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Xq" = (
+"Qj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"Qo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"Qp" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"QH" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"QQ" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"QW" = (
+/obj/structure/table/wood,
+/obj/machinery/light/directional/east,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Rf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"Rz" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"SX" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/ruin/powered/seedvault)
+"TA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
+"Ui" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Uk" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Uz" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"UP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"UW" = (
+/obj/effect/mist,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 4
+	},
+/area/ruin/powered/seedvault)
+"Vc" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Vk" = (
 /obj/machinery/light/floor,
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"XK" = (
+"Vp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/plantgenes{
+	pixel_y = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
+"Vy" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"VK" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"WU" = (
+/obj/structure/chair/pew,
+/turf/open/floor/wood/tile,
+/area/ruin/powered/seedvault)
+"WW" = (
+/obj/structure/sauna_oven,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/ruin/powered/seedvault)
+"Xm" = (
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/ruin/powered/seedvault)
+"Xr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/powered/seedvault)
+"Yi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light/directional/west{
+	pixel_y = -15
+	},
+/obj/machinery/mining_weather_monitor/directional/west,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Yu" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
+"YB" = (
 /obj/effect/mist,
 /obj/effect/spawner/liquids_spawner/shoulders,
 /turf/open/floor/iron/pool/cobble/corner,
 /area/ruin/powered/seedvault)
-"XZ" = (
+"Zq" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"Zx" = (
 /obj/machinery/door/airlock/vault,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -1438,753 +1500,692 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Ye" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Yu" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"YJ" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
+"ZB" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/autolathe,
+/obj/item/storage/toolbox/syndicate,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
-"Ze" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/ruin/powered/seedvault)
-"Zf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/ruin/powered/seedvault)
-"Zl" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"Zo" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/flatpacked_machine,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/mineral/silver{
-	amount = 25
-	},
-/obj/item/stack/sheet/mineral/titanium{
-	amount = 25
-	},
-/obj/item/stack/sheet/mineral/uranium/half{
-	amount = 20
-	},
-/obj/item/stack/sheet/mineral/plasma/thirty,
-/obj/item/stack/sheet/mineral/gold{
-	amount = 15
-	},
-/obj/item/stack/sheet/mineral/diamond{
-	amount = 25
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/catwalk_floor/iron_dark,
+"ZM" = (
+/obj/structure/sink/directional/west,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
 /area/ruin/powered/seedvault)
 
 (1,1,1) = {"
-zE
-SR
-SR
-SR
-SR
-BD
-SR
-SR
-BD
-SR
-SR
-SR
-SR
-SR
-SR
-BD
-BD
-BD
-SR
-SR
-SR
-SR
-SR
+zx
+Pq
+Pq
+Pq
+Pq
+cj
+Pq
+Pq
+cj
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+cj
+cj
+cj
+Pq
+Pq
+Pq
+Pq
+Pq
 "}
 (2,1,1) = {"
-SR
-SR
-SR
-SR
-BD
-BD
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-BD
-BD
+Pq
+Pq
+Pq
+Pq
+cj
+cj
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+cj
+cj
 "}
 (3,1,1) = {"
-BD
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-Sd
-Sd
-Sd
-Sd
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-BD
+cj
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Jv
+Jv
+Jv
+Jv
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+cj
 "}
 (4,1,1) = {"
-SR
-SR
-SR
-SR
-SR
-SR
-Sd
-Sd
-Sd
-Sd
-CX
-cH
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-BD
-SR
-BD
-BD
-BD
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Jv
+Jv
+Jv
+Jv
+rR
+Py
+Jv
+Jv
+Jv
+Jv
+Jv
+Jv
+cj
+Pq
+cj
+cj
+cj
 "}
 (5,1,1) = {"
-SR
-SR
-SR
-SR
-SR
-BD
-Sd
-WU
-Cq
-Sd
-es
-US
-yN
-wp
-ac
-fF
-XZ
-QK
-BD
-BD
-BD
-SR
-BD
+Pq
+Pq
+Pq
+Pq
+Pq
+cj
+Jv
+BF
+xq
+Jv
+iU
+Uk
+mo
+br
+Yi
+Jj
+Zx
+lZ
+cj
+cj
+cj
+Pq
+cj
 "}
 (6,1,1) = {"
-SR
-SR
-SR
-Sd
-Sd
-Sd
-Sd
-Se
-zg
-Sd
-yC
-US
-Sq
-me
-nm
-fb
-JC
-QK
-BD
-BD
-SR
-SR
-SR
+Pq
+Pq
+Pq
+Jv
+Jv
+Jv
+Jv
+Is
+uK
+Jv
+pU
+Uk
+dY
+Ui
+fW
+Iu
+Vc
+lZ
+cj
+cj
+Pq
+Pq
+Pq
 "}
 (7,1,1) = {"
-SR
-SR
-SR
-Sd
-Fi
-HP
-Sd
-WI
-cT
-Sd
-BT
-Cm
-Sd
-Sd
-cq
-bW
-Sd
-Sd
-Sd
-BD
-BD
-BD
-SR
+Pq
+Pq
+Pq
+Jv
+oG
+SX
+Jv
+jN
+vn
+Jv
+dR
+HW
+Jv
+Jv
+Og
+lB
+Jv
+Jv
+Jv
+cj
+cj
+cj
+Pq
 "}
 (8,1,1) = {"
-BD
-SR
-SR
-Sd
-Fi
-SS
-Hw
-dP
-hL
-Ei
-sm
-LI
-Sd
-WZ
-ep
-ep
-QX
-tQ
-LF
-ie
-BD
-BD
-BD
+cj
+Pq
+Pq
+Jv
+oG
+kw
+ms
+xA
+nP
+Hc
+Yu
+uH
+Jv
+PT
+ln
+ln
+Aa
+ve
+dZ
+dV
+cj
+cj
+cj
 "}
 (9,1,1) = {"
-BD
-SR
-SR
-Sd
-Fi
-gZ
-jn
-mV
-cm
-Xq
-hW
-sg
-tj
-SH
-OY
-uK
-nL
-xO
-Sd
-SR
-BD
-SR
-SR
+cj
+Pq
+Pq
+Jv
+oG
+MJ
+tw
+wl
+Rz
+Vk
+hG
+ps
+ME
+Fg
+tQ
+Kt
+cW
+aT
+Jv
+Pq
+cj
+Pq
+Pq
 "}
 (10,1,1) = {"
-SR
-SR
-SR
-Sd
-Fi
-aI
-Sd
-mV
-Iq
+Pq
+Pq
+Pq
+Jv
+oG
+Bd
+Jv
+wl
+kp
+Kl
+yK
+mp
+Jv
 QW
-wN
-Kw
-Sd
-VQ
-TW
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-SR
-SR
+zd
+Jv
+Jv
+Jv
+Jv
+Jv
+Jv
+Pq
+Pq
 "}
 (11,1,1) = {"
-SR
-SR
-SR
-Sd
-Sd
-Sd
-Sd
-mV
-dr
-rD
-ga
-Kw
-Sd
-Sd
-Sd
-Sd
-xg
-mW
-mW
-xg
-Sd
-Sd
-SR
+Pq
+Pq
+Pq
+Jv
+Jv
+Jv
+Jv
+wl
+uM
+ew
+lm
+mp
+Jv
+Jv
+Jv
+Jv
+ch
+La
+La
+ch
+Jv
+Jv
+Pq
 "}
 (12,1,1) = {"
-SR
-SR
-Sd
-Sd
-As
-xa
-Sd
-Ye
-Fs
-Ni
-Ob
-ID
-Sd
-lP
-mL
-iu
-xG
-Ee
-vC
-xZ
-jb
-Sd
-SR
+Pq
+Pq
+Jv
+Jv
+bO
+Gl
+Jv
+ii
+Uz
+wv
+IA
+UP
+Jv
+ct
+yA
+KY
+de
+jg
+eR
+ep
+Dr
+Jv
+Pq
 "}
 (13,1,1) = {"
-SR
-SR
-Sd
-Ew
-CC
-wP
-Sd
-mV
-fN
-Tl
-uu
-dg
-mX
-Ld
-eW
-DR
-zw
-nH
-rD
-UP
-Zl
-Sd
-SR
+Pq
+Pq
+Jv
+ic
+Ha
+pY
+Jv
+wl
+Fu
+fE
+nK
+fY
+hI
+tK
+aU
+AG
+Qp
+ZM
+ew
+oJ
+xW
+Jv
+Pq
 "}
 (14,1,1) = {"
-SR
-SR
-Sd
-PM
-qe
-Mj
-tp
-mV
-yg
-rD
-VE
-dg
-tp
-Mj
-dY
-dY
-ne
-aP
-eh
-zf
-Cj
-Sd
-SR
+Pq
+Pq
+Jv
+je
+pT
+oI
+nA
+wl
+nt
+ew
+Xm
+fY
+nA
+oI
+sL
+sL
+GP
+LV
+aR
+oP
+ab
+Jv
+Pq
 "}
 (15,1,1) = {"
-SR
-SR
-Sd
-dI
-ek
-QL
-Sd
-mV
-UD
-SO
-KL
-Kw
-zN
-KZ
-ye
-Ex
-WA
-ai
-QW
-qY
-Zl
-Sd
-SR
+Pq
+Pq
+Jv
+kG
+Pv
+VK
+Jv
+wl
+DY
+eh
+bX
+mp
+FU
+jW
+iE
+dB
+Lh
+ti
+Kl
+Mk
+xW
+Jv
+Pq
 "}
 (16,1,1) = {"
-SR
-SR
-Sd
-Sd
-CQ
-Zo
-Sd
-kZ
-zQ
-Eo
-OW
-bm
-Sd
-et
-NU
-np
-ve
-ST
-fD
-dq
-Zl
-Sd
-SR
+Pq
+Pq
+Jv
+Jv
+ef
+gN
+Jv
+Co
+fM
+eN
+eX
+mk
+Jv
+qd
+Vp
+gU
+uW
+sw
+Vy
+JF
+xW
+Jv
+Pq
 "}
 (17,1,1) = {"
-SR
-SR
-SR
-Sd
-Sd
-Sd
-Sd
-YJ
-Rj
-Sd
-GE
-Sd
-Sd
-Sd
-Sd
-oW
-pj
-xf
-xf
-xf
-Sd
-Sd
-SR
+Pq
+Pq
+Pq
+Jv
+Jv
+Jv
+Jv
+tS
+gQ
+Jv
+fK
+Jv
+Jv
+Jv
+Jv
+lx
+vk
+OA
+OA
+OA
+Jv
+Jv
+Pq
 "}
 (18,1,1) = {"
-SR
-SR
-SR
-Sd
-kM
-Ke
-rL
-Tk
-TT
-Sd
-vU
-EE
-dC
-HV
-jt
-Kf
-Zf
-Zf
-vH
-Sd
-Sd
-SR
-SR
+Pq
+Pq
+Pq
+Jv
+yw
+AF
+Iv
+zg
+QQ
+Jv
+Qj
+Ec
+so
+WW
+yt
+Qo
+bc
+bc
+Xr
+Jv
+Jv
+Pq
+Pq
 "}
 (19,1,1) = {"
-SR
-SR
-SR
-Sd
-EI
-bu
-bu
-bu
-Pd
-Sd
-wX
-ht
-ht
-Oq
-ht
-pi
-Jk
-Sd
-Yu
-BD
-BD
-BD
-SR
+Pq
+Pq
+Pq
+Jv
+xk
+ez
+ez
+ez
+QH
+Jv
+MW
+IZ
+IZ
+gJ
+IZ
+KG
+vQ
+Jv
+wB
+cj
+cj
+cj
+Pq
 "}
 (20,1,1) = {"
-BD
-SR
-SR
-Sd
-DT
-bu
-bu
-sr
-hO
-Sd
-wX
-Dt
-Dt
-PV
-uF
-TL
-uF
-Sd
-BD
-BD
-SR
-BD
-SR
+cj
+Pq
+Pq
+Jv
+ZB
+ez
+ez
+rd
+Md
+Jv
+MW
+KK
+KK
+xQ
+Go
+TA
+Go
+Jv
+cj
+cj
+Pq
+cj
+Pq
 "}
 (21,1,1) = {"
-BD
-BD
-SR
-Sd
-Rm
-gF
-my
-Pw
-yL
-Sd
-sb
-Oq
-vp
-Hs
-ua
-SB
-KD
-Sd
-SR
-SR
-SR
-BD
-BD
+cj
+cj
+Pq
+Jv
+xJ
+Zq
+zj
+vg
+Cq
+Jv
+DF
+gJ
+rw
+dj
+rX
+oo
+Ex
+Jv
+Pq
+Pq
+Pq
+cj
+cj
 "}
 (22,1,1) = {"
-BD
-SR
-SR
-Sd
-Sd
-Sd
-Sd
-IN
-zF
-Sd
-ms
-kg
-eV
-Hs
-XK
-VR
-cU
-Sd
-SR
-SR
-BD
-BD
-SR
+cj
+Pq
+Pq
+Jv
+Jv
+Jv
+Jv
+vf
+xr
+Jv
+AV
+Rf
+Hy
+dj
+YB
+UW
+Op
+Jv
+Pq
+Pq
+cj
+cj
+Pq
 "}
 (23,1,1) = {"
-SR
-SR
-SR
-SR
-SR
-SR
-Sd
-Sd
-Sd
-Sd
-mk
-rt
-VW
-Sd
-Sd
-Sd
-Sd
-Sd
-SR
-SR
-BD
-BD
-SR
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Jv
+Jv
+Jv
+Jv
+WU
+lj
+wH
+Jv
+Jv
+Jv
+Jv
+Jv
+Pq
+Pq
+cj
+cj
+Pq
 "}
 (24,1,1) = {"
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-Sd
-jc
-Gx
-Ze
-Sd
-SR
-SR
-SR
-BD
-SR
-SR
-SR
-SR
-SR
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Jv
+gH
+fa
+nF
+Jv
+Pq
+Pq
+Pq
+cj
+Pq
+Pq
+Pq
+Pq
+Pq
 "}
 (25,1,1) = {"
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-Sd
-Sd
-Sd
-Sd
-Sd
-SR
-SR
-SR
-SR
-SR
-BD
-SR
-SR
-SR
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Jv
+Jv
+Jv
+Jv
+Jv
+Pq
+Pq
+Pq
+Pq
+Pq
+cj
+Pq
+Pq
+Pq
 "}
 (26,1,1) = {"
-SR
-SR
-SR
-SR
-SR
-BD
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-BD
-SR
-SR
-SR
+Pq
+Pq
+Pq
+Pq
+Pq
+cj
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+cj
+Pq
+Pq
+Pq
 "}
 (27,1,1) = {"
-BD
-BD
-SR
-SR
-BD
-BD
-BD
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-BD
-BD
-BD
-BD
-SR
-SR
+cj
+cj
+Pq
+Pq
+cj
+cj
+cj
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+cj
+cj
+cj
+cj
+Pq
+Pq
 "}

--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -50,6 +50,14 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
+"cV" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/spacevine,
+/turf/open/floor/iron/terracotta/small,
+/area/ruin/powered/seedvault)
 "dc" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 5
@@ -63,9 +71,10 @@
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
 "dp" = (
-/obj/effect/spawner/liquids_spawner/shoulders,
-/obj/effect/mist,
-/turf/open/floor/iron/pool/cobble/side,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing,
+/turf/open/floor/wood/stairs/left,
 /area/ruin/powered/seedvault)
 "dv" = (
 /obj/structure/table/reinforced,
@@ -421,6 +430,14 @@
 	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
+"nS" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/structure/spacevine,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
 "nT" = (
 /obj/machinery/light/floor,
 /obj/effect/mist,
@@ -567,6 +584,11 @@
 	},
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
+"rm" = (
+/obj/effect/mob_spawn/ghost_role/human/seed_vault,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/kudzu,
+/area/ruin/powered/seedvault)
 "rn" = (
 /obj/structure/flora/bush/grassy/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -608,6 +630,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
+"sx" = (
+/obj/effect/spawner/liquids_spawner/shoulders,
+/obj/effect/mist,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 1
+	},
+/area/ruin/powered/seedvault)
 "sF" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -628,11 +657,6 @@
 	dir = 5
 	},
 /turf/open/floor/grass,
-/area/ruin/powered/seedvault)
-"tt" = (
-/obj/effect/mob_spawn/ghost_role/human/seed_vault,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating/kudzu,
 /area/ruin/powered/seedvault)
 "tA" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
@@ -655,10 +679,6 @@
 /area/ruin/powered/seedvault)
 "ur" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	invisibility = 100;
-	dir = 1
-	},
 /turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "uu" = (
@@ -731,6 +751,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
+"wu" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/powered/seedvault)
 "wH" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 9
@@ -741,8 +769,9 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/seedvault)
 "wN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/obj/effect/mist,
+/turf/open/floor/iron/pool/cobble,
 /area/ruin/powered/seedvault)
 "wS" = (
 /obj/structure/fans/tiny,
@@ -972,10 +1001,6 @@
 /obj/structure/table/wood,
 /obj/structure/towel_bin,
 /obj/machinery/light/directional/west,
-/obj/structure/railing{
-	invisibility = 100;
-	dir = 1
-	},
 /turf/open/floor/wood/large,
 /area/ruin/powered/seedvault)
 "GY" = (
@@ -987,13 +1012,6 @@
 	},
 /obj/structure/drain,
 /turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
-"Hj" = (
-/obj/effect/spawner/liquids_spawner/shoulders,
-/obj/effect/mist,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 1
-	},
 /area/ruin/powered/seedvault)
 "HB" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1096,14 +1114,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/ruin/powered/seedvault)
-"Kh" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 4
-	},
-/obj/structure/spacevine,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
 "Ks" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1147,13 +1157,6 @@
 "Lk" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
-"LH" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new,
-/turf/open/floor/iron/terracotta/herringbone,
-/area/ruin/powered/seedvault)
 "LI" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1172,13 +1175,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
-"Ma" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/contraband/kudzu/directional/north,
-/turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "MZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1201,14 +1197,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
-"Nm" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/structure/spacevine,
-/turf/open/floor/iron/terracotta/small,
-/area/ruin/powered/seedvault)
 "Nr" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/east,
@@ -1217,15 +1205,6 @@
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/seedvault)
-"Nu" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spacevine,
-/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "NH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1258,6 +1237,12 @@
 /obj/effect/spawner/random/food_or_drink/seed_vault,
 /obj/machinery/light/directional/north,
 /turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/powered/seedvault)
+"Oh" = (
+/obj/effect/turf_decal/trimline/dark_green/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "Op" = (
 /obj/machinery/smartfridge,
@@ -1355,14 +1340,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
-"Qw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/dark_green/filled/line{
-	dir = 8
-	},
-/obj/structure/spacevine,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/seedvault)
 "QS" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -1427,10 +1404,12 @@
 /obj/structure/chair/pew/left,
 /turf/open/floor/wood/tile,
 /area/ruin/powered/seedvault)
-"Sq" = (
-/obj/effect/spawner/liquids_spawner/shoulders,
-/obj/effect/mist,
-/turf/open/floor/iron/pool/cobble,
+"Sk" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/contraband/kudzu/directional/north,
+/turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "Tb" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1479,6 +1458,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
+"TU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new,
+/turf/open/floor/iron/terracotta/herringbone,
+/area/ruin/powered/seedvault)
 "TV" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1502,6 +1488,15 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
+/area/ruin/powered/seedvault)
+"UE" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/trimline/dark_green/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "UI" = (
 /obj/structure/disposalpipe/segment{
@@ -1540,9 +1535,9 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/powered/seedvault)
 "WL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/stairs/left,
+/obj/effect/spawner/liquids_spawner/shoulders,
+/obj/effect/mist,
+/turf/open/floor/iron/pool/cobble/side,
 /area/ruin/powered/seedvault)
 "WM" = (
 /obj/machinery/atmospherics/components/tank/air{
@@ -1613,12 +1608,6 @@
 /turf/open/floor/iron/pool/cobble/side{
 	dir = 8
 	},
-/area/ruin/powered/seedvault)
-"Yv" = (
-/obj/effect/turf_decal/trimline/dark_green/filled/warning,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/rubble,
-/turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)
 "YI" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -1783,7 +1772,7 @@ OZ
 pY
 Sa
 oZ
-Yv
+Oh
 jO
 qw
 RG
@@ -1876,14 +1865,14 @@ HR
 HR
 HR
 Sa
-tt
+rm
 dc
 Sa
 Qg
 pv
 PR
 jJ
-Nm
+cV
 Sa
 Nr
 eg
@@ -1913,8 +1902,8 @@ Sa
 Sa
 Sa
 Sa
-Qw
-Nu
+nS
+UE
 uB
 iJ
 Sa
@@ -2004,7 +1993,7 @@ HQ
 Zc
 lO
 Sa
-Ma
+Sk
 TV
 LM
 vQ
@@ -2066,7 +2055,7 @@ UI
 LV
 kB
 kB
-Kh
+wu
 Sa
 Sa
 HR
@@ -2082,7 +2071,7 @@ XT
 uX
 ve
 Sa
-WL
+dp
 GB
 GY
 uD
@@ -2107,11 +2096,11 @@ Lk
 Lk
 Ks
 Sa
-WL
+dp
 ur
-wN
+ur
 yN
-wN
+ur
 VR
 Da
 Sa
@@ -2186,9 +2175,9 @@ Sd
 Jq
 FS
 fG
-Hj
-Sq
-dp
+sx
+wN
+WL
 Sa
 HR
 HR
@@ -2210,7 +2199,7 @@ Sa
 dw
 dn
 PY
-LH
+TU
 FP
 rs
 lF

--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -172,11 +172,9 @@
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/powered/seedvault)
 "fC" = (
-/obj/machinery/door/window,
-/obj/machinery/door/window{
-	dir = 1
-	},
 /obj/machinery/biogenerator,
+/obj/machinery/door/window/left/directional,
+/obj/machinery/door/window/left/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "fE" = (

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -26,7 +26,7 @@
 	mutanteyes = /obj/item/organ/eyes/pod
 	mutantheart = /obj/item/organ/heart/pod
 	mutantliver = /obj/item/organ/liver/pod
-	mutantlungs = /obj/item/organ/lungs/pod
+	mutantlungs = /obj/item/organ/lungs/lavaland
 	mutantstomach = /obj/item/organ/stomach/pod
 	mutanttongue = /obj/item/organ/tongue/pod
 

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -26,7 +26,7 @@
 	mutanteyes = /obj/item/organ/eyes/pod
 	mutantheart = /obj/item/organ/heart/pod
 	mutantliver = /obj/item/organ/liver/pod
-	mutantlungs = /obj/item/organ/lungs/lavaland
+	mutantlungs = /obj/item/organ/lungs/lavaland // splurt edit PR 377
 	mutantstomach = /obj/item/organ/stomach/pod
 	mutanttongue = /obj/item/organ/tongue/pod
 

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -161,7 +161,7 @@
 	spawner_job_path = /datum/job/lifebringer
 	restricted_species = list(/datum/species/pod) //SKYRAT EDIT ADDITION
 	random_appearance = FALSE // SKYRAT EDIT ADDITION
-	quirks_enabled = TRUE
+	quirks_enabled = TRUE // splurt edit PR 377
 
 /obj/effect/mob_spawn/ghost_role/human/seed_vault/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -161,6 +161,7 @@
 	spawner_job_path = /datum/job/lifebringer
 	restricted_species = list(/datum/species/pod) //SKYRAT EDIT ADDITION
 	random_appearance = FALSE // SKYRAT EDIT ADDITION
+	quirks_enabled = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/seed_vault/Initialize(mapload)
 	. = ..()

--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -11,7 +11,8 @@
 
 ##RESPAWN
 #_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
-#_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_seed_vault_bubber.dmm
+_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_seed_vault_bubber.dmm
+#_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
 _maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
 #modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm
 #_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_ash_walker1_skyrat.dmm

--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -11,7 +11,7 @@
 
 ##RESPAWN
 #_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
-_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_seed_vault_bubber.dmm
+#_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_seed_vault_bubber.dmm
 #_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
 _maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
 #modular_skyrat/modules/mapping/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1_skyrat.dmm

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -19,6 +19,7 @@
 	name = "Podperson"
 	id = SPECIES_PODPERSON_WEAK
 	examine_limb_id = SPECIES_PODPERSON
+	mutantlungs = /obj/item/organ/lungs/pod
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -19,7 +19,7 @@
 	name = "Podperson"
 	id = SPECIES_PODPERSON_WEAK
 	examine_limb_id = SPECIES_PODPERSON
-	mutantlungs = /obj/item/organ/lungs/pod
+	mutantlungs = /obj/item/organ/lungs/pod // splurt edit PR 377
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,

--- a/modular_zzplurt/maps/offstation/seedvault.dm
+++ b/modular_zzplurt/maps/offstation/seedvault.dm
@@ -1,0 +1,5 @@
+/datum/map_template/ruin/lavaland/seed_vault
+	suffix = "lavaland_surface_seed_vault_splurt.dmm"
+	prefix = "_maps/RandomRuins/LavaRuins/zzplurt/"
+	cost = 3
+	always_place = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10208,4 +10208,5 @@
 #include "modular_zzplurt\code\modules\vending\multisec.dm"
 #include "modular_zzplurt\code\modules\vending\vending.dm"
 #include "modular_zzplurt\code\modules\wiremod\core\integrated_circuit.dm"
+#include "modular_zzplurt\maps\offstation\seedvault.dm"
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request

The current seedvault sucks, even after someone refreshed it. I've come with a full remap, dusting off this ancient map into something actually pleasant to the eyes. 
Additionally, allows _only_ Primal Podpeople to breath on lavaland. What's the point of terraforming if they can't even breath? 

## Why It's Good For The Game

Lavaland podpeople are still lackluster, yet another improvement will do better.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/9c6f3a7d-be19-44e4-9881-99bdad136f15)


</details>

## Changelog

:cl:
add: New Seedvault Map
fix: Primal Podpeople can breath on lavaland
/:cl: