### PR TITLE
The Shitcurity's Chariot cannot be stopped!

### DIFF
--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -96,9 +96,9 @@
 	name = "\improper APLU \"Paddy\""
 	icon_state = "paddy"
 	base_icon_state = "paddy"
-	movedelay = 5
-	slow_pressure_step_in = 5
-	fast_pressure_step_in = 3
+	// movedelay = 5   SPLURT EDIT: Commented.
+	// slow_pressure_step_in = 5  DRIVING IN MY PADDY AFTER A QUINTUPLSEC
+	// fast_pressure_step_in = 3  WHAT'S THAT BUMP?
 	max_temperature = 20000
 	max_integrity = 250
 	mech_type = EXOSUIT_MODULE_PADDY


### PR DESCRIPTION
## About The Pull Request

Reverts https://github.com/tgstation/tgstation/pull/91463 (brought from upstream of the upstream of the upstream)
## Why It's Good For The Game
/tg/nerfs bad. Mechs not being slower than a clown when hit by disablers good.

The slowdown would've been justified if the mech becames a bit more tankier and fully protects their pilot until its destruction like a combat mech, but no.. It just became the worst mech of the game no matter how you see it. The revert just returns the Paddy's old mobility back.
## Proof Of Testing
I just commented what MrMelbert added on /tg/station .

</details>

## Changelog
:cl:
balance: Paddy has same movement speed as Ripley MK-1 again.
/:cl:
