### PR TITLE
Gives cursekin the slowdown that comes with oversized

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/_cursekin_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_cursekin_species.dm
@@ -59,10 +59,19 @@
 /mob/living/carbon/human/species/cursekin
 	race = /datum/species/human/cursekin
 
+// SPLURT EDIT ADD - slowdown
+/datum/movespeed_modifier/cursekin_slowdown
+	multiplicative_slowdown = 0.5
+//SPLURT EDIT END - slowdown
+
+
 /datum/species/human/cursekin/on_species_gain(mob/living/carbon/human/gainer, datum/species/old_species, pref_load, regenerate_icons = TRUE)
 	. = ..()
 	gainer.AddElement(/datum/element/inorganic_rejection)
+	gainer.remove_movespeed_modifier(/datum/movespeed_modifier/cursekin_slowdown) // SPLURT EDIT ADD - slowdown
 
 /datum/species/human/cursekin/on_species_loss(mob/living/carbon/human/loser, datum/species/new_species, pref_load)
 	. = ..()
 	loser.RemoveElement(/datum/element/inorganic_rejection)
+	loser.add_movespeed_modifier(/datum/movespeed_modifier/cursekin_slowdown) //SPLURT EDIT ADD - slowdown
+


### PR DESCRIPTION

## About The Pull Request
The lack of a slowdown was apparantly intentional upstream but honestly I don't know man becoming oversized should come with the main drawback of oversized. Being slower.

## Why It's Good For The Game
Cursekin going fast at 2x size with welder-tier damage is silly. Slowdown makes them be in line with what they should be.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
Yeha I tested it
</details>

## Changelog

:cl:
balance: cursekin no longer zoom around speedy style when in big mode.
/:cl:

