### PR TITLE
Werewolf/Mosley/DeathClaw nerf

### DIFF
--- a/modular_zzplurt/code/modules/mob/funclaw.dm
+++ b/modular_zzplurt/code/modules/mob/funclaw.dm
@@ -106,9 +106,9 @@
 	icon_state = "mommyclaw"
 	desc = "A machine that turns her victim's pelv<b>is</b> into pelv<b>was</b>."
 	name = "Mommy Funclaw"
-	maxHealth = 1200
-	health = 1200
+	maxHealth = 1000
+	health = 1000
 	obj_damage = 145
-	armour_penetration = 80
-	melee_damage_lower = 80
-	melee_damage_upper = 80
+	armour_penetration = 30
+	melee_damage_lower = 40
+	melee_damage_upper = 40

--- a/modular_zzplurt/code/modules/mob/werewolves.dm
+++ b/modular_zzplurt/code/modules/mob/werewolves.dm
@@ -19,8 +19,8 @@
 	health = 500
 	obj_damage = 60
 	armour_penetration = 30
-	melee_damage_lower = 56
-	melee_damage_upper = 56
+	melee_damage_lower = 30
+	melee_damage_upper = 30
 	faction = list("werewolves")
 	unsuitable_atmos_damage = 5
 	gold_core_spawnable = HOSTILE_SPAWN
@@ -56,12 +56,12 @@
 /mob/living/basic/werewolf/funwolf/alpha
 	desc = "I hope you enjoy being stuck on a knot for 5 hours."
 	name = "Alpha Werewolf"
-	maxHealth = 1200
-	health = 1200
+	maxHealth = 1400
+	health = 1400
 	obj_damage = 145
-	armour_penetration = 80
-	melee_damage_lower = 80
-	melee_damage_upper = 80
+	armour_penetration = 50
+	melee_damage_lower = 50
+	melee_damage_upper = 50
 
 /mob/living/basic/werewolf/funwolf/bitch
 	gender = FEMALE


### PR DESCRIPTION
## About The Pull Request
Nerf of the mentioned things
## Why It's Good For The Game
It resolves bounty #545 
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
Should work just fine, there's nothing new getting added.
</details>

## Changelog
:cl:
balance: reduced funclaw health
balance: reduced funclaw armor penetration and damage
balance: reduced werewolf damage from 56 to 30
balance: reduced werewolf alpha armour penetration from 80 to 50
balance: boosted werewolf alpha maxhealth from 1200 to 1400
/:cl:
