### PR TITLE
No loss of stamina at climax

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/climax.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/climax.dm
@@ -17,7 +17,7 @@
 	var/mob/living/carbon/human/affected_mob = owner
 
 	owner.reagents.add_reagent(/datum/reagent/drug/aphrodisiac/dopamine, 0.5)
-	// SPLURT EDIT - Removed stamina loss on climax by external stimulation.
+	// owner.adjustStaminaLoss(STAMINA_REMOVAL_AMOUNT_EXTERNAL) // SPLURT EDIT - Removed stamina loss on climax by external stimulation.
 	affected_mob.adjust_arousal(AROUSAL_REMOVAL_AMOUNT)
 	affected_mob.adjust_pleasure(AROUSAL_REMOVAL_AMOUNT * (affected_mob.dna.features["lust_tolerance"] || 1)) // SPLURT EDIT - Lust tolerance
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/climax.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/climax.dm
@@ -36,7 +36,7 @@
 	var/mob/living/carbon/human/affected_mob = owner
 
 	owner.reagents.add_reagent(/datum/reagent/drug/aphrodisiac/dopamine, 0.3)
-	// SPLURT EDIT - Removed stamina loss on climax by self stimulation.
+	// owner.adjustStaminaLoss(STAMINA_REMOVAL_AMOUNT_SELF) // SPLURT EDIT - Removed stamina loss on climax by self stimulation.
 	affected_mob.adjust_arousal(AROUSAL_REMOVAL_AMOUNT)
 	affected_mob.adjust_pleasure(AROUSAL_REMOVAL_AMOUNT)
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/climax.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/climax.dm
@@ -17,7 +17,7 @@
 	var/mob/living/carbon/human/affected_mob = owner
 
 	owner.reagents.add_reagent(/datum/reagent/drug/aphrodisiac/dopamine, 0.5)
-	owner.adjustStaminaLoss(STAMINA_REMOVAL_AMOUNT_EXTERNAL)
+	// SPLURT EDIT - Removed stamina loss on climax by external stimulation.
 	affected_mob.adjust_arousal(AROUSAL_REMOVAL_AMOUNT)
 	affected_mob.adjust_pleasure(AROUSAL_REMOVAL_AMOUNT * (affected_mob.dna.features["lust_tolerance"] || 1)) // SPLURT EDIT - Lust tolerance
 
@@ -36,7 +36,7 @@
 	var/mob/living/carbon/human/affected_mob = owner
 
 	owner.reagents.add_reagent(/datum/reagent/drug/aphrodisiac/dopamine, 0.3)
-	owner.adjustStaminaLoss(STAMINA_REMOVAL_AMOUNT_SELF)
+	// SPLURT EDIT - Removed stamina loss on climax by self stimulation.
 	affected_mob.adjust_arousal(AROUSAL_REMOVAL_AMOUNT)
 	affected_mob.adjust_pleasure(AROUSAL_REMOVAL_AMOUNT)
 


### PR DESCRIPTION
## About The Pull Request
Removes stamina loss when climax event occurs

## Why It's Good For The Game
It resolves #544. This means the community does want this change.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
Removes two lines in climax.dm, at the 20th line and at the 39th respectively, that cause the user to receive a stamina removal effect.

:cl:
del: Removed old things
/:cl:

