### PR TITLE
Nerfs slime poison jelly

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -225,7 +225,7 @@
 	. = ..()
 	if(SPT_PROB(5, seconds_per_tick))
 		to_chat(affected_mob, span_danger("Your insides are burning!"))
-		if(affected_mob.adjustToxLoss(rand(20, 60), updating_health = FALSE, required_biotype = affected_biotype))
+		if(affected_mob.adjustToxLoss(rand(7, 15), updating_health = FALSE, required_biotype = affected_biotype))
 			return UPDATE_MOB_HEALTH
 	else if(SPT_PROB(23, seconds_per_tick))
 		if(affected_mob.heal_bodypart_damage(5))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces slime toxin (the edible jelly) to do 7-15 toxin damage, rather than 20-60.

This means if you accidentally or intentionally ingest this, it should give you time to call for help, survive, roleplay, talk, literally anything, rather than instantly dying within a few seconds of eating it. Seriously. 


## Why It's Good For The Game

You can roleplay about how it's disgusting, or how it hurts, or whatever, instead of dying instantly.

## Proof Of Testing

webedit changing a value

## Changelog


:cl:
balance: reduces the lethality of ingesting slime jelly (the slime food that's found in animals and food).
/:cl:

