### PR TITLE
Renames Mrrp emotes

### DIFF
--- a/modular_zzplurt/code/modules/mob/living/emote.dm
+++ b/modular_zzplurt/code/modules/mob/living/emote.dm
@@ -1180,17 +1180,17 @@
 	cooldowns = 0.8 SECONDS
 	vary = FALSE
 
-/datum/emote/living/mrrp
-	key = "mrrp"
-	key_third_person = "mrrps"
+/datum/emote/living/cattrill
+	key = "cattrill"
+	key_third_person = "cattrills"
 	message = "trills like a cat!"
 	sound = 'modular_zzplurt/sound/voice/catpeople/cat_mrrp1.ogg'
 	cooldowns = 0.8 SECONDS
 	vary = FALSE
 
-/datum/emote/living/mrrp2
-	key = "mrrp2"
-	key_third_person = "mrrps"
+/datum/emote/living/cattrill
+	key = "cattrill2"
+	key_third_person = "cattrills"
 	message = "trills like a cat!"
 	sound = 'modular_zzplurt/sound/voice/catpeople/cat_mrrp2.ogg'
 	cooldowns = 0.8 SECONDS

--- a/modular_zzplurt/code/modules/mob/living/emote.dm
+++ b/modular_zzplurt/code/modules/mob/living/emote.dm
@@ -1188,7 +1188,7 @@
 	cooldowns = 0.8 SECONDS
 	vary = FALSE
 
-/datum/emote/living/cattrill
+/datum/emote/living/cattrill2
 	key = "cattrill2"
 	key_third_person = "cattrills"
 	message = "trills like a cat!"


### PR DESCRIPTION
## About The Pull Request

Converts both *mrrp and *mrrp2 to *cattrill and *cattrill2 as....both are not "mrrps" but cat thrills like the emote says after used and it overwriten a old *mrrp emote which was a bunny Mrrp

## Why It's Good For The Game

brings back a "old" emote and renamed the other Mrrps to what they actually are

## Proof Of Testing

Works on my machine

## Changelog

:cl:
code: Renamed both *mrrp and *mrrp2 to *cattrill and *cattrill2
/:cl:
