### PR TITLE
Prevents robocop from rolling in unique AI station trait

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -321,7 +321,7 @@ LAW_WEIGHT asimov,0
 LAW_WEIGHT asimovpp,5
 LAW_WEIGHT paladin,5
 LAW_WEIGHT paladin5,5
-LAW_WEIGHT robocop,5
+LAW_WEIGHT robocop,0
 LAW_WEIGHT corporate,5
 LAW_WEIGHT hippocratic,5
 LAW_WEIGHT maintain,5


### PR DESCRIPTION

## About The Pull Request
Prevents robocop from rolling in unique AI station trait

Station trait uses LAW_WEIGHTs, they're determined in config. mosley will have to edit config for this one.
## Why It's Good For The Game
We removed robocop for a reason. It coming back when station trait rolls is kinda fuckin jank.
## Proof Of Testing
no
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
config: disabled robocop from rolling with the unique station AI trait.
/:cl:
