### PR TITLE
prevents station trait jobs from rolling antagonists

### DIFF
--- a/modular_zzplurt/code/modules/protected_roles/code/antag_restricted_jobs.dm
+++ b/modular_zzplurt/code/modules/protected_roles/code/antag_restricted_jobs.dm
@@ -1,0 +1,10 @@
+//restrict station trait jobs from antagonists
+
+/datum/job/veteran_advisor
+	antagonist_restricted = TRUE
+
+/datum/job/human_ai
+	antagonist_restricted = TRUE
+
+/datum/job/bridge_assistant
+	antagonist_restricted = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10349,6 +10349,7 @@
 #include "modular_zzplurt\code\modules\projectiles\guns\energy\kinetic_accelerator.dm"
 #include "modular_zzplurt\code\modules\projectiles\guns\energy\pka_skin_variations.dm"
 #include "modular_zzplurt\code\modules\projectiles\guns\energy\recharge.dm"
+#include "modular_zzplurt\code\modules\protected_roles\code\antag_restricted_jobs.dm"
 #include "modular_zzplurt\code\modules\quote_of_the_round\ticker.dm"
 #include "modular_zzplurt\code\modules\reagents\chemistry\machinery\chem_dispenser.dm"
 #include "modular_zzplurt\code\modules\reagents\chemistry\reagents\drug_reagents.dm"


### PR DESCRIPTION

## About The Pull Request
prevents station trait jobs from rolling antagonists

## Why It's Good For The Game
They have the flags to prevent them from rolling... but because skyrat did ??? things to the code and has their own system for blocking it, I had to do it like this.

## Proof Of Testing
Yeah I tested it

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: Veteran Sec Advisor, Big Brother, and Bridge Assistant can no longer roll antag. This was an oversight.
/:cl:

