### PR TITLE
Adds the 'Clumsy Tail' quirk

### DIFF
--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
@@ -48,10 +48,10 @@
 		return
 
 	var/list/items_to_move = list()
-	for(var/obj/item/I in pos_to_check.contents)
-		if(I.anchored)
+	for(var/obj/item/possible_move in pos_to_check.contents)
+		if(possible_move.anchored)
 			continue
-		items_to_move += I
+		items_to_move += possible_move
 
 	// Nothing to move? No problem. Shouldn't bother.
 	if(!length(items_to_move))
@@ -60,8 +60,8 @@
 	for(var/i in 1 to TAILSWEEP_MAX_OBJECTS)
 		if(!items_to_move.len)
 			break
-		var/obj/o = pick_n_take(items_to_move)
-		o.throw_at(get_ranged_target_turf(o, pick(GLOB.cardinals-new_dir), range = 1), range = 1, speed = 1)
+		var/obj/sweeped = pick_n_take(items_to_move)
+		sweeped.throw_at(get_ranged_target_turf(sweeped, pick(GLOB.cardinals-new_dir), range = 1), range = 1, speed = 1)
 
 	playsound(pos_to_check, SFX_RUSTLE, 50, TRUE, -5)
 	affected_mob.visible_message(span_danger("[affected_mob] turns, sweeping their tail across \the [tabled]!"), span_notice("You turn, sweeping your tail across \the [tabled]."))

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
@@ -81,7 +81,7 @@
 		table_contents.throw_at(get_ranged_target_turf(table_contents, pick(GLOB.cardinals-new_dir), range = 1), range = 1, speed = 1)
 
 	playsound(pos_to_check, SFX_RUSTLE, 50, TRUE, -5)
-	affected_mob.visible_message(span_danger("turns, sweeping their tail across \the [tabled]!"), span_notice("You turn, sweeping your tail across \the [tabled]."))
+	affected_mob.visible_message(span_danger("[affected_mob] turns, sweeping their tail across \the [tabled]!"), span_notice("You turn, sweeping your tail across \the [tabled]."))
 
 	COOLDOWN_START(src, spam_cooldown, TAILSWEEP_DELAY SECONDS)
 

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
@@ -15,75 +15,56 @@
 	lose_text = span_notice("You feel less inclined to sweep things off tables with your tail.")
 	medical_record_text = "Patient has a habit of clumsily knocking things off tables with their tail when turning."
 	icon = FA_ICON_ARROWS_H
-	COOLDOWN_DECLARE(spam_cooldown)
+	COOLDOWN_DECLARE(swipe_cooldown)
 
 /datum/quirk/tail_sweep/add(client/client_source)
-	// Register dir changes
 	RegisterSignal(quirk_holder, COMSIG_ATOM_POST_DIR_CHANGE, PROC_REF(on_dir_change))
 
 /datum/quirk/tail_sweep/remove()
-	// Unregister dir changes
 	UnregisterSignal(quirk_holder, COMSIG_ATOM_POST_DIR_CHANGE)
 
 /datum/quirk/tail_sweep/proc/on_dir_change(mob/living/carbon/affected_mob, old_dir, new_dir)
 
 	SIGNAL_HANDLER
-	// Don't trigger if we're dead.
-	// Or if we're resting.
-	// Or if we're on cooldown.
-	// Or if we didn't actually change direction.
-	// Or if we fail the probability check.
-	// Or if there's a windoor.
-	// Or if we don't have a tail.
-	// Or if there's no table behind us.
-	//	* ^ Not in the exact order shown, but you get the idea
 	if(affected_mob.stat == DEAD)
 		return
 	if(old_dir == new_dir)
 		return
 	if(affected_mob.resting)
 		return
-	if(!prob(TAILSWEEP_CHANCE))
-		return
-	if(!COOLDOWN_FINISHED(src, spam_cooldown))
-		return
-
-	var/turf/pos_to_check = get_step(affected_mob, REVERSE_DIR(affected_mob.dir))
-
-	// You need a tail to knock stuff off of the tables..
 	var/obj/item/organ/tail/tail = affected_mob.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
 	if(isnull(tail))
 		return
-
-	// It was requested that this quirk sweeps items off of /tables/
+	if(!prob(TAILSWEEP_CHANCE))
+		return
+	if(!COOLDOWN_FINISHED(src, swipe_cooldown))
+		return
+	var/turf/pos_to_check = get_step(affected_mob, REVERSE_DIR(affected_mob.dir))
 	var/obj/structure/table/tabled = locate(/obj/structure/table, pos_to_check)
 	if(isnull(tabled))
 		return
-
-
 	// And one final check, to stop it from triggering through windoors and railings.
 	if(!affected_mob.Adjacent(pos_to_check))
 		return
 
 	var/list/items_to_move = list()
-
-	for(var/obj/item/gen_item in pos_to_check.contents)
-		if(!gen_item.anchored)
-			if(items_to_move.len >= TAILSWEEP_MAX_OBJECTS)
-				break
-			items_to_move += gen_item
+	for(var/obj/item/I in pos_to_check.contents)
+		if(I.anchored)
+			continue
+		items_to_move += o
 
 	// Nothing to move? No problem. Shouldn't bother.
 	if(!length(items_to_move))
-		return FALSE
+		return
 
-	for(var/obj/item/table_contents in items_to_move)
-		table_contents.throw_at(get_ranged_target_turf(table_contents, pick(GLOB.cardinals-new_dir), range = 1), range = 1, speed = 1)
+	for(var/i in 1 to TAILSWEEP_MAX_OBJECTS)
+		var/obj/o = pick_n_take(items_to_move)
+		o.throw_at(get_ranged_target_turf(o, pick(GLOB.cardinals-new_dir), range = 1), range = 1, speed = 1)
 
 	playsound(pos_to_check, SFX_RUSTLE, 50, TRUE, -5)
 	affected_mob.visible_message(span_danger("[affected_mob] turns, sweeping their tail across \the [tabled]!"), span_notice("You turn, sweeping your tail across \the [tabled]."))
 
-	COOLDOWN_START(src, spam_cooldown, TAILSWEEP_DELAY SECONDS)
+	COOLDOWN_START(src, swipe_cooldown, TAILSWEEP_DELAY SECONDS)
 
 #undef TAILSWEEP_MAX_OBJECTS
 #undef TAILSWEEP_DELAY

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
@@ -1,0 +1,83 @@
+/// Maximum amount of items that tail sweep can throw at once
+#define TAILSWEEP_MAX_OBJECTS 4
+
+/// The amount of seconds between being able to tail sweep again- in seconds
+#define TAILSWEEP_DELAY 10
+
+/// % chance out of 100 that a tail sweep will occur when turning
+#define TAILSWEEP_CHANCE 25
+
+/datum/quirk/tail_sweep
+	name = "Tail Sweep"
+	desc = "You have a habit of knocking things off tables with your tail."
+	value = 0
+	gain_text = span_notice("You feel an urge to sweep things off tables with your tail.")
+	lose_text = span_notice("You feel less inclined to sweep things off tables with your tail.")
+	medical_record_text = "Patient has a habit of clumsily knocking things off tables with their tail when turning."
+	icon = FA_ICON_ARROWS_H
+	COOLDOWN_DECLARE(spam_cooldown)
+
+/datum/quirk/tail_sweep/add(client/client_source)
+	// Register dir changes
+	RegisterSignal(quirk_holder, COMSIG_ATOM_POST_DIR_CHANGE, PROC_REF(on_dir_change))
+
+/datum/quirk/tail_sweep/remove()
+	// Unregister dir changes
+	UnregisterSignal(quirk_holder, COMSIG_ATOM_POST_DIR_CHANGE)
+
+/datum/quirk/tail_sweep/proc/on_dir_change(mob/living/carbon/affected_mob, old_dir, new_dir)
+
+	SIGNAL_HANDLER
+
+	// Don't trigger if we're dead.
+	// Or if we're resting.
+	// Or if we're on cooldown.
+	// Or if we didn't actually change direction.
+	// Or if we fail the probability check.
+	// Or if we don't have a tail.
+	if(isdead(affected_mob))
+		return FALSE
+	else if(affected_mob.resting)
+		return FALSE
+	else if(!COOLDOWN_FINISHED(src, spam_cooldown))
+		return FALSE
+	else if(old_dir == new_dir)
+		return FALSE
+	else if(!prob(TAILSWEEP_CHANCE))
+		return FALSE
+
+	// You need a tail to knock stuff off of the tables..
+	var/obj/item/organ/tail/tail = affected_mob.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
+	if(isnull(tail))
+		return FALSE
+
+	var/turf/pos_to_check = get_turf(get_step(affected_mob,turn(affected_mob.dir, 180)))
+
+	// It was requested that this quirk sweeps items off of /tables/
+	var/obj/structure/table/tabled = locate(/obj/structure/table, pos_to_check)
+	if(!tabled)
+		return FALSE
+
+	var/list/items_to_move = list()
+
+	for(var/obj/item/gen_item in pos_to_check.contents)
+		if(!gen_item.anchored)
+			if(items_to_move.len >= TAILSWEEP_MAX_OBJECTS)
+				break
+			items_to_move += gen_item
+
+	// Nothing to move? No problem. Shouldn't bother.
+	if(!length(items_to_move))
+		return FALSE
+
+	for(var/obj/item/table_contents in items_to_move)
+		table_contents.throw_at(get_ranged_target_turf(table_contents, pick(GLOB.cardinals-new_dir), range = 1), range = 1, speed = 1)
+
+	playsound(pos_to_check, SFX_RUSTLE, 50, TRUE, -5)
+	affected_mob.visible_message(span_danger("turns, sweeping their tail across \the [tabled]!"), span_notice("You turn, sweeping your tail across \the [tabled]."))
+
+	COOLDOWN_START(src, spam_cooldown, TAILSWEEP_DELAY SECONDS)
+
+#undef TAILSWEEP_MAX_OBJECTS
+#undef TAILSWEEP_DELAY
+#undef TAILSWEEP_CHANCE

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/tail_sweep.dm
@@ -51,13 +51,15 @@
 	for(var/obj/item/I in pos_to_check.contents)
 		if(I.anchored)
 			continue
-		items_to_move += o
+		items_to_move += I
 
 	// Nothing to move? No problem. Shouldn't bother.
 	if(!length(items_to_move))
 		return
 
 	for(var/i in 1 to TAILSWEEP_MAX_OBJECTS)
+		if(!items_to_move.len)
+			break
 		var/obj/o = pick_n_take(items_to_move)
 		o.throw_at(get_ranged_target_turf(o, pick(GLOB.cardinals-new_dir), range = 1), range = 1, speed = 1)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9935,6 +9935,7 @@
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\phobia.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\sodiumsensetivity.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\storage_concealment.dm"
+#include "modular_zzplurt\code\datums\quirks\neutral_quirks\tail_sweep.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\trashcan.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\undead.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\werewolf.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a new neutral quirk, 'Clumsy Tail'.

As the name implies, you're clumsy. Whenever you turn whilst walking, or standing still, the quirk checks for a table behind your character.
Should there be one, there is a 25% chance that your tail sweep 3 items off of the table, followed by a 10 second cooldown before it may trigger again.
This is involuntary, there is no ability button.

The chance, the max amount of items and the cooldown can be changed in the defines.
## Why It's Good For The Game

To quote the commisioner, Vanilla1040 :
> Adds a small funny thing for people who have tails.
## Proof Of Testing
Tested it every step of the way.
<details>
<summary>Screenshots/Videos</summary>
<br>

_Should there be any suggestion for a different icon, feel free to mention me in the comments._

<img width="476" height="80" alt="image" src="https://github.com/user-attachments/assets/de868e5f-e3d2-427f-991d-bd7b5dd90960" />


_The quirk triggers on turning._

https://github.com/user-attachments/assets/5c68d943-ad25-4bbc-bb79-862c0fac5d44

_The quirk does not trigger through railings, or windoors._

https://github.com/user-attachments/assets/e7574de6-610d-416a-8ebb-43de4e708f28

_It checks whether the dir has changed from the old one, due to the fact that ctrl + movement keys can be held down to trigger the comsig every tick._



</details>

## Changelog

:cl:
add: Added the 'Clumsy Tail' quirk
/:cl:
