### PR TITLE
Makes the civhud implant cost 1 quirk point instead of 4

### DIFF
--- a/modular_zzplurt/code/modules/customization/client/augment/implants.dm
+++ b/modular_zzplurt/code/modules/customization/client/augment/implants.dm
@@ -1,0 +1,3 @@
+//override to make it hella cheap
+/datum/augment_item/implant/eyes/civhud
+	cost = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10173,6 +10173,7 @@
 #include "modular_zzplurt\code\modules\clothing\wrists\watches.dm"
 #include "modular_zzplurt\code\modules\colormate\color_matrix.dm"
 #include "modular_zzplurt\code\modules\colormate\colormate.dm"
+#include "modular_zzplurt\code\modules\customization\client\augment\implants.dm"
 #include "modular_zzplurt\code\modules\customization\client\augment\organs.dm"
 #include "modular_zzplurt\code\modules\customization\client\augment\species_limbs.dm"
 #include "modular_zzplurt\code\modules\customization\modules\mob\dead\new_player\sprite_accessories\tails.dm"


### PR DESCRIPTION

## About The Pull Request
I wanted it to be 1 when I added it on bubber but they were like "4". All the implant does is show you the job icons if you have it toggled on. 
## Why It's Good For The Game
The server has people dress ???? whatever they want to really. You can have naked engineers. People should be able to easily see what job someone is. Making it hella expensive means people aren't inclined to use it that much. All it does is show the job icon. No wanted/permit status or anything like that. Not even mindshields. Just the job icon.
## Proof Of Testing
<img width="343" height="131" alt="afbeelding" src="https://github.com/user-attachments/assets/0e75059c-4dc4-4d1c-903f-9106f50aa49f" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Civhud implants now only cost 1 point instead of 4.
/:cl:
