### PR TITLE
Removes robocop AI law module from harmless AI module spawners

### DIFF
--- a/modular_zzplurt/code/game/objects/effects/spawners/ai_spawner_removal.dm
+++ b/modular_zzplurt/code/game/objects/effects/spawners/ai_spawner_removal.dm
@@ -1,4 +1,4 @@
 /// Remove robocop from harmless AI module spawner
-/obj/effect/spawner/random/aimodule/harmless/Initialize(mapload)
-	. = ..()
+/obj/effect/spawner/random/aimodule/harmless/spawn_loot(lootcount_override)
 	loot -= /obj/item/ai_module/core/full/robocop
+	return ..()


### PR DESCRIPTION

## About The Pull Request
Removes robocop AI law module from harmless AI module spawners
## Why It's Good For The Game
## Proof Of Testing
<img width="321" height="580" alt="image" src="https://github.com/user-attachments/assets/e44ec4b8-87f1-4709-8a65-9f7144cf62ad" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Removed robocop law board from spawning in AI Upload
/:cl:
