### PR TITLE
Prevents cursekin from joining as prisoner

### DIFF
--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -37,7 +37,7 @@
 		return TRUE
 	else if(!(my_id in get_selectable_species()))
 		return TRUE
-	if(species_blacklist && species_blacklist[my_id])
+	if(LAZYLEN(species_blacklist) && (my_id in species_blacklist))
 		return TRUE
 	return FALSE
 

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -37,7 +37,7 @@
 		return TRUE
 	else if(!(my_id in get_selectable_species()))
 		return TRUE
-	if(LAZYLEN(species_blacklist) && (my_id in species_blacklist)) //SPLURT EDIT - this didnt work lmao
+	if(LAZYLEN(species_blacklist) && (my_id in species_blacklist)) //SPLURT EDIT - this didnt work lmao so i fixed it
 		return TRUE
 	return FALSE
 

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -37,7 +37,7 @@
 		return TRUE
 	else if(!(my_id in get_selectable_species()))
 		return TRUE
-	if(LAZYLEN(species_blacklist) && (my_id in species_blacklist))
+	if(LAZYLEN(species_blacklist) && (my_id in species_blacklist)) //SPLURT EDIT - this didnt work lmao
 		return TRUE
 	return FALSE
 

--- a/modular_zzplurt/code/modules/jobs/_job.dm
+++ b/modular_zzplurt/code/modules/jobs/_job.dm
@@ -1,0 +1,3 @@
+// Splurt Blacklist For Cursekin from prisoner
+/datum/job/prisoner
+	species_blacklist = list(SPECIES_CURSEKIN, SPECIES_LYCAN)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10198,6 +10198,7 @@
 #include "modular_zzplurt\code\modules\hilbertshotel\hotelroomcontroller.dm"
 #include "modular_zzplurt\code\modules\hud\_hud.dm"
 #include "modular_zzplurt\code\modules\hud\screen_objects.dm"
+#include "modular_zzplurt\code\modules\jobs\_job.dm"
 #include "modular_zzplurt\code\modules\jobs\job_types\cargo_technician.dm"
 #include "modular_zzplurt\code\modules\jobs\job_types\nanotrasen_consultant.dm"
 #include "modular_zzplurt\code\modules\jobs\job_types\quartermaster.dm"


### PR DESCRIPTION
## About The Pull Request
no prisoner cursekin

## Why It's Good For The Game
Cursekin are reasonablewhen they're crew and things anyone can pick up a welder and do the damage the cursekin melee do (15). But on prisoners? It makes them basically The Same But Better.

Prisoners do not have the luxury of having the damage of a lit welder at their disposal at basically any time and the other downsides (no guns, no batons, illiterate, chunky fingers, no clothes/backpack, a slowdown.) already don't really apply to them in a case like this whilst it's all detrimental stuff for autolathe-tier damage for regular crew.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
This sucked to do trust me it works
</details>

## Changelog

:cl:
balance: Prevents cursekin from joining as prisoners. 
/:cl:

