### PR TITLE
Makes Freon a purchaseable gas and Tritium not.

### DIFF
--- a/modular_zzplurt/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/modular_zzplurt/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -1,0 +1,5 @@
+/datum/gas/tritium
+	purchaseable = FALSE
+
+/datum/gas/freon
+	purchaseable = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9877,6 +9877,7 @@
 #include "modular_zzplurt\code\modules\asset_cache\assets\emojipedia.dm"
 #include "modular_zzplurt\code\modules\asset_cache\assets\inventory.dm"
 #include "modular_zzplurt\code\modules\asset_cache\assets\tgui.dm"
+#include "modular_zzplurt\code\modules\atmospherics\gasmixtures\gas_types.dm"
 #include "modular_zzplurt\code\modules\atmospherics\machinery\portable\canister.dm"
 #include "modular_zzplurt\code\modules\barks\bark_list.dm"
 #include "modular_zzplurt\code\modules\blueshield\code\closet.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Tritium canister from being purchaseable from cargo, and replaces it with a Freon one.

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

The reason for this PR is split between two departments:

For engineering, Tritium is a rarely utilized and easily made gas in general, it can be scrubbed out in good quantities from a tritium turbine setup, or be mass produced by the average atmos tech. While its main uses are for synthesizing Hyper-Noblium (which is useful for beefy cooling systems) and running the HFR.
While on the other hand, Freon is a really useful gas, having a higher heat capacity than plasma, however being much time-consuming to make, due to it needing the synthesis of another gas (BZ) for its production. And as such would benefit from being easier to acquire, letting an engineer build a good internal cooling setup (using Freon instead of Plasma) for the supermatter minutes after round-start, for example. 

For science, Freon won't have any major impacts for the department, when Tritium just feels like a major crutch, since having high quantities of it will just give you a ton of good TTVs, while making the toxin's burn chamber almost useless.


But I could always just change it so both are purchasable at cargo, if that ends up being the best course of action.

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

![freon](https://github.com/user-attachments/assets/ee34736f-1d68-4da9-aae2-0c13f6926fee)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: myraowo
add: Added Freon as a purchaseable gas from cargo
del: Removed Tritium as a purchaseable gas from cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
