### PR TITLE
Flutter no longer effects your zero-gravity movement

### DIFF
--- a/modular_zzplurt/code/datums/quirks/positive_quirks/flutter.dm
+++ b/modular_zzplurt/code/datums/quirks/positive_quirks/flutter.dm
@@ -19,14 +19,16 @@
 	quirk_holder.AddElementTrait(TRAIT_FLUTTER_MOVE, TRAIT_FLUTTER, /datum/element/flutter_move, FLUTTER_FUNCTIONAL_FORCE, FLUTTER_MIN_PRESSURE)
 
 	// Add drifting trait
-	ADD_TRAIT(quirk_holder, TRAIT_NOGRAV_ALWAYS_DRIFT, TRAIT_FLUTTER)
+	//ADD_TRAIT(quirk_holder, TRAIT_NOGRAV_ALWAYS_DRIFT, TRAIT_FLUTTER)
 
 /datum/quirk/flutter/remove()
 	// Remove movement element
 	REMOVE_TRAIT(quirk_holder, TRAIT_FLUTTER_MOVE, TRAIT_FLUTTER)
 
 	// Remove drifting trait
-	REMOVE_TRAIT(quirk_holder, TRAIT_NOGRAV_ALWAYS_DRIFT, TRAIT_FLUTTER)
+	//REMOVE_TRAIT(quirk_holder, TRAIT_NOGRAV_ALWAYS_DRIFT, TRAIT_FLUTTER)
 
+	//Originally this trait was supposed to make it so you also don't wall-cling in atmosphere, so you fly forward while fluttering in a hallway.
+	//But this also made it so you can't hold walls in zero atmosphere either, making the trait near-useless
 #undef FLUTTER_FUNCTIONAL_FORCE
 #undef FLUTTER_MIN_PRESSURE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So, the Flutter quirk has a weird behavior where it allows you to move in zero-gravity with atmosphere BUT denies you from moving in zero gravity without atmosphere. You essentially can't hold onto walls like people without the quirk can.

In Issue #317 @evandarksky says it's intended behavior, but looking into the commit history makes me believe it isn't. The [commit that added it](https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/commit/ace84d9a569cb8f8530d7f51664932ed1435535e) looks like it just intended to force drifting inside atmospheres, since it makes no mention in the quirk description of not being able to wall-cling in space.

Either way, this should make the flutter quirk usable again rather than quite literally being worse than nothing. Does NOT make you able to move in space freely without a jetpack, you can still only move along walls like everyone else.

Has been tested, only effect of this change is making it so the quirk only works if you're not already touching a wall and allowing you to move in zero-G zero atmosphere like everyone else can.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The flutter quirk no longer prevents you from moving along walls in zero gravity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
