### PR TITLE
Reverts Primal Podpeople Lung Change

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -26,7 +26,7 @@
 	mutanteyes = /obj/item/organ/eyes/pod
 	mutantheart = /obj/item/organ/heart/pod
 	mutantliver = /obj/item/organ/liver/pod
-	mutantlungs = /obj/item/organ/lungs/lavaland // splurt edit PR 377
+	mutantlungs = /obj/item/organ/lungs/pod
 	mutantstomach = /obj/item/organ/stomach/pod
 	mutanttongue = /obj/item/organ/tongue/pod
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -19,7 +19,6 @@
 	name = "Podperson"
 	id = SPECIES_PODPERSON_WEAK
 	examine_limb_id = SPECIES_PODPERSON
-	mutantlungs = /obj/item/organ/lungs/pod // splurt edit PR 377
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,


### PR DESCRIPTION
## About The Pull Request

oops! turns out that with random lavaland airmix, it's a gamble whether or not you can even breath in the seedvault.

## Changelog

:cl:
fix: reverts primal podpeople lung change
/:cl: