### PR TITLE
Prevent items dropped by borgs from becoming invisible

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -21,6 +21,7 @@
 	SIGNAL_HANDLER
 
 	if(stored)
+		modify_appearance(stored, FALSE) // SPLURT EDIT - CYBORGS - Reverting to original appearance
 		stored.forceMove(get_turf(src))
 		stored = null
 
@@ -249,6 +250,7 @@
 	var/obj/item/organ = stored
 	user.visible_message(span_notice("[user] dumps [organ] from [src]."), span_notice("You dump [organ] from [src]."))
 	cut_overlays()
+	modify_appearance(stored, FALSE) // SPLURT EDIT - CYBORGS - Reverting to original appearance
 	organ.forceMove(get_turf(src))
 	return CLICK_ACTION_SUCCESS
 

--- a/modular_zzplurt/code/game/objects/items/devices/cyborg_modules/general_modules.dm
+++ b/modular_zzplurt/code/game/objects/items/devices/cyborg_modules/general_modules.dm
@@ -7,6 +7,7 @@
 
 /obj/item/borg/apparatus/dropped(mob/user, silent)
 	if(stored)
+		modify_appearance(stored, FALSE)
 		stored.forceMove(user.drop_location())
 	else
 		. = ..()


### PR DESCRIPTION

## About The Pull Request
calls `modify_appearance(stored, FALSE)` in a few places it was neglected when borgs drop items
resolves issue [#573](https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/issues/573)
## Why It's Good For The Game
Many objects dropped from borg modules were made invisible due to failure to restore their `mutable_appearance` when dropped.
 This most notably included brains when dropped from a medical borg's organ storage bag.
 This caused a player's brain to be lost in round 9019, effectively round removing them.
## Proof Of Testing
Tested on local server
## Changelog
:cl:
fix: Items dropped by borg modules are no longer invisible
/:cl:
