### PR TITLE
Added a resizer module for borgs that lets the borg itself pick the size

### DIFF
--- a/modular_zzplurt/code/modules/cyborgs/resize_module.dm
+++ b/modular_zzplurt/code/modules/cyborgs/resize_module.dm
@@ -1,0 +1,143 @@
+/**
+ * Borg Resizer
+ * A borg module that will let the borg player themselves pick what specific size in percentage they want to be.
+ *
+ * Primarily utilises code from old Splurt Base alongside code from SPLURT-TG's expander borg module.
+ *
+ * This file is completely modular, disabling it will revert all changes made to the code base and re-enable the expander/shrinker for the crew.
+ * The expander and shrinker is available always to the borg panel utilized by admins
+ *
+ * File contains the following:
+ * * Defines for the Robot base to ensure that the resizer can't be installed if it already has been installed.
+ * * Code for the Resizer module that lets the borg player pick the percentage of a size they want to be at.
+ * * Design so the crew has access to this module at round start
+ * * Code that disables the printing of expand/shrink modules.
+ */
+
+/mob/living/silicon/robot
+	// If the borg has been resized already, utilized to prevent people from inserting yet another borg resizer module and possibly causing sprite size issues.
+	var/resized = FALSE
+
+/obj/item/borg/upgrade/resize
+	name = "borg resizer"
+	desc = "A cyborg resizer, it makes a cyborg grow/shrink to different sizes." //Could probably use a different description
+	icon_state = "module_general"
+	// Standard resize percentage, makes the borg the same size an expander would have made them unless specified otherwise
+	var/resize_amount = 160
+
+// Lets a roboticist pick the size for the borg itself if they know about the feature, will also let them make ai shells have a setting
+/obj/item/borg/upgrade/resize/attack_self(mob/user, modifiers)
+	if(src && !user.incapacitated && in_range(user,src))
+		resize_amount = resize_amount = tgui_input_number(user, "Choose the percentage size of Resizing (70-250)","Resizer size setting")
+		if(src && resize_amount && !user.incapacitated && in_range(user,src))
+			sanitize_integer(resize_amount, 70, 250, 160) //sanitize_integer won't work!
+			if(resize_amount >= 250 || !isnum(resize_amount) || resize_amount == null)
+				resize_amount = 250
+			if(resize_amount <= 70)
+				resize_amount = 70
+			to_chat(user, span_notice("Expand set to [resize_amount]%."))
+			return resize_amount
+
+/obj/item/borg/upgrade/resize/action(mob/living/silicon/robot/borg, mob/living/user = usr)
+	. = ..()
+	if(!. || HAS_TRAIT(borg, TRAIT_NO_TRANSFORM))
+		return FALSE
+
+	// All these conditions are to prevent this from being installed on borgs that either have been expanded/shrunk or have had a resizer already installed
+	if(borg.hasExpanded)
+		to_chat(usr, span_warning("This unit already has an expand module installed!"))
+		return FALSE
+
+	if(borg.hasShrunk)
+		to_chat(usr, span_warning("This unit already has a shrink module installed!"))
+		return FALSE
+
+	if(borg.resized)
+		to_chat(usr, span_warning("This unit already has an resizing module installed!"))
+		return FALSE
+
+	// SKYRAT EDIT ADDITION BEGIN
+	if(TRAIT_R_EXPANDER_BLOCKED in borg.model.model_features)
+		to_chat(usr, span_warning("This unit is unable to equip an resize module!"))
+		return FALSE
+	// SKYRAT EDIT ADDITION END
+
+	// Let's the borg player themselves pick what size they want to be in percentage.
+	resize_amount = tgui_input_number(borg, "Choose the percentage size of Resizing (70-250)","Resizer size setting")
+	// We do not trust the input given, no matter if it's ran through tgui first, so we are sanitizing it to prevent any possible malicious inputs
+	sanitize_integer(resize_amount, 70, 250, 160)
+
+	// 250 is the current limit of what we allow for. A Drakeborg at such a size would be almost 5 tiles long.
+	if(resize_amount >= 250 || !isnum(resize_amount) || resize_amount == null || resize_amount <= 0)
+		resize_amount = 250
+
+	// Agreed upon limit to prevent power gaming or people utilizing smaller borg sizes to make themselves harder to hit.
+	if(resize_amount <= 70)
+		resize_amount = 70
+	to_chat(borg, span_notice("Resize set to [resize_amount]%"))
+
+	ADD_TRAIT(borg, TRAIT_NO_TRANSFORM, REF(src))
+	var/prev_lockcharge = borg.lockcharge
+	borg.SetLockdown(TRUE)
+	borg.set_anchored(TRUE)
+	var/datum/effect_system/fluid_spread/smoke/smoke = new
+	smoke.set_up(1, holder = borg, location = borg.loc)
+	smoke.start()
+	sleep(0.2 SECONDS)
+	for(var/i in 1 to 4)
+		playsound(borg, pick(
+			'sound/items/tools/drill_use.ogg',
+			'sound/items/tools/jaws_cut.ogg',
+			'sound/items/tools/jaws_pry.ogg',
+			'sound/items/tools/welder.ogg',
+			'sound/items/tools/ratchet.ogg',
+			), 80, TRUE, -1)
+		sleep(1.2 SECONDS)
+	if(!prev_lockcharge)
+		borg.SetLockdown(FALSE)
+	borg.set_anchored(FALSE)
+	REMOVE_TRAIT(borg, TRAIT_NO_TRANSFORM, REF(src))
+	borg.resized = TRUE
+	borg.update_transform(resize_amount/100) // Divide by 100 to reach usable number so 160% / 100 will become 1.6 and 250% / 100 will be 2.5%
+
+/obj/item/borg/upgrade/resize/deactivate(mob/living/silicon/robot/borg, mob/living/user = usr)
+	. = ..()
+	if(!.)
+		return .
+	if (borg.resized)
+		borg.resized = FALSE
+
+/mob/living/silicon/robot/ResetModel()
+	if (resized)
+		// Resets the transformation, I do not FULLY understand how this works but this will make the robot ALWAYS return to original size, no matter the size inputted.
+		transform = null
+		resized = FALSE
+
+	. = ..()
+
+// Borg Resize Module Design
+/datum/design/borg_upgrade_resize
+	name = "Resize Module"
+	id = "borg_upgrade_resize"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/resize
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT*1,
+		/datum/material/titanium =SHEET_MATERIAL_AMOUNT * 2.5,
+	)
+	construction_time = 12 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
+	)
+
+/datum/techweb_node/augmentation/New()
+	. = ..()
+	// Removes the shrink and expander from the pool of designs the crew can print, used so there's only one option to use for resizing rather than commenting out those lines of code
+	design_ids -= list(
+		"borg_upgrade_expand",
+		"borg_upgrade_shrink"
+	)
+	// Adds the borg_upgrade_resize to the design pool.
+	design_ids += list(
+		"borg_upgrade_resize"
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10122,6 +10122,7 @@
 #include "modular_zzplurt\code\modules\customization\modules\mob\dead\new_player\sprite_accessories\underwear\underwear.dm"
 #include "modular_zzplurt\code\modules\customization\species\proteans\_proteans.species.dm"
 #include "modular_zzplurt\code\modules\cyborgs\dogborg_interactions.dm"
+#include "modular_zzplurt\code\modules\cyborgs\resize_module.dm"
 #include "modular_zzplurt\code\modules\cyborgs\robot.dm"
 #include "modular_zzplurt\code\modules\cyborgs\robot_model.dm"
 #include "modular_zzplurt\code\modules\discord\tgs_commands.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR ports the Borg Resizer from the old codebase and introduces the ability to let borgs themselves pick what percentage size they want their chassis to be at.

This PR also adds in the design to the tech tree so it's available on round start for any Mech Fabricators.
The downside however is that this disables the expander and shrinker from being printable by the crew.
On the other hand you get a more modular version so there's an upside to it instead.

Currently this file is completely modular, all changes are done within it so all you have to do is untick it for the expander and shrinker to be printable by the crew again

Since this is for the bounty
Closes #537 

For balancing purposes (at the request of `kamin_cullen`) The lower limit a borg can be is 70% with the max being 250%

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Makes the borgs able to be the size they want to be.
Lets players make their robotic characters more accurate.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>
Proof that they return back to normal after having a module reset.


https://github.com/user-attachments/assets/02999f96-9c73-4f8b-8ab1-49ecaac1186b

<img width="469" height="391" alt="image" src="https://github.com/user-attachments/assets/c52dfd78-0093-49be-be8a-36eb53f7571d" />
<img width="613" height="144" alt="image" src="https://github.com/user-attachments/assets/19a15086-8e43-47f8-b879-c85e0b20cd4b" />
<img width="284" height="166" alt="Screenshot 2025-09-04 202955" src="https://github.com/user-attachments/assets/c86cc152-d8a7-441b-af07-6f62ab90a3a6" />


The two limits 70% and 250%
<img width="410" height="258" alt="Screenshot 2025-09-04 203107" src="https://github.com/user-attachments/assets/c6744de8-24c8-4d24-8e52-70c118f1642f" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added the Borg Resizer, this new borg module will allow your robotic crew to be the size they truly want to be (Within reason)
balance: Balanced the lower size out so the limit is 70% rather than 50%
code: Allowed borg players to now pick their own character size for the borg once the Resize module is installed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
