### PR TITLE
Adds storytellers without antags

### DIFF
--- a/code/__DEFINES/~~~splurt_defines/storyteller_defines.dm
+++ b/code/__DEFINES/~~~splurt_defines/storyteller_defines.dm
@@ -5,4 +5,7 @@
 //High Chaos
 #define TAG_HIGH "High Chaos"
 
+//OPFOR-only tags
+#define TAG_OPFOR_ONLY "OPFOR-only"
+
 #define STORYTELLER_TYPE_EXTENDED 3 // Extended storyteller - attempting to balance the amount of extended vs chaos

--- a/code/__DEFINES/~~~splurt_defines/storyteller_defines.dm
+++ b/code/__DEFINES/~~~splurt_defines/storyteller_defines.dm
@@ -8,4 +8,17 @@
 //OPFOR-only tags
 #define TAG_OPFOR_ONLY "OPFOR-only"
 
-#define STORYTELLER_TYPE_EXTENDED 3 // Extended storyteller - attempting to balance the amount of extended vs chaos
+
+// Storyteller types
+#undef STORYTELLER_TYPE_CALM
+#define STORYTELLER_TYPE_CALM (1<<0)
+
+#undef STORYTELLER_TYPE_INTENSE
+#define STORYTELLER_TYPE_INTENSE (1<<1)
+
+#define STORYTELLER_TYPE_EXTENDED (1<<2)
+
+#define STORYTELLER_TYPE_OPFOR_ONLY (1<<3)
+
+#define STORYTELLER_TYPE_ANTAGS (1<<4)
+

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -688,7 +688,7 @@ SUBSYSTEM_DEF(gamemode)
 	for(var/storyteller_type in storytellers)
 		var/datum/storyteller/storyboy = storytellers[storyteller_type]
 		/// Prevent repeating storytellers
-		if(storyboy.storyteller_type && storyboy.storyteller_type == SSpersistence.last_storyteller_type)
+		if(storyboy.storyteller_type && storyboy.storyteller_type & SSpersistence.last_storyteller_type) //SPLURT EDIT: Uses bitwise - original: storyboy.storyteller_type == SSpersistence.last_storyteller_type
 			continue
 		if(!storyboy.votable)
 			continue

--- a/modular_zzplurt/code/modules/storyteller/_events/_event.dm
+++ b/modular_zzplurt/code/modules/storyteller/_events/_event.dm
@@ -1,0 +1,4 @@
+/datum/round_event_control/New()
+	. = ..()
+	if(!(tags & TAG_OPFOR_ONLY) && (tags & TAG_CREW_ANTAG))
+		tags |= TAG_OPFOR_ONLY

--- a/modular_zzplurt/code/modules/storyteller/event_defines/crewset/_antagonist_event.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/crewset/_antagonist_event.dm
@@ -1,0 +1,4 @@
+/datum/round_event_control/antagonist/New()
+	. = ..()
+	if(!(tags & TAG_OPFOR_ONLY))
+		tags |= TAG_OPFOR_ONLY

--- a/modular_zzplurt/code/modules/storyteller/event_defines/ghostset/ghostset_overrides.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/ghostset/ghostset_overrides.dm
@@ -2,17 +2,17 @@
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_MEDIUM)
 
 /datum/round_event_control/space_dragon
-	tags = list(TAG_COMBAT, TAG_CHAOTIC, TAG_HIGH)
+	tags = list(TAG_COMBAT, TAG_CHAOTIC, TAG_HIGH, TAG_OPFOR_ONLY)
 	max_occurrences = 0
 
 /datum/round_event_control/space_ninja
-	tags = list(TAG_COMBAT, TAG_HIGH)
+	tags = list(TAG_COMBAT, TAG_HIGH, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/changeling
 	tags = list(TAG_COMBAT, TAG_CREW_ANTAG, TAG_LOW)
 
 /datum/round_event_control/alien_infestation
-	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CHAOTIC, TAG_HIGH)
+	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CHAOTIC, TAG_HIGH, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/spider_infestation
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_CHAOTIC, TAG_MEDIUM)

--- a/modular_zzplurt/code/modules/storyteller/event_defines/ghostset/lone_infiltrator.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/ghostset/lone_infiltrator.dm
@@ -1,2 +1,2 @@
 /datum/round_event_control/lone_infiltrator
-	tags = list(TAG_COMBAT, TAG_HIGH)
+	tags = list(TAG_COMBAT, TAG_HIGH, TAG_OPFOR_ONLY)

--- a/modular_zzplurt/code/modules/storyteller/event_defines/major/major_overrides.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/major/major_overrides.dm
@@ -5,7 +5,7 @@
 	tags = list(TAG_COMMUNAL, TAG_LOW)
 
 /datum/round_event_control/blob
-	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_CHAOTIC, TAG_HIGH)
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_CHAOTIC, TAG_HIGH, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/meteor_wave
 	tags = list(TAG_COMMUNAL, TAG_SPACE, TAG_DESTRUCTIVE, TAG_CHAOTIC, TAG_MEDIUM)
@@ -29,26 +29,26 @@
 	tags = list(TAG_DESTRUCTIVE, TAG_HIGH)
 
 /datum/round_event_control/revenant
-	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY, TAG_MEDIUM)
+	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY, TAG_MEDIUM, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/abductor
-	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CHAOTIC, TAG_LOW)
+	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CHAOTIC, TAG_LOW, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/fugitives
-	tags = list(TAG_COMBAT, TAG_LOW)
+	tags = list(TAG_COMBAT, TAG_LOW, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/cme
 	tags = list(TAG_DESTRUCTIVE, TAG_COMMUNAL, TAG_CHAOTIC, TAG_HIGH)
 
 /datum/round_event_control/stray_cargo/changeling_zombie
-	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC, TAG_SPOOKY, TAG_HIGH)
+	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC, TAG_SPOOKY, TAG_HIGH, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/pirates
-	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_MEDIUM)
+	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_MEDIUM, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/cortical_borer
-	tags = list(TAG_TARGETED, TAG_SPOOKY, TAG_LOW)
+	tags = list(TAG_TARGETED, TAG_SPOOKY, TAG_LOW, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/morph
-	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY, TAG_MEDIUM)
+	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY, TAG_MEDIUM, TAG_OPFOR_ONLY)
 

--- a/modular_zzplurt/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -44,7 +44,7 @@
 	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC, TAG_MEDIUM)
 
 /datum/round_event_control/obsessed
-	tags = list(TAG_TARGETED, TAG_LOW)
+	tags = list(TAG_TARGETED, TAG_LOW, TAG_OPFOR_ONLY)
 
 /datum/round_event_control/operative
-	tags = list(TAG_MEDIUM)
+	tags = list(TAG_MEDIUM, TAG_OPFOR_ONLY)

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
@@ -17,3 +17,20 @@
 	)
 	antag_divisor = 32
 	storyteller_type = STORYTELLER_TYPE_CALM
+
+/datum/storyteller/low/opfor
+	name = /datum/storyteller/low::name + " (OPFOR)"
+	desc = /datum/storyteller/low::desc + " (antags are OPFOR-only)"
+	welcome_text = /datum/storyteller/low::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round)")
+
+	guarantees_roundstart_crewset = FALSE
+
+	tag_multipliers = list(
+		TAG_COMBAT = 0.3,
+		TAG_DESTRUCTIVE = 0.3,
+		TAG_CHAOTIC = 0.1,
+		TAG_LOW = 1,
+		TAG_MEDIUM = 0,
+		TAG_HIGH = 0,
+		TAG_OPFOR_ONLY = 0
+	)

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
@@ -16,7 +16,7 @@
 		TAG_HIGH = 0
 	)
 	antag_divisor = 32
-	storyteller_type = STORYTELLER_TYPE_CALM
+	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_ANTAGS
 
 /datum/storyteller/low/opfor
 	name = /datum/storyteller/low::name + " (OPFOR)"
@@ -34,3 +34,4 @@
 		TAG_HIGH = 0,
 		TAG_OPFOR_ONLY = 0
 	)
+	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_OPFOR_ONLY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
@@ -11,3 +11,17 @@
 		TAG_HIGH = 0
 		)
 	storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE
+
+/datum/storyteller/medium/opfor
+	name = /datum/storyteller/medium::name + " (OPFOR)"
+	desc = /datum/storyteller/medium::desc + " (antags are OPFOR-only)"
+	welcome_text = /datum/storyteller/medium::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round)")
+
+	guarantees_roundstart_crewset = FALSE
+
+	tag_multipliers = list(
+		TAG_LOW = 1,
+		TAG_MEDIUM = 1,
+		TAG_HIGH = 0,
+		TAG_OPFOR_ONLY = 0
+	)

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
@@ -10,7 +10,7 @@
 		TAG_MEDIUM = 1,
 		TAG_HIGH = 0
 		)
-	storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE
+	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_ANTAGS
 
 /datum/storyteller/medium/opfor
 	name = /datum/storyteller/medium::name + " (OPFOR)"
@@ -25,3 +25,4 @@
 		TAG_HIGH = 0,
 		TAG_OPFOR_ONLY = 0
 	)
+	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_OPFOR_ONLY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
@@ -17,3 +17,20 @@
 
 	antag_divisor = 5
 	storyteller_type = STORYTELLER_TYPE_INTENSE
+
+/datum/storyteller/high/opfor
+	name = /datum/storyteller/high::name + " (OPFOR)"
+	desc = /datum/storyteller/high::desc + " (antags are OPFOR-only)"
+	welcome_text = /datum/storyteller/high::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round)")
+
+	guarantees_roundstart_crewset = FALSE
+
+	tag_multipliers = list(
+		TAG_COMBAT = 1.5,
+		TAG_DESTRUCTIVE = 0.7,
+		TAG_CHAOTIC = 1.3,
+		TAG_LOW = 1,
+		TAG_MEDIUM = 1,
+		TAG_HIGH = 1,
+		TAG_OPFOR_ONLY = 0
+	)

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
@@ -16,7 +16,7 @@
 	)
 
 	antag_divisor = 5
-	storyteller_type = STORYTELLER_TYPE_INTENSE
+	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_ANTAGS
 
 /datum/storyteller/high/opfor
 	name = /datum/storyteller/high::name + " (OPFOR)"
@@ -24,6 +24,8 @@
 	welcome_text = /datum/storyteller/high::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round)")
 
 	guarantees_roundstart_crewset = FALSE
+
+	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_OPFOR_ONLY
 
 	tag_multipliers = list(
 		TAG_COMBAT = 1.5,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10292,6 +10292,8 @@
 #include "modular_zzplurt\code\modules\storyteller\config.dm"
 #include "modular_zzplurt\code\modules\storyteller\gamemode.dm"
 #include "modular_zzplurt\code\modules\storyteller\storyteller_vote.dm"
+#include "modular_zzplurt\code\modules\storyteller\_events\_event.dm"
+#include "modular_zzplurt\code\modules\storyteller\event_defines\crewset\_antagonist_event.dm"
 #include "modular_zzplurt\code\modules\storyteller\event_defines\crewset\bloodsucker.dm"
 #include "modular_zzplurt\code\modules\storyteller\event_defines\crewset\changeling.dm"
 #include "modular_zzplurt\code\modules\storyteller\event_defines\crewset\heretic.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As per our storyteller-related poll from a month or so ago, the main issue with all storytellers were the antags themselves, therefore, I've divised a way to solve this issue by adding the option of choosing storytellers without antags.
These storytellers work the same as the normal storytellers, except they don't roll antags automatically. Instead, it's expected that players try and use the OPFOR verb to get antag, in such a way that eventmins can control it. 
These are NOT meant to replace storytellers with automatic antags, but rather be an option within the storyteller's pool to add more gameplay options to our server. And also give eventmins something to do
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
- Addresses the complaints about antags being the main issue within rounds as shown by our storytellers poll
- Adds more opportunities for controlled, organized chaos while also allowing for normal chaos to exist
- Adds options for storytellers so that they can be used in specific events
- Gives eventmins an actual job to do besides running event rounds every now and then
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing
We'll see once we try this on the live server.
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: adds OPFOR-only versions of storytellers, these work the same as normal storytellers, except antags are OPFOR-only. Feel free to apply to become an antag for the round!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
