### PR TITLE
[SPRITE FIX] Splurt taur bodies' genitals fix

### DIFF
--- a/modular_zzplurt/code/modules/sprite_accessories/taur.dm
+++ b/modular_zzplurt/code/modules/sprite_accessories/taur.dm
@@ -9,6 +9,7 @@ Taurus Bodies
 /datum/sprite_accessory/taur/splurt/chemlight
 	name = "Chemlight (Splurt)"
 	icon_state = "chemlight"
+	taur_mode = STYLE_TAUR_PAW
 
 // /datum/sprite_accessory/taur/splurt/altchemlight // Not enough sprites. Fix that, if you are a sprite artist.
 // 	name = "Alt Chemlight (Splurt)"
@@ -17,6 +18,7 @@ Taurus Bodies
 /datum/sprite_accessory/taur/splurt/chemnaga
 	name = "Chemnaga (Splurt)"
 	icon_state = "chemnaga"
+	taur_mode = STYLE_TAUR_SNAKE
 
 /datum/sprite_accessory/taur/splurt/leopardseal
 	name = "Leopard Seal (Splurt)"
@@ -25,6 +27,7 @@ Taurus Bodies
 /datum/sprite_accessory/taur/splurt/noodledragon
 	name = "Noodle Dragon (Splurt)"
 	icon_state = "noodledragon"
+	taur_mode = STYLE_TAUR_PAW
 
 /datum/sprite_accessory/taur/splurt/spider
 	name = "Spider (Splurt)"

--- a/modular_zzplurt/code/modules/sprite_accessories/taur.dm
+++ b/modular_zzplurt/code/modules/sprite_accessories/taur.dm
@@ -19,6 +19,7 @@ Taurus Bodies
 	name = "Chemnaga (Splurt)"
 	icon_state = "chemnaga"
 	taur_mode = STYLE_TAUR_SNAKE
+	organ_type = /obj/item/organ/taur_body/serpentine
 
 /datum/sprite_accessory/taur/splurt/leopardseal
 	name = "Leopard Seal (Splurt)"
@@ -32,6 +33,7 @@ Taurus Bodies
 /datum/sprite_accessory/taur/splurt/spider
 	name = "Spider (Splurt)"
 	icon_state = "spider"
+	organ_type = /obj/item/organ/taur_body/spider
 
 /datum/sprite_accessory/taur/splurt/sloog
 	name = "Sloog (Splurt)"

--- a/modular_zzplurt/code/modules/sprite_accessories/taur.dm
+++ b/modular_zzplurt/code/modules/sprite_accessories/taur.dm
@@ -9,7 +9,6 @@ Taurus Bodies
 /datum/sprite_accessory/taur/splurt/chemlight
 	name = "Chemlight (Splurt)"
 	icon_state = "chemlight"
-	taur_mode = STYLE_TAUR_PAW
 
 // /datum/sprite_accessory/taur/splurt/altchemlight // Not enough sprites. Fix that, if you are a sprite artist.
 // 	name = "Alt Chemlight (Splurt)"
@@ -18,7 +17,6 @@ Taurus Bodies
 /datum/sprite_accessory/taur/splurt/chemnaga
 	name = "Chemnaga (Splurt)"
 	icon_state = "chemnaga"
-	taur_mode = STYLE_TAUR_SNAKE
 
 /datum/sprite_accessory/taur/splurt/leopardseal
 	name = "Leopard Seal (Splurt)"
@@ -27,7 +25,6 @@ Taurus Bodies
 /datum/sprite_accessory/taur/splurt/noodledragon
 	name = "Noodle Dragon (Splurt)"
 	icon_state = "noodledragon"
-	taur_mode = STYLE_TAUR_PAW
 
 /datum/sprite_accessory/taur/splurt/spider
 	name = "Spider (Splurt)"


### PR DESCRIPTION
## About The Pull Request
This PR adds crucial `taur_mode` for a few SPLURT taur bodies.
- `/datum/sprite_accessory/taur/splurt/chemlight` and `/datum/sprite_accessory/taur/splurt/noodledragon` got `STYLE_TAUR_PAW` variables of `taur_mode`.
- `/datum/sprite_accessory/taur/splurt/spider` got `organ_type = /obj/item/organ/taur_body/spider` variable.
- `/datum/sprite_accessory/taur/splurt/chemnaga` changes:
    - Got `taur_mode = STYLE_TAUR_SNAKE` variable.
    - Got `organ_type = /obj/item/organ/taur_body/serpentine` variable.

"Why no bitflag for X/Y?":
- `Leopard Seal` is confusing me and have a very short height. I would assume, you need a personal bitflag for it with custom sprite height.
- `Spider (Splurt)` - I think for a drider and spider characters it's better to have it old way. Future sprite artists would paint for us sprites near spinneret.
- `Sloog (Splurt)` - as I tested, due to this body thickness you could not see any genital beneath their belly. I see this a bigger flaw compared to no penis depiction at all.

## Why It's Good For The Game
This would force those taur bodies to use skyrat genital sprites when `penis_taur_mode` is selected as YES in the character edit screen. 
Bounty coder did not test taur bodies properly - "belly dicks" were a result for SPLURT taurs. For a naga/snake body this would apply correct sprite texture when a MOD parts are worn and, also for splurt spider, make it a serpentine and spider taur organ instead of horselike.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![taurs](https://github.com/user-attachments/assets/93123e3a-5464-4869-b2a8-9dc67abc05de) <img width="141" height="140" alt="image" src="https://github.com/user-attachments/assets/a29296ac-ca9d-4ec8-a224-971c14e186f7" />

</details>

## Changelog
:cl:
fix: Penis Taur Mode is now working properly for "chemlight" and "noodle dragon" taur bodies.
fix: Chemnaga taur body should work properly with MODs and is now considered as serpentine organ.
/:cl:
