### PR TITLE
Fixes several horn types not being visible

### DIFF
--- a/modular_zzplurt/code/modules/sprite_accessories/horns.dm
+++ b/modular_zzplurt/code/modules/sprite_accessories/horns.dm
@@ -61,9 +61,7 @@ Horns
 	name = "Halo (Splurt)"
 	icon_state = "halo"
 
-/datum/sprite_accessory/horns/big
-	icon = 'modular_zzplurt/icons/mob/sprite_accessories/horns_large.dmi'
-
 /datum/sprite_accessory/horns/big/cryptid
 	name = "Cryptid Antlers"
 	icon_state = "cryptid"
+	icon = 'modular_zzplurt/icons/mob/sprite_accessories/horns_large.dmi'


### PR DESCRIPTION
## About The Pull Request
Turns out the cryptid horns used the same datum typepath (/datum/sprite_accessory/horns/big) as the other one and then used the .dmi for it, the old dmi was overwritten. Oops. Changed the cryptid horns to NOT override them. Yes it breaks inheritance but its better than not having it work and if I were to make a /datum/sprite_accessory/horns/big datum they wouldnt show up either so hey I guess this works.

## Why It's Good For The Game
Bug Fix Good
Fixes #509
## Proof Of Testing
I did test it and it works

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
Fix: the big horns are once more visible.
/:cl:

