### PR TITLE
[UPSTREAM] Fixes Multi-Cell Chargers working at range

### DIFF
--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -171,6 +171,8 @@
 		for(var/obj/item/stock_parts/power_store/cell/battery in charging_batteries)
 			buttons["[battery.name] ([round(battery.percent(), 1)]%)"] = battery
 		var/cell_name = tgui_input_list(user, "Please choose what cell you'd like to remove.", "Remove a cell", buttons)
+		if(!in_range(loc, user))
+			return FALSE
 		charging = buttons[cell_name]
 	else
 		charging = charging_batteries[1]


### PR DESCRIPTION
## About The Pull Request
Pulls from upstream a PR that fixes the issue regarding the multi cell recharger.

The issue being that one could interact with the UI and walk away before finally grabbing one of the cells, causing it to teleport to the hand from a distance of Unlimited.

Fixes #522 

I'm closing the old PR since it got rejected from upstream.
* https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/pull/561

This PR pulls
* https://github.com/Bubberstation/Bubberstation/pull/4608

From upstream!
## Why It's Good For The Game
Fixes good
Bugs Baaaad
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/29418453-798b-454e-a706-2940452d4564


</details>

## Changelog
:cl:SpaceCatSS13
fix: Multi-Cell chargers can't be withdrawn from range anymore.
/:cl:
