### PR TITLE
ore silos are fire and acidproof (modular)

### DIFF
--- a/modular_zzplurt/code/modules/mining/machine_silo.dm
+++ b/modular_zzplurt/code/modules/mining/machine_silo.dm
@@ -1,0 +1,5 @@
+// Makes Ore Silos fire- and acid-proof, and increases their durability. //
+/obj/machinery/ore_silo
+	desc = "An all-in-one bluespace storage and transmission system for the station's mineral distribution needs. It appears to be extremely robust."
+	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	max_integrity = 500


### PR DESCRIPTION
## About The Pull Request

Simply adds the fire and acid proof resistance flags to the Ore Silo machine, and ups the integrity from 200 to 500.
## Why It's Good For The Game

The ore silo can't be destroyed via 'lazy' or environmental methods such as fire or acid, it's also a bit tougher to basic attacks now.

## Proof Of Testing

It compiles

:cl:
balance: Ore Silo is tougher now
/:cl:

