### PR TITLE
Minerborg, law two: Go fetch my kinetic weapons!

### DIFF
--- a/modular_zubbers/code/game/objects/items/robot/items/storage.dm
+++ b/modular_zubbers/code/game/objects/items/robot/items/storage.dm
@@ -232,6 +232,7 @@
 					/obj/item/borg/upgrade/modkit,						// ...their things with them or they dropped them while dead.
 					/obj/item/kinetic_crusher,							// Who's a good boy~?
 					/obj/item/skeleton_key,								// Yes! You are!
+					/obj/item/reagent_containers/hypospray/medipen/survival  // Also a SPLURT edit.
 					)
 
 /obj/item/robot_model/miner/Initialize(mapload)

--- a/modular_zubbers/code/game/objects/items/robot/items/storage.dm
+++ b/modular_zubbers/code/game/objects/items/robot/items/storage.dm
@@ -228,6 +228,10 @@
 					/obj/item/survivalcapsule/,
 					/obj/item/extraction_pack,
 					/obj/item/fulton_core,
+					/obj/item/gun/energy/recharge/kinetic_accelerator,  // SPLURT EDIT. In case if your fellow miners forgets carrying...
+					/obj/item/borg/upgrade/modkit,						// ...their things with them or they dropped them while dead.
+					/obj/item/kinetic_crusher,							// Who's a good boy~?
+					/obj/item/skeleton_key,								// Yes! You are!
 					)
 
 /obj/item/robot_model/miner/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Minerborgs can now carry kinetic weapons of their fellow miners( in case if they forget them during a critical event), modkits and skeleton keys... About if they could use them? No idea, they already have kinetic weapons in their modulesets anyway.

And most importantly! They can store survival medipens now!

## Why It's Good For The Game

Don't get me wrong, the minerborg's gripper looks useful because they can carry legion cores and.... bring strange rocks for example(lol, who even does that?), but since its implementation I feel like it lacks of more usefulness.

If you don't like the idea, tell me in comments what should a minerborg be carrying with their gripper instead? For example, I think they forgot their ability to carry survival medipens they had at oldbase... 🤔

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: Minerborg's gripper can now carry kinetic weapons, modkits, survival medipens and skeleton key.
/:cl:
