### PR TITLE
Disable braintrauma and heartattack random event

### DIFF
--- a/modular_zzplurt/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
@@ -2,9 +2,13 @@
 	tags = list(TAG_COMMUNAL, TAG_POSITIVE, TAG_SPACE, TAG_LOW)
 
 /datum/round_event_control/brain_trauma
+	weight = 0
+	max_occurrences = 0
 	tags = list(TAG_TARGETED, TAG_LOW)
 
 /datum/round_event_control/heart_attack
+	weight = 0
+	max_occurrences = 0
 	tags = list(TAG_TARGETED, TAG_LOW)
 
 /datum/round_event_control/camera_failure


### PR DESCRIPTION
## About The Pull Request
Disables a couple of dogshit random events
## Why It's Good For The Game
These events only serve to ruin erp. They are not interesting at all to other players and happen to some specific unlucky bastard.
I've been gimped (not in the good way) several times mid-erp and, in the latest fiasco, I got the split-personality trauma which caused another player to take over my body and unwillingly participate in my erp while my controls were locked and all I could do is LOOC. It's extra work for admins to have to come in and cure it, and in times where there are no admins, I have to either respawn or take 10-20 mins away from the erp to get it resolved.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: Disabled random brain trauma and heart attack event
/:cl:
