### PR TITLE
Adjusts Restorative Metabolism

### DIFF
--- a/modular_zzplurt/code/datums/quirks/positive_quirks/restorative_metabolism.dm
+++ b/modular_zzplurt/code/datums/quirks/positive_quirks/restorative_metabolism.dm
@@ -1,5 +1,5 @@
 #define RESTMETA_BRUTE_THRESHOLD 40
-#define RESTMETA_BRUTE_AMOUNT -0.3
+#define RESTMETA_BRUTE_AMOUNT -0.4
 #define RESTMETA_BURN_THRESHOLD 40
 #define RESTMETA_BURN_AMOUNT -0.2
 #define RESTMETA_TOX_THRESHOLD 30
@@ -13,7 +13,7 @@
 	gain_text = span_notice("You feel a surge of reconstructive vitality coursing through your body...")
 	lose_text = span_notice("You sense your enhanced reconstructive ability fading away...")
 	medical_record_text = "Patient possesses a Semi self-reconstructive condition. Medical care is required way less frequently"
-	species_blacklist = list(SPECIES_SYNTH, SPECIES_PODPERSON_WEAK,)
+	species_blacklist = list(SPECIES_PODPERSON_WEAK,)
 	mob_trait = TRAIT_RESTORATIVE_METABOLISM
 	hardcore_value = -10
 	icon = FA_ICON_BRIEFCASE_MEDICAL


### PR DESCRIPTION
## About The Pull Request

This PR adjusts the healing from restorative metabolism brute healing to other healing like pod people healing and stable purple extract healing 0.12 > 0.4
Burn healing from 0.1 > 0.2
Toxic healing from 0.08 > 0.1
Toxic Threshold 20 > 30

This also lowers the cost for restorative from 10 > 8 points

## Why It's Good For The Game

Criticism about it being too low now so bumping it up to "the default" and lowering quirk points needed to offset the nerf

## Proof Of Testing

Works on my machine

## Changelog

:cl:
balance: Restorative metabolism heals 0.4 instead of 0.12 (Old 0.5) a bit more then a stable purple
balance: Restorative metabolism quirk cost 10 > 8
/:cl: