### PR TITLE
[ADMIN] Player Panel improvements and runtime fixes | Added Admin Ticket Statistics Panel 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,11 @@ Temporary Items
 
 #Visual studio stuff
 *.vscode/*
+
+# Cursor stuff
+*.cursor/*
+.cursorrules
+
 /tools/MapAtmosFixer/MapAtmosFixer/obj/*
 /tools/MapAtmosFixer/MapAtmosFixer/bin/*
 /tools/CreditsTool/bin/*

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -170,9 +170,11 @@ SUBSYSTEM_DEF(player_ranks)
 	)
 
 	if(!query_load_player_rank.warn_execute())
+		qdel(query_load_player_rank) // SPLURT EDIT - Fix SQL qdel
 		return
 
 	rank_controller.load_from_query(query_load_player_rank)
+	qdel(query_load_player_rank) // SPLURT EDIT - Fix SQL qdel
 
 
 /// Allows fetching the appropriate player_rank_controller based on its
@@ -278,8 +280,10 @@ SUBSYSTEM_DEF(player_ranks)
 	)
 
 	if(!query_add_player_rank.warn_execute())
+		qdel(query_add_player_rank) // SPLURT EDIT - Fix SQL qdel
 		return FALSE
 
+	qdel(query_add_player_rank) // SPLURT EDIT - Fix SQL qdel
 	controller.add_player(ckey)
 	return TRUE
 
@@ -357,8 +361,10 @@ SUBSYSTEM_DEF(player_ranks)
 	)
 
 	if(!query_remove_player_rank.warn_execute())
+		qdel(query_remove_player_rank) // SPLURT EDIT - Fix SQL qdel
 		return FALSE
 
+	qdel(query_remove_player_rank) // SPLURT EDIT - Fix SQL qdel
 	controller.remove_player(ckey)
 	return TRUE
 
@@ -413,11 +419,14 @@ SUBSYSTEM_DEF(player_ranks)
 	)
 
 	if(!query_get_existing_entries.warn_execute())
+		qdel(query_get_existing_entries) // SPLURT EDIT - Fix SQL qdel
 		return
 
 	while(query_get_existing_entries.NextRow())
 		var/ckey = ckey(query_get_existing_entries.item[INDEX_CKEY])
 		ckeys_to_migrate -= ckey
+
+	qdel(query_get_existing_entries) // SPLURT EDIT - Fix SQL qdel
 
 	var/list/rows_to_insert = list()
 

--- a/modular_zzplurt/code/controllers/subsystem/maturity.dm
+++ b/modular_zzplurt/code/controllers/subsystem/maturity.dm
@@ -125,12 +125,16 @@ SUBSYSTEM_DEF(maturity_guard)
 	)
 
 	if(!query_age_from_db.warn_execute())
+		qdel(query_age_from_db)
 		return FALSE
 
 	// There should be only one, we're querying by the primary key; if it returns more than one row something is very wrong
 	var/result = query_age_from_db.NextRow()
 	if(result)
-		return query_age_from_db.item
+		var/age_data = query_age_from_db.item
+		qdel(query_age_from_db)
+		return age_data
+	qdel(query_age_from_db)
 	return FALSE
 
 
@@ -159,8 +163,10 @@ SUBSYSTEM_DEF(maturity_guard)
 	)
 
 	if(!add_age_to_db.warn_execute())
+		qdel(add_age_to_db)
 		return FALSE
 
+	qdel(add_age_to_db)
 	return TRUE
 
 // Logic inspired by S.P.L.U.R.T age_gate //Oh really? How kind!

--- a/modular_zzplurt/code/modules/admin/admin_ticket_stats_panel.dm
+++ b/modular_zzplurt/code/modules/admin/admin_ticket_stats_panel.dm
@@ -1,0 +1,239 @@
+/datum/ticket_stats
+	var/client/admin_client
+	var/list/last_query_result = list()
+	var/last_error_message = ""
+	var/is_loading = FALSE
+
+/datum/ticket_stats/New(client/admin)
+	. = ..()
+	admin_client = admin
+
+/datum/ticket_stats/Destroy(force, ...)
+	admin_client = null
+	SStgui.close_uis(src)
+	return ..()
+
+/datum/ticket_stats/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if (!ui)
+		ui = new(user, src, "AdminTicketStats", "Admin Ticket Statistics")
+		ui.open()
+
+/datum/ticket_stats/ui_state(mob/user)
+	return ADMIN_STATE(R_ADMIN)
+
+/datum/ticket_stats/ui_static_data(mob/user)
+	. = list()
+
+	var/current_time = world.timeofday
+	var/current_year = text2num(time2text(current_time, "YYYY"))
+	var/current_month = text2num(time2text(current_time, "MM"))
+
+	.["current_year"] = current_year
+	.["current_month"] = current_month
+	.["current_date"] = time2text(current_time, "YYYY-MM-DD")
+
+	var/month_start = "[current_year]-[add_leading(num2text(current_month), 2, "0")]-01"
+	var/days_in_month = 31
+	if(current_month == 2)
+		days_in_month = (current_year % 4 == 0) ? 29 : 28
+	else if(current_month == 4 || current_month == 6 || current_month == 9 || current_month == 11)
+		days_in_month = 30
+	var/month_end = "[current_year]-[add_leading(num2text(current_month), 2, "0")]-[add_leading(num2text(days_in_month), 2, "0")]"
+
+	.["default_start_date"] = month_start
+	.["default_end_date"] = month_end
+
+	.["available_columns"] = list(
+		list("key" = "Total_tickets", "name" = "Total Tickets"),
+		list("key" = "Ticket_replies", "name" = "Ticket Replies"),
+		list("key" = "Rejected_count", "name" = "Rejected"),
+		list("key" = "Resolved_count", "name" = "Resolved"),
+		list("key" = "Closed_count", "name" = "Closed"),
+		list("key" = "IC_Issue_count", "name" = "IC Issues"),
+		list("key" = "Interaction_count", "name" = "Interaction")
+	)
+
+	.["grouping_options"] = list(
+		list("key" = "none", "name" = "No Grouping"),
+		list("key" = "day", "name" = "By Day"),
+		list("key" = "month", "name" = "By Month")
+	)
+
+	var/list/admin_list = list()
+	if(SSdbcore.IsConnected())
+		var/datum/db_query/admin_query = SSdbcore.NewQuery("SELECT DISTINCT ckey FROM admin WHERE rank != 'NEW ADMIN' ORDER BY ckey")
+		if(admin_query.warn_execute())
+			while(admin_query.NextRow())
+				admin_list += admin_query.item[1]
+		qdel(admin_query)
+	.["admin_list"] = admin_list
+
+/datum/ticket_stats/ui_data(mob/user)
+	. = list()
+	.["loading"] = is_loading
+	.["stats_data"] = last_query_result
+	.["error_message"] = last_error_message
+
+/datum/ticket_stats/ui_act(action, params, datum/tgui/ui)
+	. = ..()
+	if(.)
+		return
+
+	var/client/admin_client = usr?.client
+	if(!check_rights_for(admin_client, R_ADMIN))
+		return
+
+	switch(action)
+		if("fetch_stats")
+			if(is_loading)
+				return TRUE
+
+			is_loading = TRUE
+			SStgui.update_uis(src)
+
+			log_admin("[admin_client.ckey] requested ticket stats with params: [json_encode(params)]")
+			var/result = fetch_ticket_statistics(params)
+
+			is_loading = FALSE
+			if(result["error"])
+				last_error_message = result["error"]
+				last_query_result = list()
+				log_admin("Ticket stats error: [result["error"]]")
+			else if(result["success"])
+				last_query_result = result["data"] || list()
+				last_error_message = ""
+				log_admin("Ticket stats success: [length(result["data"])] rows returned")
+			SStgui.update_uis(src)
+			return TRUE
+
+/datum/ticket_stats/proc/fetch_ticket_statistics(list/params)
+	if(!SSdbcore.IsConnected())
+		return list("error" = "Database not connected")
+
+	var/start_date = params["start_date"] || ""
+	var/end_date = params["end_date"] || ""
+	var/admin_filter = params["admin_filter"] || params["admin_name"] || ""
+	var/grouping = params["grouping"] || "none"
+	var/list/selected_columns = params["selected_columns"] || params["columns"] || list()
+	var/sort_column = params["sort_column"] || "admin_name"
+	var/sort_order = params["sort_order"] || "ASC"
+
+	if(!start_date || !end_date)
+		return list("error" = "Start and end dates are required")
+
+	return generate_report(start_date, end_date, admin_filter, grouping, selected_columns, sort_column, sort_order)
+
+/datum/ticket_stats/proc/generate_report(start_date, end_date, admin_filter = "", grouping = "none", selected_columns = list(), sort_column = "admin_name", sort_order = "ASC")
+	if(length(start_date) <= 10)
+		start_date += " 00:00:00"
+	if(length(end_date) <= 10)
+		end_date += " 23:59:59"
+
+	var/list/column_clauses = list()
+	var/date_condition = "timestamp BETWEEN '[start_date]' AND '[end_date]'"
+
+	if(grouping == "none")
+		for(var/column in selected_columns)
+			switch(column)
+				if("Total_tickets")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action IN ('Rejected', 'Resolved', 'Closed', 'IC Issue') AND [date_condition]) AS Total_tickets"
+				if("Ticket_replies")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Reply' AND [date_condition]) AS Ticket_replies"
+				if("Rejected_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Rejected' AND [date_condition]) AS Rejected_count"
+				if("Resolved_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Resolved' AND [date_condition]) AS Resolved_count"
+				if("Closed_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Closed' AND [date_condition]) AS Closed_count"
+				if("IC_Issue_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'IC Issue' AND [date_condition]) AS IC_Issue_count"
+				if("Interaction_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Interaction' AND [date_condition]) AS Interaction_count"
+	else
+		var/period_field = ""
+		switch(grouping)
+			if("day")
+				period_field = "DATE(ticket.timestamp)"
+			if("month")
+				period_field = "DATE_FORMAT(ticket.timestamp, '%Y-%m')"
+
+		for(var/column in selected_columns)
+			switch(column)
+				if("Total_tickets")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action IN ('Rejected', 'Resolved', 'Closed', 'IC Issue') AND [date_condition] AND [period_field] = periods.period_group) AS Total_tickets"
+				if("Ticket_replies")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Reply' AND [date_condition] AND [period_field] = periods.period_group) AS Ticket_replies"
+				if("Rejected_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Rejected' AND [date_condition] AND [period_field] = periods.period_group) AS Rejected_count"
+				if("Resolved_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Resolved' AND [date_condition] AND [period_field] = periods.period_group) AS Resolved_count"
+				if("Closed_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Closed' AND [date_condition] AND [period_field] = periods.period_group) AS Closed_count"
+				if("IC_Issue_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'IC Issue' AND [date_condition] AND [period_field] = periods.period_group) AS IC_Issue_count"
+				if("Interaction_count")
+					column_clauses += "(SELECT COUNT(*) FROM ticket WHERE CAST(sender AS CHAR) = CAST(admin.ckey AS CHAR) AND action = 'Interaction' AND [date_condition] AND [period_field] = periods.period_group) AS Interaction_count"
+
+	if(!length(column_clauses))
+		return list("error" = "No columns selected")
+
+	var/main_query = ""
+	if(grouping == "none")
+		main_query = "SELECT admin.ckey AS admin_name, admin.rank AS admin_rank, " + jointext(column_clauses, ", ")
+		main_query += " FROM admin WHERE admin.rank != 'NEW ADMIN'"
+	else
+		var/period_query = ""
+		switch(grouping)
+			if("day")
+				period_query = "SELECT DISTINCT DATE(timestamp) AS period_group FROM ticket WHERE [date_condition] ORDER BY period_group"
+			if("month")
+				period_query = "SELECT DISTINCT DATE_FORMAT(timestamp, '%Y-%m') AS period_group FROM ticket WHERE [date_condition] ORDER BY period_group"
+
+		main_query = "SELECT periods.period_group, admin.ckey AS admin_name, admin.rank AS admin_rank, " + jointext(column_clauses, ", ")
+		main_query += " FROM admin CROSS JOIN ([period_query]) AS periods"
+		main_query += " WHERE admin.rank != 'NEW ADMIN'"
+
+	if(admin_filter && admin_filter != "")
+		main_query += " AND admin.ckey LIKE '%[admin_filter]%'"
+
+	if(grouping != "none")
+		main_query += " ORDER BY period_group ASC, admin_name ASC"
+	else
+		main_query += " ORDER BY admin_name ASC"
+
+	var/datum/db_query/query = SSdbcore.NewQuery(main_query)
+
+	if(!query.warn_execute())
+		qdel(query)
+		return list("error" = "Database query failed: [query.ErrorMsg()]")
+
+	var/list/results = list()
+	while(query.NextRow())
+		var/list/row = list()
+		var/column_index = 1
+
+		if(grouping != "none")
+			row["period_group"] = query.item[column_index++]
+
+		row["admin_name"] = query.item[column_index++]
+		row["admin_rank"] = query.item[column_index++]
+
+		var/has_tickets = FALSE
+		for(var/column in selected_columns)
+			var/raw_value = query.item[column_index++]
+			var/numeric_value = text2num("[raw_value]") || 0
+			row[column] = numeric_value
+			if(numeric_value > 0)
+				has_tickets = TRUE
+
+		if(has_tickets)
+			results += list(row)
+
+	qdel(query)
+	return list("success" = TRUE, "data" = results, "grouping" = grouping)
+
+ADMIN_VERB(show_admin_ticket_stats, R_ADMIN, "Show Admin tickets Stats", "View statistics for admin ticket handling", ADMIN_CATEGORY_MAIN)
+	var/datum/ticket_stats/stats = new(user)
+	stats.ui_interact(user.mob)
+	BLACKBOX_LOG_ADMIN_VERB("Show Admin Ticket Stats")

--- a/modular_zzplurt/code/modules/admin/player_panel.dm
+++ b/modular_zzplurt/code/modules/admin/player_panel.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 /datum/player_panel
 	var/mob/targetMob
 	var/client/targetClient
+	var/discord_id_cache = null
 
 /datum/player_panel/New(mob/target)
 	. = ..()
@@ -29,6 +30,45 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 
 	SStgui.close_uis(src)
 	return ..()
+
+/datum/player_panel/proc/get_target_ckey()
+	if(targetMob.client)
+		return targetMob.client.ckey
+	if(targetMob.ckey)
+		if(copytext(targetMob.ckey, 1, 2) == "@")
+			var/result = copytext(targetMob.ckey, 2)
+			return result
+		else
+			return targetMob.ckey
+	return null
+
+/datum/player_panel/proc/load_discord_id()
+	if(!targetMob)
+		return
+
+	var/target_ckey = get_target_ckey()
+	if(!target_ckey)
+		discord_id_cache = "No ckey found"
+		return
+
+	var/datum/db_query/discord_query = SSdbcore.NewQuery(
+		"SELECT discord_id FROM [format_table_name("discord_links")] WHERE ckey = :ckey",
+		list("ckey" = target_ckey)
+	)
+	if(discord_query.warn_execute())
+		if(discord_query.NextRow())
+			discord_id_cache = discord_query.item[1]
+		else
+			discord_id_cache = "Not found"
+	else
+		discord_id_cache = "Database error"
+	qdel(discord_query)
+
+/datum/player_panel/proc/update_after_transform(mob/admin_user)
+	if(!targetMob || !admin_user)
+		return
+	// Force update the UI data after transformation
+	SStgui.update_uis(src)
 
 /datum/player_panel/ui_interact(mob/user, datum/tgui/ui)
 	if(!targetMob)
@@ -44,36 +84,75 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 
 /datum/player_panel/ui_data(mob/user)
 	. = list()
+
+	if(!targetMob)
+		return .
+
 	.["mob_name"] = targetMob.real_name
 	.["mob_type"] = targetMob.type
 	.["admin_mob_type"] = user.client?.mob.type
-	.["godmode"] = HAS_TRAIT(user, TRAIT_GODMODE)
+	.["godmode"] = HAS_TRAIT(targetMob, TRAIT_GODMODE)
 
 	var/mob/living/L = targetMob
 	if (istype(L))
 		.["is_frozen"] = L.admin_frozen
 		.["is_slept"] = L.admin_sleeping
 		.["mob_scale"] = L.current_size
+		.["mob_speed"] = L.cached_multiplicative_slowdown
+		.["mob_status_flags"] = L.status_flags
+		if(islist(L.faction))
+			.["current_faction"] = L.faction
+		else if(L.faction)
+			.["current_faction"] = list(L.faction)
+		else
+			.["current_faction"] = list()
 
 	if(targetMob.client)
 		targetClient = targetMob.client
 		.["client_ckey"] = targetClient.ckey
 		.["client_muted"] = targetClient.prefs.muted
 		.["client_rank"] = targetClient.holder ? targetClient.holder.ranks : "Player"
+		.["discord_id"] = discord_id_cache
 	else
 		targetClient = null
 		.["client_ckey"] = null
+		.["discord_id"] = discord_id_cache
 
 		if (targetMob.ckey)
-			.["last_ckey"] = copytext(targetMob.ckey, 2)
+			.["last_ckey"] = get_target_ckey()
 
 /datum/player_panel/ui_static_data(mob/user)
 	. = list()
+
+	if(!targetMob)
+		return .
 
 	.["transformables"] = GLOB.pp_transformables
 	.["glob_limbs"] = GLOB.pp_limbs
 	.["glob_mute_bits"] = GLOB.mute_bits
 	.["current_time"] = time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")
+
+	// Status flags
+	.["glob_status_flags"] = list(
+		"Stun" = CANSTUN,
+		"Knockdown" = CANKNOCKDOWN,
+		"Unconscious" = CANUNCONSCIOUS,
+		"Push" = CANPUSH,
+		"Godmode" = "godmode" // Special string for godmode trait
+	)
+
+	// Factions list
+	.["glob_factions"] = list(
+		"None",
+		"neutral",
+		"crew",
+		"hostile",
+		"mining",
+		"pirate",
+		"spider",
+		"wizard",
+		"Custom"
+	)
 
 	if(targetClient)
 		var/byond_version = "Unknown"
@@ -85,6 +164,8 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 		.["data_related_cid"] = targetClient.related_accounts_cid
 		.["data_related_ip"] = targetClient.related_accounts_ip
 
+
+
 		var/datum/persistent_client/PC = GLOB.persistent_clients_by_ckey[targetClient.ckey]
 		.["data_old_names"] = PC?.get_played_names() || null
 
@@ -93,10 +174,6 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 			player_ranks += "Donator"
 		if(SSplayer_ranks.is_mentor(targetClient, admin_bypass = FALSE))
 			player_ranks += "Mentor"
-		// SPLURT EDIT: Remove Veteran. Veteran cut from the Bubberstation build.
-		// if(SSplayer_ranks.is_veteran(targetClient, admin_bypass = FALSE))
-		//	player_ranks += "Veteran"
-		//
 		if(SSplayer_ranks.is_vetted(targetClient, admin_bypass = FALSE))
 			player_ranks |= "Vetted"
 		.["ranks"] = length(player_ranks) ? player_ranks.Join(", ") : null
@@ -104,9 +181,17 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 		if(CONFIG_GET(flag/use_exp_tracking))
 			.["playtimes_enabled"] = TRUE
 			.["playtime"] = targetMob.client.get_exp_living()
+	else if(targetMob.ckey)
+		var/target_ckey = get_target_ckey()
+		if(target_ckey)
+			var/datum/persistent_client/PC = GLOB.persistent_clients_by_ckey[target_ckey]
+			.["data_old_names"] = PC?.get_played_names() || null
 
 /datum/player_panel/ui_act(action, params, datum/tgui/ui)
 	. = ..()
+
+	if(!targetMob)
+		return TRUE
 
 	var/mob/adminMob = ui.user
 	var/client/adminClient = adminMob.client
@@ -122,8 +207,7 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 			if (targetMob.client || !targetMob.ckey)
 				return
 
-			// Remove '@' from the start of the ckey.
-			var/ckey = copytext(targetMob.ckey, 2)
+			var/ckey = get_target_ckey()
 			var/mob/latestMob = get_mob_by_ckey(ckey)
 
 			if(!latestMob)
@@ -311,20 +395,29 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 			qdel(targetClient)
 
 		if ("ban")
-			var/player_key = targetMob.key
-			var/player_ip = targetMob.client.address
-			var/player_cid = targetMob.client.computer_id
-			adminClient.holder.ban_panel(player_key, player_ip, player_cid)
+			var/target_ckey = get_target_ckey()
+			var/player_ip = targetMob.client?.address
+			var/player_cid = targetMob.client?.computer_id
+			if(!target_ckey)
+				to_chat(adminClient, span_warning("No ckey found for this mob."))
+				return
+			adminClient.holder.ban_panel(target_ckey, player_ip, player_cid)
 
 		if ("sticky_ban")
 			var/list/ban_settings = list()
-			if(targetMob.client)
-				ban_settings["ckey"] = targetMob.ckey
+			var/target_ckey = get_target_ckey()
+			if(!target_ckey)
+				to_chat(adminClient, span_warning("No ckey found for this mob."))
+				return
+			ban_settings["ckey"] = target_ckey
 			adminClient.holder.stickyban("add", ban_settings)
 
 		if ("notes")
-			if (targetMob.client)
-				browse_messages(target_ckey = ckey(targetMob.ckey))
+			var/target_ckey = get_target_ckey()
+			if(!target_ckey)
+				to_chat(adminClient, span_warning("No ckey found for this mob."))
+				return
+			browse_messages(target_ckey = target_ckey)
 
 		if ("logs")
 			var/source = targetMob.client ? LOGSRC_CKEY : LOGSRC_MOB
@@ -369,6 +462,10 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 				dat += related_accounts
 				adminClient << browse(dat.Join("<br>"), "window=related_[targetMob.client];size=420x300")
 
+		if ("show_discord_id")
+			load_discord_id()
+			SStgui.update_uis(src)
+
 		if ("transform")
 			var/choice = params["newType"]
 			if (choice == "/mob/living")
@@ -377,9 +474,6 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 					return
 
 			adminClient.holder.transformMob(targetMob, adminMob, choice, params["newTypeName"])
-
-		if ("toggle_godmode")
-			adminClient.cmd_admin_godmode(targetMob)
 
 		if ("spell")
 			SSadmin_verbs.dynamic_invoke_verb(adminClient, /datum/admin_verb/give_spell, targetMob)
@@ -462,6 +556,12 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 		if ("skill_panel")
 			SSadmin_verbs.dynamic_invoke_verb(adminClient, /datum/admin_verb/show_skill_panel, targetMob)
 
+		if ("borg_panel")
+			if(!iscyborg(targetMob))
+				to_chat(adminClient, span_warning("This can only be used on cyborgs."))
+				return
+			SSadmin_verbs.dynamic_invoke_verb(adminClient, /datum/admin_verb/borg_panel, targetMob)
+
 		if ("commend")
 			if(!targetMob.ckey)
 				to_chat(adminClient, span_warning("This mob either no longer exists or no longer is being controlled by someone!"))
@@ -490,4 +590,92 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 			SSquirks.AssignQuirks(H, H.client)
 			log_admin("[key_name(adminClient)] applied client quirks to [key_name(H)].")
 			message_admins(span_adminnotice("[key_name_admin(adminClient)] applied client quirks to [key_name_admin(H)]."))
+
+		if ("toggle_status_flag")
+			var/mob/living/L = targetMob
+			if(!istype(L))
+				return
+
+			var/flag = params["flag"]
+			var/enabled = params["enabled"]
+
+			// Special handling for godmode trait
+			if(flag == "godmode")
+				adminClient.cmd_admin_godmode(targetMob)
+			else
+				var/numeric_flag = text2num(flag)
+				if(enabled)
+					L.status_flags |= numeric_flag
+				else
+					L.status_flags &= ~numeric_flag
+				log_admin("[key_name(adminClient)] [enabled ? "enabled" : "disabled"] status flag [numeric_flag] on [key_name(targetMob)].")
+
+		if ("set_speed")
+			var/mob/living/L = targetMob
+			if(!istype(L))
+				return
+
+			var/new_speed = text2num(params["speed"])
+			if(isnull(new_speed))
+				return
+
+			// Remove existing admin speed modifier
+			L.remove_movespeed_modifier(/datum/movespeed_modifier/admin_varedit)
+			var/diff = new_speed - L.cached_multiplicative_slowdown
+			if(diff != 0)
+				L.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/admin_varedit, multiplicative_slowdown = diff)
+
+			log_admin("[key_name(adminClient)] set speed of [key_name(targetMob)] to [new_speed].")
+
+		if ("add_faction")
+			var/mob/living/L = targetMob
+			if(!istype(L))
+				return
+
+			var/new_faction = params["faction"]
+			if(new_faction == "Custom")
+				new_faction = input(adminClient, "Enter custom faction name:", "Custom Faction") as text
+				if(!new_faction)
+					return
+
+			if(!L.faction)
+				L.faction = list()
+			else if(!islist(L.faction))
+				L.faction = list(L.faction)
+
+			if(!(new_faction in L.faction))
+				L.faction += new_faction
+
+			log_admin("[key_name(adminClient)] added faction [new_faction] to [key_name(targetMob)].")
+			message_admins(span_adminnotice("[key_name_admin(adminClient)] added faction [new_faction] to [key_name_admin(targetMob)]."))
+
+		if ("remove_faction")
+			var/mob/living/L = targetMob
+			if(!istype(L))
+				return
+
+			var/faction_to_remove = params["faction"]
+			if(!L.faction || !islist(L.faction))
+				return
+
+			L.faction -= faction_to_remove
+
+			if(!length(L.faction))
+				L.faction = null
+
+			log_admin("[key_name(adminClient)] removed faction [faction_to_remove] from [key_name(targetMob)].")
+			message_admins(span_adminnotice("[key_name_admin(adminClient)] removed faction [faction_to_remove] from [key_name_admin(targetMob)]."))
+
+		if ("load_preferences")
+			var/mob/living/carbon/human/H = targetMob
+			if(!istype(H))
+				to_chat(adminClient, "This can only be used on humans.", confidential = TRUE)
+				return
+			if(!H.client)
+				to_chat(adminClient, "[H] has no client!", confidential = TRUE)
+				return
+
+			H.client.prefs.apply_prefs_to(H)
+			log_admin("[key_name(adminClient)] loaded preferences onto [key_name(H)].")
+			message_admins(span_adminnotice("[key_name_admin(adminClient)] loaded preferences onto [key_name_admin(H)]."))
 

--- a/modular_zzplurt/code/modules/admin/player_panel.dm
+++ b/modular_zzplurt/code/modules/admin/player_panel.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 		return
 
 	var/datum/db_query/discord_query = SSdbcore.NewQuery(
-		"SELECT discord_id FROM [format_table_name("discord_links")] WHERE ckey = :ckey",
+		"SELECT CAST(discord_id AS CHAR) FROM [format_table_name("discord_links")] WHERE ckey = :ckey",
 		list("ckey" = target_ckey)
 	)
 	if(discord_query.warn_execute())

--- a/modular_zzplurt/code/modules/lewd/pain.dm
+++ b/modular_zzplurt/code/modules/lewd/pain.dm
@@ -11,10 +11,10 @@
 								'modular_zzplurt/sound/voice/painmoanf (5).ogg',
 								'modular_zzplurt/sound/voice/painmoanf (6).ogg',
 								'modular_zzplurt/sound/voice/painmoanf (7).ogg',
-								'modular_zzplurt/sound/voice/painmoanf (8).ogg'))
+								'modular_zzplurt/sound/voice/painmoanf (8).ogg'), 25)
 			else
 				playsound(src, pick('modular_zzplurt/sound/voice/painmoanm (1).ogg',
 								'modular_zzplurt/sound/voice/painmoanm (2).ogg',
 								'modular_zzplurt/sound/voice/painmoanm (3).ogg',
 								'modular_zzplurt/sound/voice/painmoanm (4).ogg',
-								'modular_zzplurt/sound/voice/painmoanm (5).ogg'))
+								'modular_zzplurt/sound/voice/painmoanm (5).ogg'), 25)

--- a/modular_zzplurt/code/modules/loadout/loadout_items.dm
+++ b/modular_zzplurt/code/modules/loadout/loadout_items.dm
@@ -30,7 +30,8 @@
 /datum/loadout_item/on_equip_item(obj/item/equipped_item, datum/preferences/preference_source, list/preference_list, mob/living/carbon/human/equipper, visuals_only)
 	. = ..()
 
-	ASSERT(!isnull(equipped_item))
+	if(isnull(equipped_item))
+		return NONE
 
 	var/list/item_details = preference_list[item_path]
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9979,6 +9979,7 @@
 #include "modular_zzplurt\code\game\objects\structures\crates_lockers\crates\cardboard.dm"
 #include "modular_zzplurt\code\game\objects\structures\crates_lockers\crates\critter.dm"
 #include "modular_zzplurt\code\game\objects\structures\crates_lockers\crates\secure.dm"
+#include "modular_zzplurt\code\modules\admin\admin_ticket_stats_panel.dm"
 #include "modular_zzplurt\code\modules\admin\chat_commands.dm"
 #include "modular_zzplurt\code\modules\admin\individual_logging.dm"
 #include "modular_zzplurt\code\modules\admin\player_panel.dm"

--- a/tgui/packages/tgui/interfaces/AdminTicketStats.tsx
+++ b/tgui/packages/tgui/interfaces/AdminTicketStats.tsx
@@ -1,0 +1,647 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dropdown,
+  Icon,
+  Input,
+  LabeledList,
+  NoticeBox,
+  Section,
+  Stack,
+  Table,
+} from 'tgui-core/components';
+import { BooleanLike } from 'tgui-core/react';
+
+import { useBackend } from '../backend';
+import { Window } from '../layouts';
+import { LoadingScreen } from './common/LoadingScreen';
+
+type Data = {
+  current_year: number;
+  current_month: number;
+  current_date: string;
+  default_start_date: string;
+  default_end_date: string;
+  available_columns: ColumnOption[];
+  grouping_options: GroupOption[];
+  admin_list: string[];
+  loading: BooleanLike;
+  stats_data: StatsRow[];
+  error_message: string;
+};
+
+type ColumnOption = {
+  key: string;
+  name: string;
+};
+
+type GroupOption = {
+  key: string;
+  name: string;
+};
+
+type StatsRow = {
+  admin_name: string;
+  admin_rank?: string;
+  period_group?: string;
+  Total_tickets?: number;
+  Ticket_replies?: number;
+  Rejected_count?: number;
+  Resolved_count?: number;
+  Closed_count?: number;
+  IC_Issue_count?: number;
+  Interaction_count?: number;
+};
+
+const DatePicker = ({ value, onChange, label }) => {
+  const [showCalendar, setShowCalendar] = useState(false);
+  const [tempDate, setTempDate] = useState(value);
+
+  const currentDate = new Date();
+  const [year, month, day] = value.split('-').map(Number);
+
+  const yearOptions = Array.from({ length: 10 }, (_, i) => {
+    const yearValue = currentDate.getFullYear() - 5 + i;
+    return { value: yearValue.toString(), displayText: yearValue.toString() };
+  });
+
+  const monthOptions = Array.from({ length: 12 }, (_, i) => {
+    const monthValue = (i + 1).toString().padStart(2, '0');
+    const monthName = new Date(0, i).toLocaleString('en-US', {
+      month: 'long',
+    });
+    return { value: monthValue, displayText: monthName };
+  });
+
+  const getDaysInMonth = (year: number, month: number) =>
+    new Date(year, month, 0).getDate();
+
+  const dayOptions = Array.from(
+    { length: getDaysInMonth(year, month) },
+    (_, i) => {
+      const dayValue = (i + 1).toString().padStart(2, '0');
+      return { value: dayValue, displayText: dayValue };
+    },
+  );
+
+  const handleDateChange = () => {
+    onChange(tempDate);
+    setShowCalendar(false);
+  };
+
+  const formatDateForInput = (dateStr: string) => {
+    const [y, m, d] = dateStr.split('-');
+    return `${d.padStart(2, '0')}.${m.padStart(2, '0')}.${y}`;
+  };
+
+  return (
+    <Box position="relative">
+      <Box style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+        <Input
+          placeholder="DD.MM.YYYY"
+          value={formatDateForInput(value)}
+          readOnly
+          style={{ flex: 1 }}
+        />
+        <Button
+          icon="calendar"
+          onClick={() => setShowCalendar(!showCalendar)}
+          tooltip="Select date"
+          color={showCalendar ? 'good' : 'default'}
+        />
+      </Box>
+      {showCalendar && (
+        <Box
+          position="absolute"
+          top="100%"
+          left="0"
+          right="0"
+          backgroundColor="rgba(16, 16, 16, 0.95)"
+          border="2px solid #4a90e2"
+          borderRadius="6px"
+          padding="12px"
+          style={{
+            zIndex: 1000,
+            boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
+            minWidth: '280px',
+          }}
+        >
+          <Stack vertical>
+            <Stack.Item>
+              <Box
+                fontSize="14px"
+                fontWeight="bold"
+                mb={1}
+                textAlign="center"
+                color="good"
+              >
+                Select Date
+              </Box>
+              <LabeledList>
+                <LabeledList.Item label="Year">
+                  <Dropdown
+                    selected={tempDate.split('-')[0]}
+                    options={yearOptions}
+                    onSelected={(value) => {
+                      const [, m, d] = tempDate.split('-');
+                      setTempDate(`${value}-${m}-${d}`);
+                    }}
+                    width="100%"
+                  />
+                </LabeledList.Item>
+                <LabeledList.Item label="Month">
+                  <Dropdown
+                    selected={tempDate.split('-')[1]}
+                    options={monthOptions}
+                    onSelected={(value) => {
+                      const [y, , d] = tempDate.split('-');
+                      setTempDate(`${y}-${value}-${d}`);
+                    }}
+                    width="100%"
+                  />
+                </LabeledList.Item>
+                <LabeledList.Item label="Day">
+                  <Dropdown
+                    selected={tempDate.split('-')[2]}
+                    options={dayOptions}
+                    onSelected={(value) => {
+                      const [y, m] = tempDate.split('-');
+                      setTempDate(`${y}-${m}-${value}`);
+                    }}
+                    width="100%"
+                  />
+                </LabeledList.Item>
+              </LabeledList>
+            </Stack.Item>
+            <Stack.Item>
+              <Stack>
+                <Stack.Item grow>
+                  <Button
+                    fluid
+                    content="Apply"
+                    color="good"
+                    onClick={handleDateChange}
+                  />
+                </Stack.Item>
+                <Stack.Item grow>
+                  <Button
+                    fluid
+                    content="Cancel"
+                    color="bad"
+                    onClick={() => {
+                      setTempDate(value);
+                      setShowCalendar(false);
+                    }}
+                  />
+                </Stack.Item>
+              </Stack>
+            </Stack.Item>
+          </Stack>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const getValueColor = (value: number | string) => {
+  const numValue =
+    typeof value === 'string' ? parseInt(value, 10) || 0 : value || 0;
+  if (numValue === 0) return 'bad';
+  if (numValue <= 20) return 'average';
+  if (numValue >= 50) return 'good';
+  return 'default';
+};
+
+export const AdminTicketStats = (props) => {
+  const { act, data } = useBackend<Data>();
+  const {
+    current_year,
+    current_month,
+    current_date,
+    default_start_date,
+    default_end_date,
+    available_columns = [],
+    grouping_options = [],
+    admin_list = [],
+    loading,
+    stats_data = [],
+    error_message,
+  } = data;
+
+  const [startDate, setStartDate] = useState(
+    default_start_date || current_date || '',
+  );
+  const [endDate, setEndDate] = useState(
+    default_end_date || current_date || '',
+  );
+  const [selectedAdmin, setSelectedAdmin] = useState('All');
+  const [groupBy, setGroupBy] = useState('none');
+  const [selectedColumns, setSelectedColumns] = useState(() => {
+    const initial = {};
+    if (available_columns && available_columns.length > 0) {
+      available_columns.forEach((col) => {
+        initial[col.key] = true;
+      });
+    }
+    return initial;
+  });
+  const [sortColumn, setSortColumn] = useState('');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+  useMemo(() => {
+    if (available_columns && available_columns.length > 0) {
+      setSelectedColumns((prev) => {
+        const updated = {};
+        available_columns.forEach((col) => {
+          updated[col.key] = prev[col.key] !== undefined ? prev[col.key] : true;
+        });
+        return updated;
+      });
+    }
+  }, [available_columns]);
+
+  const handleColumnToggle = useCallback((columnKey: string) => {
+    setSelectedColumns((prev) => ({
+      ...prev,
+      [columnKey]: !prev[columnKey],
+    }));
+  }, []);
+
+  const handleSort = useCallback((column: string) => {
+    setSortColumn((prevColumn) => {
+      if (prevColumn === column) {
+        setSortOrder((prevOrder) => (prevOrder === 'asc' ? 'desc' : 'asc'));
+        return column;
+      } else {
+        setSortOrder('desc');
+        return column;
+      }
+    });
+  }, []);
+
+  const handleFetchStats = useCallback(() => {
+    if (loading) return;
+
+    const selectedCols = Object.keys(selectedColumns).filter(
+      (key) => selectedColumns[key],
+    );
+
+    if (selectedCols.length === 0) {
+      return;
+    }
+
+    act('fetch_stats', {
+      start_date: startDate,
+      end_date: endDate,
+      admin_filter: selectedAdmin === 'All' ? '' : selectedAdmin,
+      grouping: groupBy,
+      selected_columns: selectedCols,
+    });
+  }, [
+    act,
+    startDate,
+    endDate,
+    selectedAdmin,
+    groupBy,
+    selectedColumns,
+    loading,
+  ]);
+
+  const adminOptions = useMemo(() => {
+    const options = [{ value: 'All', displayText: 'All Admins' }];
+    if (admin_list && admin_list.length > 0) {
+      admin_list.forEach((admin) => {
+        options.push({ value: admin, displayText: admin });
+      });
+    }
+    return options;
+  }, [admin_list]);
+
+  const groupingOptions = useMemo(() => {
+    if (grouping_options && grouping_options.length > 0) {
+      return grouping_options.map((opt) => ({
+        value: opt.key,
+        displayText: opt.name,
+      }));
+    }
+    return [{ value: 'none', displayText: 'No Grouping' }];
+  }, [grouping_options]);
+
+  const filteredAndSortedData = useMemo(() => {
+    if (!stats_data || stats_data.length === 0) return [];
+
+    let filtered = [...stats_data];
+
+    if (sortColumn) {
+      filtered.sort((a, b) => {
+        const aVal = a[sortColumn];
+        const bVal = b[sortColumn];
+
+        const aNum = parseFloat(aVal);
+        const bNum = parseFloat(bVal);
+
+        let comparison = 0;
+        if (!isNaN(aNum) && !isNaN(bNum)) {
+          comparison = aNum - bNum;
+        } else {
+          comparison = String(aVal).localeCompare(String(bVal));
+        }
+
+        return sortOrder === 'asc' ? comparison : -comparison;
+      });
+    }
+
+    return filtered;
+  }, [stats_data, sortColumn, sortOrder]);
+
+  const visibleColumns = useMemo(() => {
+    if (!available_columns || available_columns.length === 0) return [];
+    return available_columns.filter((col) => selectedColumns[col.key]);
+  }, [available_columns, selectedColumns]);
+
+  const displayError = error_message && error_message.trim() !== '';
+  const hasData = stats_data && stats_data.length > 0;
+  const hasSelectedColumns = Object.values(selectedColumns).some(Boolean);
+
+  if (loading) {
+    return (
+      <Window
+        title="Admin Ticket Statistics"
+        width={1200}
+        height={800}
+        theme="admin"
+      >
+        <Window.Content>
+          <LoadingScreen label="Generating ticket statistics..." />
+        </Window.Content>
+      </Window>
+    );
+  }
+
+  return (
+    <Window
+      title="Admin Ticket Statistics"
+      width={1200}
+      height={800}
+      theme="admin"
+    >
+      <Window.Content>
+        <Stack vertical fill>
+          <Stack.Item>
+            <Section
+              title="Filters & Settings"
+              buttons={
+                <Button
+                  icon="chart-bar"
+                  content="Generate Report"
+                  color="good"
+                  onClick={handleFetchStats}
+                  disabled={loading || !hasSelectedColumns}
+                  tooltip={
+                    !hasSelectedColumns
+                      ? 'Please select at least one column'
+                      : ''
+                  }
+                />
+              }
+            >
+              <Stack>
+                <Stack.Item basis="50%">
+                  <LabeledList>
+                    <LabeledList.Item label="Start Date">
+                      <DatePicker
+                        value={startDate}
+                        onChange={setStartDate}
+                        label="Start Date"
+                      />
+                    </LabeledList.Item>
+                    <LabeledList.Item label="End Date">
+                      <DatePicker
+                        value={endDate}
+                        onChange={setEndDate}
+                        label="End Date"
+                      />
+                    </LabeledList.Item>
+                  </LabeledList>
+                </Stack.Item>
+                <Stack.Item basis="50%">
+                  <LabeledList>
+                    <LabeledList.Item label="Admin">
+                      <Dropdown
+                        selected={selectedAdmin}
+                        options={adminOptions}
+                        onSelected={setSelectedAdmin}
+                        width="100%"
+                      />
+                    </LabeledList.Item>
+                    <LabeledList.Item label="Group By">
+                      <Dropdown
+                        selected={groupBy}
+                        options={groupingOptions}
+                        onSelected={setGroupBy}
+                        width="100%"
+                      />
+                    </LabeledList.Item>
+                  </LabeledList>
+                </Stack.Item>
+              </Stack>
+            </Section>
+          </Stack.Item>
+
+          <Stack.Item>
+            <Section title="Display Columns">
+              {available_columns && available_columns.length > 0 ? (
+                <Box
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '8px',
+                    alignItems: 'center',
+                  }}
+                >
+                  {available_columns.map((column) => (
+                    <Button.Checkbox
+                      key={column.key}
+                      checked={selectedColumns[column.key] || false}
+                      onClick={() => handleColumnToggle(column.key)}
+                      style={{ minWidth: 'fit-content', marginBottom: '4px' }}
+                    >
+                      {column.name}
+                    </Button.Checkbox>
+                  ))}
+                </Box>
+              ) : (
+                <Box color="average">Loading columns...</Box>
+              )}
+            </Section>
+          </Stack.Item>
+
+          <Stack.Item grow>
+            {displayError ? (
+              <Section fill>
+                <NoticeBox color="bad">{error_message}</NoticeBox>
+              </Section>
+            ) : hasData ? (
+              <Section
+                fill
+                title={`Statistics (${filteredAndSortedData.length} rows)`}
+              >
+                <Table>
+                  <Table.Row header>
+                    {/* Period Group column (only when grouping is enabled) */}
+                    {groupBy !== 'none' && (
+                      <Table.Cell
+                        style={{ cursor: 'pointer', userSelect: 'none' }}
+                        onClick={() => handleSort('period_group')}
+                      >
+                        <Stack align="center">
+                          <Stack.Item>Period</Stack.Item>
+                          <Stack.Item>
+                            {sortColumn === 'period_group' && (
+                              <Icon
+                                name={
+                                  sortOrder === 'asc'
+                                    ? 'sort-amount-up'
+                                    : 'sort-amount-down'
+                                }
+                                size={0.8}
+                              />
+                            )}
+                          </Stack.Item>
+                        </Stack>
+                      </Table.Cell>
+                    )}
+
+                    {/* Admin Name column */}
+                    <Table.Cell
+                      style={{ cursor: 'pointer', userSelect: 'none' }}
+                      onClick={() => handleSort('admin_name')}
+                    >
+                      <Stack align="center">
+                        <Stack.Item>Admin Name</Stack.Item>
+                        <Stack.Item>
+                          {sortColumn === 'admin_name' && (
+                            <Icon
+                              name={
+                                sortOrder === 'asc'
+                                  ? 'sort-amount-up'
+                                  : 'sort-amount-down'
+                              }
+                              size={0.8}
+                            />
+                          )}
+                        </Stack.Item>
+                      </Stack>
+                    </Table.Cell>
+
+                    {/* Admin Rank column */}
+                    <Table.Cell
+                      style={{ cursor: 'pointer', userSelect: 'none' }}
+                      onClick={() => handleSort('admin_rank')}
+                    >
+                      <Stack align="center">
+                        <Stack.Item>Rank</Stack.Item>
+                        <Stack.Item>
+                          {sortColumn === 'admin_rank' && (
+                            <Icon
+                              name={
+                                sortOrder === 'asc'
+                                  ? 'sort-amount-up'
+                                  : 'sort-amount-down'
+                              }
+                              size={0.8}
+                            />
+                          )}
+                        </Stack.Item>
+                      </Stack>
+                    </Table.Cell>
+
+                    {/* Selected data columns */}
+                    {visibleColumns.map((column) => (
+                      <Table.Cell
+                        key={column.key}
+                        style={{ cursor: 'pointer', userSelect: 'none' }}
+                        onClick={() => handleSort(column.key)}
+                      >
+                        <Stack align="center">
+                          <Stack.Item>{column.name}</Stack.Item>
+                          <Stack.Item>
+                            {sortColumn === column.key && (
+                              <Icon
+                                name={
+                                  sortOrder === 'asc'
+                                    ? 'sort-amount-up'
+                                    : 'sort-amount-down'
+                                }
+                                size={0.8}
+                              />
+                            )}
+                          </Stack.Item>
+                        </Stack>
+                      </Table.Cell>
+                    ))}
+                  </Table.Row>
+                  {filteredAndSortedData.map((row, index) => (
+                    <Table.Row
+                      key={index}
+                      className={index % 2 === 0 ? '' : 'candystripe'}
+                    >
+                      {/* Period Group cell */}
+                      {groupBy !== 'none' && (
+                        <Table.Cell>
+                          <Box color="label">{row.period_group || 'N/A'}</Box>
+                        </Table.Cell>
+                      )}
+
+                      {/* Admin Name cell */}
+                      <Table.Cell>
+                        <Box color="good" bold>
+                          {row.admin_name}
+                        </Box>
+                      </Table.Cell>
+
+                      {/* Admin Rank cell */}
+                      <Table.Cell>
+                        <Box color="label">{row.admin_rank || 'Unknown'}</Box>
+                      </Table.Cell>
+
+                      {/* Data cells with color coding */}
+                      {visibleColumns.map((column) => {
+                        const value = row[column.key] || 0;
+                        return (
+                          <Table.Cell key={column.key} textAlign="center">
+                            <Box color={getValueColor(value)} bold>
+                              {value}
+                            </Box>
+                          </Table.Cell>
+                        );
+                      })}
+                    </Table.Row>
+                  ))}
+                </Table>
+              </Section>
+            ) : (
+              <Section fill>
+                <Box
+                  textAlign="center"
+                  color="average"
+                  fontSize="1.2em"
+                  style={{ marginTop: '100px' }}
+                >
+                  <Stack vertical>
+                    <Stack.Item>📊 No data available</Stack.Item>
+                    <Stack.Item>
+                      Configure your filters and click &quot;Generate
+                      Report&quot; to view statistics
+                    </Stack.Item>
+                  </Stack>
+                </Box>
+              </Section>
+            )}
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/AdminTicketStats.tsx
+++ b/tgui/packages/tgui/interfaces/AdminTicketStats.tsx
@@ -101,7 +101,7 @@ const DatePicker = ({ value, onChange, label }) => {
         <Input
           placeholder="DD.MM.YYYY"
           value={formatDateForInput(value)}
-          readOnly
+          readonly
           style={{ flex: 1 }}
         />
         <Button
@@ -120,7 +120,7 @@ const DatePicker = ({ value, onChange, label }) => {
           backgroundColor="rgba(16, 16, 16, 0.95)"
           border="2px solid #4a90e2"
           borderRadius="6px"
-          padding="12px"
+          p={3}
           style={{
             zIndex: 1000,
             boxShadow: '0 4px 12px rgba(0,0,0,0.5)',

--- a/tgui/packages/tgui/interfaces/AdminTicketStats.tsx
+++ b/tgui/packages/tgui/interfaces/AdminTicketStats.tsx
@@ -101,7 +101,7 @@ const DatePicker = ({ value, onChange, label }) => {
         <Input
           placeholder="DD.MM.YYYY"
           value={formatDateForInput(value)}
-          readonly
+          disabled
           style={{ flex: 1 }}
         />
         <Button
@@ -118,13 +118,13 @@ const DatePicker = ({ value, onChange, label }) => {
           left="0"
           right="0"
           backgroundColor="rgba(16, 16, 16, 0.95)"
-          border="2px solid #4a90e2"
-          borderRadius="6px"
           p={3}
           style={{
             zIndex: 1000,
             boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
             minWidth: '280px',
+            border: '2px solid #4a90e2',
+            borderRadius: '6px',
           }}
         >
           <Stack vertical>

--- a/tgui/packages/tgui/interfaces/PlayerPanel.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Button,
@@ -11,6 +11,7 @@ import {
   NumberInput,
   Section,
   Slider,
+  Stack,
   Tabs,
   Tooltip,
 } from 'tgui-core/components';
@@ -26,6 +27,7 @@ type Data = {
   client_rank: string;
   ranks: string;
   last_ckey: string;
+  discord_id: string;
   playtimes_enabled: boolean;
   playtime: string;
   godmode: boolean;
@@ -39,6 +41,9 @@ type Data = {
   data_account_join_date: string;
   data_byond_version: string;
   data_old_names: string;
+  mob_speed: number;
+  mob_status_flags: number;
+  current_faction: string[];
 
   glob_mute_bits: {
     name: string;
@@ -48,6 +53,12 @@ type Data = {
   glob_limbs: {
     [key: string]: string;
   };
+
+  glob_status_flags: {
+    [key: string]: number;
+  };
+
+  glob_factions: string[];
 
   transformables: {
     name: string;
@@ -118,154 +129,164 @@ export const PlayerPanel = () => {
   } = data;
 
   return (
-    <Window title={`${mob_name} Player Panel`} width={650} height={500}>
-      <Window.Content scrollable>
-        <Section>
-          <Flex>
-            <Flex.Item width="80px" color="label" align="center">
-              Name:
-            </Flex.Item>
-            <Flex.Item grow={1}>
-              <Input
-                width="100%"
-                value={mob_name}
-                onChange={(value) => act('set_name', { name: value })}
-              />
-            </Flex.Item>
-            {!!client_ckey && (
-              <Flex.Item>
-                <Box inline ml=".75rem" mr=".5rem" color="label">
-                  Rank:
-                </Box>
-                <Flex.Item inline>
-                  <Button
-                    minWidth="11rem"
-                    textAlign="center"
-                    onClick={() => act('edit_rank')}
-                  >
-                    {client_rank}
-                  </Button>
-                </Flex.Item>
-              </Flex.Item>
-            )}
-          </Flex>
-          <Flex mt={1} align="center" wrap="wrap" justify="flex-end">
-            <Flex.Item width="80px" color="label">
-              Mob Type:
-            </Flex.Item>
-            <Flex.Item grow={1} align="right">
-              {mob_type}
-            </Flex.Item>
-            <Flex.Item align="right">
-              <Button
-                minWidth="11rem"
-                textAlign="center"
-                ml=".5rem"
-                icon="window-restore"
-                onClick={() => act('access_variables')}
-              >
-                Access Variables
-              </Button>
-            </Flex.Item>
-            {!!client_ckey && (
-              <Flex.Item>
-                <Button
-                  minWidth="11rem"
-                  textAlign="center"
-                  ml=".5rem"
-                  icon="window-restore"
-                  disabled={!playtimes_enabled}
-                  onClick={() => act('access_playtimes')}
-                >
-                  {playtimes_enabled ? playtime : 'Playtimes'}
-                </Button>
-              </Flex.Item>
-            )}
-          </Flex>
-          {(!!client_ckey || !!last_ckey) && (
-            <Flex mt={1} align="center">
-              <Flex.Item width="80px" color="label">
-                {client_ckey ? 'Client:' : 'Last client:'}
-              </Flex.Item>
-              <Flex.Item tooltip grow={1}>
-                <Tooltip
-                  position="bottom"
-                  content={ranks || 'No additional ranks'}
-                >
-                  <Box
-                    inline
-                    style={{
-                      borderBottom: ranks
-                        ? '2px dotted rgba(255, 255, 255, 0.8)'
-                        : 'none',
-                    }}
-                  >
-                    {client_ckey || last_ckey}
-                  </Box>
-                </Tooltip>
-
-                {!client_ckey && !!last_ckey && (
-                  <Button
-                    ml={1}
-                    icon="magnifying-glass"
-                    tooltip="Get player's current panel"
-                    onClick={() => act('open_latest_panel')}
+    <Window title={`${mob_name} Player Panel`} width={600} height={480}>
+      <Window.Content>
+        <Stack fill vertical>
+          <Stack.Item>
+            <Section>
+              <Stack>
+                <Stack.Item width="80px" color="label">
+                  Name:
+                </Stack.Item>
+                <Stack.Item grow={1}>
+                  <Input
+                    width="100%"
+                    value={mob_name}
+                    onChange={(value) => act('set_name', { name: value })}
                   />
+                </Stack.Item>
+                {!!client_ckey && (
+                  <Stack.Item>
+                    <Box inline ml=".75rem" mr=".5rem" color="label">
+                      Rank:
+                    </Box>
+                    <Stack.Item inline>
+                      <Button
+                        minWidth="11rem"
+                        textAlign="center"
+                        onClick={() => act('edit_rank')}
+                      >
+                        {client_rank}
+                      </Button>
+                    </Stack.Item>
+                  </Stack.Item>
                 )}
-              </Flex.Item>
+              </Stack>
 
-              {!!client_ckey && (
-                <Flex.Item align="right">
+              <Stack mt={1}>
+                <Stack.Item width="80px" color="label">
+                  Mob Type:
+                </Stack.Item>
+                <Stack.Item grow={1}>{mob_type}</Stack.Item>
+                <Stack.Item>
                   <Button
                     minWidth="11rem"
                     textAlign="center"
-                    mx=".5rem"
-                    icon="comment-dots"
-                    onClick={() => act('private_message')}
+                    ml=".5rem"
+                    icon="window-restore"
+                    onClick={() => act('access_variables')}
                   >
-                    Private Message
+                    Access Variables
                   </Button>
-                  <Button
-                    minWidth="11rem"
-                    textAlign="center"
-                    icon="phone-alt"
-                    onClick={() => act('subtle_message')}
-                  >
-                    Subtle Message
-                  </Button>
-                </Flex.Item>
-              )}
-            </Flex>
-          )}
-        </Section>
-        <Flex grow>
-          <Flex.Item>
-            <Section fitted>
-              <Tabs vertical>
-                {PAGES.map((page, i) => {
-                  if (page.canAccess && !page.canAccess(data)) {
-                    return;
-                  }
-
-                  return (
-                    <Tabs.Tab
-                      key={i}
-                      color={page.color}
-                      selected={i === pageIndex}
-                      icon={page.icon}
-                      onClick={() => setPageIndex(i)}
+                </Stack.Item>
+                {!!client_ckey && (
+                  <Stack.Item>
+                    <Button
+                      minWidth="11rem"
+                      textAlign="center"
+                      ml=".5rem"
+                      icon="window-restore"
+                      disabled={!playtimes_enabled}
+                      onClick={() => act('access_playtimes')}
                     >
-                      {page.title}
-                    </Tabs.Tab>
-                  );
-                })}
-              </Tabs>
+                      {playtimes_enabled ? playtime : 'Playtimes'}
+                    </Button>
+                  </Stack.Item>
+                )}
+              </Stack>
+
+              {(!!client_ckey || !!last_ckey) && (
+                <Stack mt={1}>
+                  <Stack.Item width="80px" color="label">
+                    {client_ckey ? 'Client:' : 'Last client:'}
+                  </Stack.Item>
+                  <Stack.Item grow={1}>
+                    <Tooltip
+                      position="bottom"
+                      content={ranks || 'No additional ranks'}
+                    >
+                      <Box
+                        inline
+                        style={{
+                          borderBottom: ranks
+                            ? '2px dotted rgba(255, 255, 255, 0.8)'
+                            : 'none',
+                        }}
+                      >
+                        {client_ckey || last_ckey}
+                      </Box>
+                    </Tooltip>
+
+                    {!client_ckey && !!last_ckey && (
+                      <Button
+                        ml={1}
+                        icon="magnifying-glass"
+                        tooltip="Get player's current panel"
+                        onClick={() => act('open_latest_panel')}
+                      />
+                    )}
+                  </Stack.Item>
+
+                  {!!client_ckey && (
+                    <Stack.Item>
+                      <Button
+                        minWidth="11rem"
+                        textAlign="center"
+                        ml=".5rem"
+                        icon="comment-dots"
+                        onClick={() => act('private_message')}
+                      >
+                        Private Message
+                      </Button>
+                      <Button
+                        minWidth="11rem"
+                        textAlign="center"
+                        ml=".5rem"
+                        icon="phone-alt"
+                        onClick={() => act('subtle_message')}
+                      >
+                        Subtle Message
+                      </Button>
+                    </Stack.Item>
+                  )}
+                </Stack>
+              )}
             </Section>
-          </Flex.Item>
-          <Flex.Item grow>
-            <PageComponent />
-          </Flex.Item>
-        </Flex>
+          </Stack.Item>
+
+          <Stack.Item grow>
+            <Stack fill>
+              <Stack.Item>
+                <Section fitted>
+                  <Tabs vertical>
+                    {PAGES.map((page, i) => {
+                      if (page.canAccess && !page.canAccess(data)) {
+                        return;
+                      }
+
+                      return (
+                        <Tabs.Tab
+                          key={i}
+                          color={page.color}
+                          selected={i === pageIndex}
+                          icon={page.icon}
+                          onClick={() => setPageIndex(i)}
+                        >
+                          {page.title}
+                        </Tabs.Tab>
+                      );
+                    })}
+                  </Tabs>
+                </Section>
+              </Stack.Item>
+              <Stack.Item grow basis={0} ml={1}>
+                <Section fill scrollable>
+                  <PageComponent />
+                </Section>
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );
@@ -277,7 +298,7 @@ const GeneralActions = () => {
   return (
     <Section>
       <Section title="Damage">
-        <Flex>
+        <Stack>
           <Button
             width="100%"
             icon="heart"
@@ -289,7 +310,6 @@ const GeneralActions = () => {
           </Button>
           <Button
             width="100%"
-            height="100%"
             icon="bolt"
             color="orange"
             disabled={!mob_type.includes('/mob/living/carbon/human')}
@@ -297,11 +317,11 @@ const GeneralActions = () => {
           >
             Smite
           </Button>
-        </Flex>
+        </Stack>
       </Section>
 
       <Section title="Teleportation">
-        <Flex>
+        <Stack>
           <Button.Confirm
             width="100%"
             icon="reply"
@@ -314,36 +334,16 @@ const GeneralActions = () => {
           </Button>
           <Button.Confirm
             width="100%"
-            height="100%"
             icon="share"
             onClick={() => act('jump_to')}
           >
             Jump To
           </Button.Confirm>
-        </Flex>
+        </Stack>
       </Section>
 
       <Section title="Miscellaneous">
-        <Flex>
-          <Button
-            width="100%"
-            icon="user-tie"
-            disabled={!mob_type.includes('/mob/living/carbon/human')}
-            onClick={() => act('select_equipment')}
-          >
-            Select Equipment
-          </Button>
-          <Button.Confirm
-            icon="trash-alt"
-            width="100%"
-            height="100%"
-            disabled={!mob_type.includes('/mob/living/carbon/human')}
-            onClick={() => act('strip')}
-          >
-            Drop All Items
-          </Button.Confirm>
-        </Flex>
-        <Flex>
+        <Stack>
           <Button.Confirm
             icon="snowflake"
             width="100%"
@@ -355,7 +355,6 @@ const GeneralActions = () => {
           </Button.Confirm>
           <Button.Confirm
             width="100%"
-            height="100%"
             color="orange"
             icon="undo"
             disabled={!mob_type.includes('/mob/dead/observer')}
@@ -368,10 +367,21 @@ const GeneralActions = () => {
           >
             Send To Lobby
           </Button.Confirm>
-        </Flex>
+        </Stack>
+        <Stack>
+          <Button
+            width="100%"
+            icon="user-cog"
+            disabled={!mob_type.includes('/mob/living/carbon/human')}
+            onClick={() => act('load_preferences')}
+          >
+            Load Preferences
+          </Button>
+        </Stack>
       </Section>
+
       <Section title="Control">
-        <Flex>
+        <Stack>
           <Button.Confirm
             width="100%"
             icon="ghost"
@@ -394,7 +404,6 @@ const GeneralActions = () => {
           </Button.Confirm>
           <Button.Confirm
             width="100%"
-            height="100%" // weird ass bug here, so height set to 100%
             icon="ghost"
             tooltip="Offers control to ghosts"
             disabled={!mob_type.includes('/mob/living')}
@@ -402,7 +411,7 @@ const GeneralActions = () => {
           >
             Offer Control
           </Button.Confirm>
-        </Flex>
+        </Stack>
       </Section>
     </Section>
   );
@@ -410,86 +419,63 @@ const GeneralActions = () => {
 
 const PhysicalActions = () => {
   const { act, data } = useBackend<Data>();
-  const { glob_limbs, godmode, mob_type } = data;
+  const {
+    glob_limbs,
+    glob_status_flags,
+    mob_speed,
+    mob_status_flags,
+    mob_type,
+    current_faction,
+    glob_factions,
+  } = data;
   const [mobScale, setMobScale] = useState(1);
+  const [mobSpeed, setMobSpeed] = useState(mob_speed || 0);
   const limbs = Object.keys(glob_limbs);
   const limb_flags = limbs.map((_, i) => 1 << i);
   const [delimbOption, setDelimbOption] = useState(0);
 
+  // Update local speed state when server data changes
+  React.useEffect(() => {
+    setMobSpeed(mob_speed || 0);
+  }, [mob_speed]);
+
   return (
     <Section fill>
-      <Section
-        title="Traits"
-        buttons={
-          <Button
-            icon={godmode ? 'check-square-o' : 'square-o'}
-            color={godmode ? 'green' : 'transparent'}
-            onClick={() => act('toggle_godmode')}
-          >
-            God Mode
-          </Button>
-        }
-      >
-        <Flex>
-          <Button
-            width="100%"
-            icon="paw"
-            disabled={!mob_type.includes('/mob/living/carbon/human')}
-            onClick={() => act('species')}
-          >
-            Species
-          </Button>
-          <Button
-            width="100%"
-            icon="bolt"
-            disabled={!mob_type.includes('/mob/living/carbon/human')}
-            onClick={() => act('quirk')}
-          >
-            Quirks
-          </Button>
-          <Button
-            width="100%"
-            height="100%"
-            icon="magic"
-            onClick={() => act('spell')}
-          >
-            Spells
-          </Button>
-        </Flex>
-        <Flex>
-          <Button
-            width="100%"
-            icon="fist-raised"
-            disabled={!mob_type.includes('/mob/living/carbon/human')}
-            onClick={() => act('martial_art')}
-          >
-            Martial Arts
-          </Button>
-          <Button
-            width="100%"
-            icon="lightbulb"
-            onClick={() => act('skill_panel')}
-          >
-            Skills
-          </Button>
-          <Button
-            width="100%"
-            height="100%"
-            icon="comment-dots"
-            onClick={() => act('languages')}
-          >
-            Languages
-          </Button>
-        </Flex>
+      <Section title="Status Flags">
+        <Stack wrap>
+          {Object.keys(glob_status_flags).map((flag) => {
+            let isActive;
+            if (flag === 'Godmode') {
+              isActive = data.godmode;
+            } else {
+              isActive = mob_status_flags & glob_status_flags[flag];
+            }
+            return (
+              <Button.Checkbox
+                key={flag}
+                checked={isActive}
+                color={isActive ? 'green' : 'red'}
+                onClick={() =>
+                  act('toggle_status_flag', {
+                    flag: glob_status_flags[flag],
+                    enabled: !isActive,
+                  })
+                }
+              >
+                {flag}
+              </Button.Checkbox>
+            );
+          })}
+        </Stack>
       </Section>
+
       <Section
         title="Limbs"
         buttons={
-          <Flex>
+          <Stack>
             {limbs.map((val, index) => (
               <Button.Checkbox
                 key={index}
-                height="100%"
                 checked={delimbOption & limb_flags[index]}
                 disabled={!mob_type.includes('/mob/living/carbon/human')}
                 onClick={() =>
@@ -503,10 +489,10 @@ const PhysicalActions = () => {
                 {val}
               </Button.Checkbox>
             ))}
-          </Flex>
+          </Stack>
         }
       >
-        <Flex>
+        <Stack>
           <Button.Confirm
             width="100%"
             icon="unlink"
@@ -526,7 +512,6 @@ const PhysicalActions = () => {
           </Button.Confirm>
           <Button.Confirm
             width="100%"
-            height="100%"
             icon="link"
             color="green"
             disabled={!mob_type.includes('/mob/living/carbon/human')}
@@ -541,8 +526,9 @@ const PhysicalActions = () => {
           >
             Relimb
           </Button.Confirm>
-        </Flex>
+        </Stack>
       </Section>
+
       <Section
         title="Scale"
         buttons={
@@ -557,44 +543,141 @@ const PhysicalActions = () => {
           </Button>
         }
       >
-        <Flex mt={1}>
-          <Slider
-            minValue={0.25}
-            maxValue={8}
-            value={mobScale}
-            stepPixelSize={12}
-            step={0.25}
-            onChange={(_event, value: number) => {
-              setMobScale(value);
-              act('scale', { new_scale: value });
-            }}
-            unit="x"
-          />
-        </Flex>
+        <Slider
+          minValue={0.25}
+          maxValue={8}
+          value={mobScale}
+          stepPixelSize={12}
+          step={0.25}
+          onChange={(_event, value: number) => {
+            setMobScale(value);
+            act('scale', { new_scale: value });
+          }}
+          unit="x"
+        />
       </Section>
+
+      <Section title="Speed">
+        <Tooltip
+          content="Negative values = faster, positive values = slower"
+          position="bottom"
+        >
+          <Box
+            mb={1}
+            color="label"
+            style={{
+              borderBottom: '2px dotted rgba(255, 255, 255, 0.8)',
+              display: 'inline-block',
+              cursor: 'help',
+            }}
+          >
+            Current speed: {mobSpeed}
+          </Box>
+        </Tooltip>
+        <Slider
+          minValue={-10}
+          maxValue={10}
+          value={mobSpeed}
+          stepPixelSize={6}
+          step={0.25}
+          onChange={(_event, value: number) => {
+            setMobSpeed(value);
+            act('set_speed', { speed: value });
+          }}
+          unit="Speed"
+        />
+      </Section>
+
       <Section title="Speak">
-        <Flex mt={1}>
-          <Flex.Item width="100px" color="label">
+        <Stack mt={1}>
+          <Stack.Item width="100px" color="label">
             Force Say:
-          </Flex.Item>
-          <Flex.Item grow={1}>
+          </Stack.Item>
+          <Stack.Item grow={1}>
             <Input
               width="100%"
               onEnter={(value) => act('force_say', { to_say: value })}
             />
-          </Flex.Item>
-        </Flex>
-        <Flex mt={2}>
-          <Flex.Item width="100px" color="label">
+          </Stack.Item>
+        </Stack>
+        <Stack mt={2}>
+          <Stack.Item width="100px" color="label">
             Force Emote:
-          </Flex.Item>
-          <Flex.Item grow={1}>
+          </Stack.Item>
+          <Stack.Item grow={1}>
             <Input
               width="100%"
               onEnter={(value) => act('force_emote', { to_emote: value })}
             />
-          </Flex.Item>
-        </Flex>
+          </Stack.Item>
+        </Stack>
+      </Section>
+
+      <Section title="Equipment">
+        <Stack>
+          <Button
+            width="100%"
+            icon="user-tie"
+            disabled={!mob_type.includes('/mob/living/carbon/human')}
+            onClick={() => act('select_equipment')}
+          >
+            Select Equipment
+          </Button>
+          <Button.Confirm
+            icon="trash-alt"
+            width="100%"
+            disabled={!mob_type.includes('/mob/living/carbon/human')}
+            onClick={() => act('strip')}
+          >
+            Drop All Items
+          </Button.Confirm>
+        </Stack>
+      </Section>
+
+      <Section title="Faction">
+        <Stack vertical>
+          <Stack.Item>
+            <Stack>
+              <Stack.Item width="100px" color="label">
+                Current:
+              </Stack.Item>
+              <Stack.Item grow={1}>
+                {current_faction && current_faction.length > 0 ? (
+                  <Stack wrap>
+                    {current_faction.map((faction, index) => (
+                      <Button
+                        key={index}
+                        color="orange"
+                        icon="times"
+                        tooltip="Click to remove faction"
+                        onClick={() => act('remove_faction', { faction })}
+                      >
+                        {faction}
+                      </Button>
+                    ))}
+                  </Stack>
+                ) : (
+                  <Box color="label">No factions</Box>
+                )}
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+          <Stack.Item>
+            <Stack>
+              <Stack.Item width="100px" color="label">
+                Add:
+              </Stack.Item>
+              <Stack.Item grow={1}>
+                <Dropdown
+                  width="100%"
+                  placeholder="Select faction to add"
+                  options={glob_factions}
+                  onSelected={(value) => act('add_faction', { faction: value })}
+                />
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+        </Stack>
       </Section>
     </Section>
   );
@@ -650,6 +733,7 @@ const PunishmentActions = () => {
   const { act, data } = useBackend<Data>();
   const {
     client_ckey,
+    last_ckey,
     mob_type,
     is_frozen,
     is_slept,
@@ -661,25 +745,29 @@ const PunishmentActions = () => {
     data_player_join_date,
     data_account_join_date,
     data_old_names,
+    discord_id,
     current_time,
   } = data;
+
+  // Check if we have any key (current client or last known)
+  const hasAnyKey = !!(client_ckey || last_ckey);
+
   return (
     <Section>
-      <Flex>
+      <Stack>
         <Button
           width="50%"
           py=".5rem"
           icon="clipboard-list"
           color="orange"
           textAlign="center"
-          disabled={!client_ckey}
+          disabled={!hasAnyKey}
           onClick={() => act('notes')}
         >
           Notes
         </Button>
         <Button
           width="50%"
-          height="100%"
           py=".5rem"
           icon="clipboard-list"
           color="orange"
@@ -688,9 +776,9 @@ const PunishmentActions = () => {
         >
           Logs
         </Button>
-      </Flex>
+      </Stack>
       <Section title="Contain">
-        <Flex>
+        <Stack>
           <Button
             width="100%"
             color={is_frozen ? 'orange' : ''}
@@ -711,7 +799,6 @@ const PunishmentActions = () => {
           </Button>
           <Button.Confirm
             width="100%"
-            height="100%"
             icon="share"
             color="bad"
             disabled={!mob_type.includes('/mob/living')}
@@ -719,11 +806,11 @@ const PunishmentActions = () => {
           >
             Admin Prison
           </Button.Confirm>
-        </Flex>
+        </Stack>
       </Section>
 
       <Section title="Banishment">
-        <Flex>
+        <Stack>
           <Button.Confirm
             width="100%"
             icon="ban"
@@ -737,22 +824,21 @@ const PunishmentActions = () => {
             width="100%"
             icon="gavel"
             color="red"
-            disabled={!client_ckey}
+            disabled={!hasAnyKey}
             onClick={() => act('ban')}
           >
             Ban
           </Button>
           <Button.Confirm
             width="100%"
-            height="100%"
             icon="gavel"
             color="red"
-            disabled={!client_ckey}
+            disabled={!hasAnyKey}
             onClick={() => act('sticky_ban')}
           >
             Sticky Ban
           </Button.Confirm>
-        </Flex>
+        </Stack>
       </Section>
 
       <Section
@@ -778,14 +864,13 @@ const PunishmentActions = () => {
           </>
         }
       >
-        <Flex>
+        <Stack>
           {glob_mute_bits.map((bit, i) => {
             const isMuted = client_muted && client_muted & bit.bitflag;
             return (
               <Button
                 key={i}
                 width="100%"
-                height="100%"
                 icon={isMuted ? 'check-square-o' : 'square-o'}
                 color={isMuted ? 'bad' : ''}
                 disabled={!client_ckey}
@@ -801,15 +886,15 @@ const PunishmentActions = () => {
               </Button>
             );
           })}
-        </Flex>
+        </Stack>
       </Section>
       <Section
         title="Investigate"
         buttons={
-          <Flex>
-            <Flex.Item align="center" mr=".5rem" color="label">
+          <Stack>
+            <Stack.Item align="center" mr=".5rem" color="label">
               Related accounts by:
-            </Flex.Item>
+            </Stack.Item>
             <Button
               minWidth="5rem"
               color="orange"
@@ -822,7 +907,6 @@ const PunishmentActions = () => {
             </Button>
             <Button
               minWidth="5rem"
-              height="100%"
               color="orange"
               textAlign="center"
               disabled={!data_related_ip}
@@ -830,7 +914,7 @@ const PunishmentActions = () => {
             >
               IP
             </Button>
-          </Flex>
+          </Stack>
         }
       >
         <Collapsible width="100%" color="orange" title="Details">
@@ -849,6 +933,30 @@ const PunishmentActions = () => {
             </LabeledList.Item>
             <LabeledList.Item label="Old names">
               {data_old_names}
+            </LabeledList.Item>
+            <LabeledList.Item label="Discord">
+              {discord_id &&
+              discord_id !== 'Not found' &&
+              discord_id !== 'Database error' &&
+              discord_id !== 'No ckey found' ? (
+                <Box color="good">{'<@' + discord_id + '>'}</Box>
+              ) : discord_id === 'Not found' ? (
+                <Box color="bad">No Discord ID found</Box>
+              ) : discord_id === 'Database error' ? (
+                <Box color="bad">Database error</Box>
+              ) : discord_id === 'No ckey found' ? (
+                <Box color="bad">No ckey found</Box>
+              ) : (
+                <Button
+                  icon="discord"
+                  color="purple"
+                  compact
+                  disabled={!hasAnyKey}
+                  onClick={() => act('show_discord_id')}
+                >
+                  Get ID
+                </Button>
+              )}
             </LabeledList.Item>
           </LabeledList>
         </Collapsible>
@@ -1149,6 +1257,16 @@ const OtherActions = () => {
           onClick={() => act('apply_client_quirks')}
         >
           Apply Client Quirks
+        </Button>
+        <Button
+          width="100%"
+          p=".5rem"
+          mb=".5rem"
+          textAlign="center"
+          disabled={!mob_type.includes('/mob/living/silicon/robot')}
+          onClick={() => act('borg_panel')}
+        >
+          Borg Panel
         </Button>
       </Section>
     </Section>

--- a/tgui/packages/tgui/interfaces/PlayerPanel.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.tsx
@@ -672,6 +672,7 @@ const PhysicalActions = () => {
                   width="100%"
                   placeholder="Select faction to add"
                   options={glob_factions}
+                  selected={null}
                   onSelected={(value) => act('add_faction', { faction: value })}
                 />
               </Stack.Item>

--- a/tgui/packages/tgui/interfaces/PlayerPanel.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import {
   Box,
   Button,
@@ -435,12 +435,70 @@ const PhysicalActions = () => {
   const [delimbOption, setDelimbOption] = useState(0);
 
   // Update local speed state when server data changes
-  React.useEffect(() => {
+  useEffect(() => {
     setMobSpeed(mob_speed || 0);
   }, [mob_speed]);
 
   return (
     <Section fill>
+      <Section title="Traits">
+        <Flex>
+          <Button
+            width="100%"
+            height="100%"
+            icon="paw"
+            disabled={!mob_type.includes('/mob/living/carbon/human')}
+            onClick={() => act('species')}
+          >
+            Species
+          </Button>
+          <Button
+            width="100%"
+            height="100%"
+            icon="bolt"
+            disabled={!mob_type.includes('/mob/living/carbon/human')}
+            onClick={() => act('quirk')}
+          >
+            Quirks
+          </Button>
+          <Button
+            width="100%"
+            height="100%"
+            icon="magic"
+            onClick={() => act('spell')}
+          >
+            Spells
+          </Button>
+        </Flex>
+        <Flex mt={1}>
+          <Button
+            width="100%"
+            height="100%"
+            icon="fist-raised"
+            disabled={!mob_type.includes('/mob/living/carbon/human')}
+            onClick={() => act('martial_art')}
+          >
+            Martial Arts
+          </Button>
+          <Button
+            width="100%"
+            height="100%"
+            icon="lightbulb"
+            onClick={() => act('skill_panel')}
+          >
+            Skills
+          </Button>
+          <Button
+            width="100%"
+            height="100%"
+            icon="comment-dots"
+            onClick={() => act('languages')}
+          >
+            Languages
+          </Button>
+        </Flex>
+      </Section>
+
       <Section title="Status Flags">
         <Stack wrap>
           {Object.keys(glob_status_flags).map((flag) => {

--- a/tgui/packages/tgui/interfaces/PlayerPanel.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.tsx
@@ -298,7 +298,7 @@ const GeneralActions = () => {
   return (
     <Section>
       <Section title="Damage">
-        <Stack>
+        <Flex>
           <Button
             width="100%"
             icon="heart"
@@ -310,6 +310,7 @@ const GeneralActions = () => {
           </Button>
           <Button
             width="100%"
+            height="100%"
             icon="bolt"
             color="orange"
             disabled={!mob_type.includes('/mob/living/carbon/human')}
@@ -317,11 +318,11 @@ const GeneralActions = () => {
           >
             Smite
           </Button>
-        </Stack>
+        </Flex>
       </Section>
 
       <Section title="Teleportation">
-        <Stack>
+        <Flex>
           <Button.Confirm
             width="100%"
             icon="reply"
@@ -334,16 +335,36 @@ const GeneralActions = () => {
           </Button>
           <Button.Confirm
             width="100%"
+            height="100%"
             icon="share"
             onClick={() => act('jump_to')}
           >
             Jump To
           </Button.Confirm>
-        </Stack>
+        </Flex>
       </Section>
 
       <Section title="Miscellaneous">
-        <Stack>
+        <Flex>
+          <Button
+            width="100%"
+            icon="user-tie"
+            disabled={!mob_type.includes('/mob/living/carbon/human')}
+            onClick={() => act('select_equipment')}
+          >
+            Select Equipment
+          </Button>
+          <Button.Confirm
+            icon="trash-alt"
+            width="100%"
+            height="100%"
+            disabled={!mob_type.includes('/mob/living/carbon/human')}
+            onClick={() => act('strip')}
+          >
+            Drop All Items
+          </Button.Confirm>
+        </Flex>
+        <Flex>
           <Button.Confirm
             icon="snowflake"
             width="100%"
@@ -355,6 +376,7 @@ const GeneralActions = () => {
           </Button.Confirm>
           <Button.Confirm
             width="100%"
+            height="100%"
             color="orange"
             icon="undo"
             disabled={!mob_type.includes('/mob/dead/observer')}
@@ -367,8 +389,8 @@ const GeneralActions = () => {
           >
             Send To Lobby
           </Button.Confirm>
-        </Stack>
-        <Stack>
+        </Flex>
+        <Flex>
           <Button
             width="100%"
             icon="user-cog"
@@ -377,11 +399,11 @@ const GeneralActions = () => {
           >
             Load Preferences
           </Button>
-        </Stack>
+        </Flex>
       </Section>
 
       <Section title="Control">
-        <Stack>
+        <Flex>
           <Button.Confirm
             width="100%"
             icon="ghost"
@@ -404,6 +426,7 @@ const GeneralActions = () => {
           </Button.Confirm>
           <Button.Confirm
             width="100%"
+            height="100%"
             icon="ghost"
             tooltip="Offers control to ghosts"
             disabled={!mob_type.includes('/mob/living')}
@@ -411,7 +434,7 @@ const GeneralActions = () => {
           >
             Offer Control
           </Button.Confirm>
-        </Stack>
+        </Flex>
       </Section>
     </Section>
   );
@@ -671,27 +694,6 @@ const PhysicalActions = () => {
         </Stack>
       </Section>
 
-      <Section title="Equipment">
-        <Stack>
-          <Button
-            width="100%"
-            icon="user-tie"
-            disabled={!mob_type.includes('/mob/living/carbon/human')}
-            onClick={() => act('select_equipment')}
-          >
-            Select Equipment
-          </Button>
-          <Button.Confirm
-            icon="trash-alt"
-            width="100%"
-            disabled={!mob_type.includes('/mob/living/carbon/human')}
-            onClick={() => act('strip')}
-          >
-            Drop All Items
-          </Button.Confirm>
-        </Stack>
-      </Section>
-
       <Section title="Faction">
         <Stack vertical>
           <Stack.Item>
@@ -813,7 +815,7 @@ const PunishmentActions = () => {
 
   return (
     <Section>
-      <Stack>
+      <Flex>
         <Button
           width="50%"
           py=".5rem"
@@ -827,6 +829,7 @@ const PunishmentActions = () => {
         </Button>
         <Button
           width="50%"
+          height="100%"
           py=".5rem"
           icon="clipboard-list"
           color="orange"
@@ -835,9 +838,9 @@ const PunishmentActions = () => {
         >
           Logs
         </Button>
-      </Stack>
+      </Flex>
       <Section title="Contain">
-        <Stack>
+        <Flex>
           <Button
             width="100%"
             color={is_frozen ? 'orange' : ''}
@@ -858,6 +861,7 @@ const PunishmentActions = () => {
           </Button>
           <Button.Confirm
             width="100%"
+            height="100%"
             icon="share"
             color="bad"
             disabled={!mob_type.includes('/mob/living')}
@@ -865,11 +869,11 @@ const PunishmentActions = () => {
           >
             Admin Prison
           </Button.Confirm>
-        </Stack>
+        </Flex>
       </Section>
 
       <Section title="Banishment">
-        <Stack>
+        <Flex>
           <Button.Confirm
             width="100%"
             icon="ban"
@@ -890,6 +894,7 @@ const PunishmentActions = () => {
           </Button>
           <Button.Confirm
             width="100%"
+            height="100%"
             icon="gavel"
             color="red"
             disabled={!hasAnyKey}
@@ -897,7 +902,7 @@ const PunishmentActions = () => {
           >
             Sticky Ban
           </Button.Confirm>
-        </Stack>
+        </Flex>
       </Section>
 
       <Section
@@ -923,13 +928,14 @@ const PunishmentActions = () => {
           </>
         }
       >
-        <Stack>
+        <Flex>
           {glob_mute_bits.map((bit, i) => {
             const isMuted = client_muted && client_muted & bit.bitflag;
             return (
               <Button
                 key={i}
                 width="100%"
+                height="100%"
                 icon={isMuted ? 'check-square-o' : 'square-o'}
                 color={isMuted ? 'bad' : ''}
                 disabled={!client_ckey}
@@ -945,15 +951,15 @@ const PunishmentActions = () => {
               </Button>
             );
           })}
-        </Stack>
+        </Flex>
       </Section>
       <Section
         title="Investigate"
         buttons={
-          <Stack>
-            <Stack.Item align="center" mr=".5rem" color="label">
+          <Flex>
+            <Flex.Item align="center" mr=".5rem" color="label">
               Related accounts by:
-            </Stack.Item>
+            </Flex.Item>
             <Button
               minWidth="5rem"
               color="orange"
@@ -968,12 +974,13 @@ const PunishmentActions = () => {
               minWidth="5rem"
               color="orange"
               textAlign="center"
+              height="100%"
               disabled={!data_related_ip}
               onClick={() => act('related_accounts', { related_thing: 'IP' })}
             >
               IP
             </Button>
-          </Stack>
+          </Flex>
         }
       >
         <Collapsible width="100%" color="orange" title="Details">


### PR DESCRIPTION
## About The Pull Request
This PR improves the admin Player Panel interface and fixes several runtime errors that were occurring during gameplay.
Key improvements:
- Fixed multiple runtime errors related to sound volume, loadout assertions, and SQL

Admin Panel Changes:
- Notes, Ban, and Sticky Ban buttons now work for disconnected players
- Status Flags section: Toggle Stun, Knockdown, Unconscious, Push, and Godmode flags
- Speed Control: Slider to adjust character movement speed (-10 to +10 range)
- Mob Faction: View current factions, add predefined or custom factions, remove factions
- Discord: Display Discord ID in Punish > Investigate section (if verified)
- Borg Panel Access: Added "Borg Panel" button in Other section for cyborgs
- Load Preferences

Added Admin Ticket Statistics Panel
- The Admin Ticket Statistics Panel is a comprehensive administrative interface for analysing ticket handling performance across different time periods. The panel provides detailed metrics on ticket resolution, replies, rejections and other admin actions, and offers flexible filtering by date range, administrator and grouping by day or month. It features sortable columns, colour-coded performance indicators and exportable data to support administrative oversight and performance evaluation.

Runtime Fixes:
- Fixed sound volume runtime errors during audio playback
- Resolved loadout assertion failures during character initialization
- Fixed SQL qdel in database queries
- Eliminated "Cannot read null.tgui_shared_states" errors during UI operations
## Why It's Good For The Game
## Proof Of Testing
<details>
<summary>
Admin Panel
</summary>

![image](https://github.com/user-attachments/assets/9d731e60-d8fb-4aa6-8fe1-71a0467c0378)
![image](https://github.com/user-attachments/assets/c3ca13d9-2823-4471-9935-e091c84e2021)
![image](https://github.com/user-attachments/assets/ed78aeaf-40f4-4406-b4c6-30a0173520d8)


</details>
<details>
<summary>
Admin Ticket Statistics Panel
</summary>

![image](https://github.com/user-attachments/assets/96970a36-667a-4c42-b6f8-41337fe00e51)

</details>

## Changelog
:cl:
fix: Fixed multiple runtime
admin: Enhanced Player Panel with more stuff
admin: Added Admin Ticket Statistics panel for tracking admin ticket handling performance
/:cl:
