### PR TITLE
A fix for issue: 474

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_headphones.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/kinky_headphones.dm
@@ -58,7 +58,7 @@
 //we dropping item so we not deaf now. hurray.
 /obj/item/clothing/ears/kinky_headphones/dropped(mob/living/carbon/human/user)
 	. = ..()
-	if(!(src == user.ears || src == user.ears_extra))
+	if(!(src == user.ears || src == user.ears_extra)) // SPLURT EDIT - fixes the headphones on ears_extra
 		return
 	REMOVE_TRAIT(user, TRAIT_DEAF, CLOTHING_TRAIT)
 	to_chat(user, span_purple("You can finally hear the world around you once more."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A small one line fix that has the headphones check if its been removed from either slot instead of just the right ear. This could potentially be an issue with other EAR items that have the same check for if they are removed. But this one was the most likely to leave a player permanently impaired.

Issue mentioned in Title https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/issues/474

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Fixes an issue that could cause a player to easily think they have become permanently deaf. A
## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Video of the fix.
</summary>

https://github.com/user-attachments/assets/e38ea7d7-95b5-45df-9117-cc037aa3b7df

</details>


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed Kinky Headphones making a user permanently deaf.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
