### PR TITLE
Fixes Assistants can punch their own punch cards with their PDAs

### DIFF
--- a/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
+++ b/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
@@ -13,7 +13,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/max_punches = 6
 	var/punches = 0
-	req_access = list(ACCESS_COMMAND) // Splurt edit for now - Without this, assistants can punch the card that comes from the machine after they've turned in their roundstart card by using their own PDA.
+	req_access = list(ACCESS_COMMAND) // Without this, assistants can punch the card that comes from the machine after they've turned in their roundstart card by using their own PDA.
 	COOLDOWN_DECLARE(gbp_punch_cooldown)
 
 /obj/item/gbp_punchcard/starting

--- a/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
+++ b/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
@@ -13,7 +13,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/max_punches = 6
 	var/punches = 0
-	req_access = list(ACCESS_COMMAND) // Without this, assistants can punch the card that comes from the machine after they've turned in their roundstart card by using their own PDA.
+	req_access = list(ACCESS_COMMAND) // Splurt edit for now - Without this, assistants can punch the card that comes from the machine after they've turned in their roundstart card by using their own PDA.
 	COOLDOWN_DECLARE(gbp_punch_cooldown)
 
 /obj/item/gbp_punchcard/starting

--- a/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
+++ b/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
@@ -13,6 +13,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/max_punches = 6
 	var/punches = 0
+	req_access = list(ACCESS_COMMAND) // Splurt edit for now - Without this, assistants can punch the card that comes from the machine after they've turned in their roundstart card by using their own PDA.
 	COOLDOWN_DECLARE(gbp_punch_cooldown)
 
 /obj/item/gbp_punchcard/starting


### PR DESCRIPTION

## About The Pull Request
Long story short
Assistants could punch their punch cards by turning it in and then using their PDA on the newly created one.

This PR fixes that problem
Since I'm porting this upstream as well to maintain the modularity and ensuring upstream has this fix as well, I'm assigning the Test Merge Only label to this.

Fixes #534
## Why It's Good For The Game
Less issues happening is good, and this one seems to have been an oversight by the coder.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/efe6e7bf-a2ed-410d-a668-73f06401da42

</details>

## Changelog
:cl:
fix: Fixes an oversight made by a previous coder who created the punch card PDA system.
/:cl:
