### PR TITLE
Engi, CE, Atmos wintercoat back items allowed on tailcoats. (copy)

### DIFF
--- a/modular_zzplurt/code/modules/clothing/suits/jackets.dm
+++ b/modular_zzplurt/code/modules/clothing/suits/jackets.dm
@@ -48,3 +48,43 @@
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	toggle_noun = "buttons"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
+/obj/item/clothing/suit/jacket/tailcoat/engineer/Initialize(mapload)
+	. = ..()
+	allowed += list(
+		/obj/item/analyzer,
+		/obj/item/construction/rcd,
+		/obj/item/pipe_dispenser,
+		/obj/item/construction/rld,
+		/obj/item/construction/rtd,
+		/obj/item/gun/ballistic/rifle/rebarxbow,
+		/obj/item/storage/bag/rebar_quiver,
+		/obj/item/storage/bag/construction,
+	)
+
+/obj/item/clothing/suit/utility/fire/atmos_tech_tailcoat/Initialize(mapload)
+	. = ..()
+	allowed += list(
+		/obj/item/analyzer,
+		/obj/item/construction/rcd,
+		/obj/item/pipe_dispenser,
+		/obj/item/construction/rld,
+		/obj/item/construction/rtd,
+		/obj/item/gun/ballistic/rifle/rebarxbow,
+		/obj/item/storage/bag/rebar_quiver,
+		/obj/item/storage/bag/construction,
+	)
+
+/obj/item/clothing/suit/utility/fire/ce_tailcoat/Initialize(mapload)
+	. = ..()
+	allowed += list(
+		/obj/item/analyzer,
+		/obj/item/construction/rcd,
+		/obj/item/pipe_dispenser,
+		/obj/item/construction/rld,
+		/obj/item/construction/rtd,
+		/obj/item/gun/ballistic/rifle/rebarxbow,
+		/obj/item/storage/bag/rebar_quiver,
+		/obj/item/storage/bag/construction,
+		/obj/item/melee/baton/telescopic,
+	)


### PR DESCRIPTION
## About The Pull Request

_Copy of #371, edited the main brach so made a new PR to fix it._

Adds the allowed items on the Engineer, Atmos and CE winter coats to their respective tailcoats
## Why It's Good For The Game

Lets you use the full bunnysuit outfit without having to cover them with a winter coat, just because a tailcoat won't hold the items you need for your job (RCD, RPD, etc...).
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![engineer](https://github.com/user-attachments/assets/6c10e3af-c524-46f6-b7c9-8f92618a88da)

![atmos tech](https://github.com/user-attachments/assets/9106a075-64e7-4ef5-9afe-012788cde045)

![ce](https://github.com/user-attachments/assets/965602e6-6803-47b7-8d20-0b76a0dfa12c)


</details>

## Changelog
:cl: myraowo
fix: Engineering, CE and Atmos winter coat back items are now allowed on tailcoats
/:cl:
