### PR TITLE
Armored Harness Nudist Fix

### DIFF
--- a/modular_zzplurt/code/modules/clothing/suits/armor.dm
+++ b/modular_zzplurt/code/modules/clothing/suits/armor.dm
@@ -103,6 +103,7 @@
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits.dmi'
 	worn_icon_state = "suit_harness"
 	inhand_icon_state = "armor"
+	body_parts_covered = NONE
 
 /obj/item/clothing/suit/hooded/explorer/explorerharness
 	name = "explorer suit harness"


### PR DESCRIPTION
## About The Pull Request
Fixes the Armoured harness to not cover any body parts as it was intended to in [PR #237](https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/pull/237)

This was reported by Orvel on Discord but the issue was closed automatically by the bot, likely due to formatting
[Closed Issue #625](https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/issues/625)
## Why It's Good For The Game
Per original PR:
"Crucial for exhibitionists. Plus it was something you could do on the old SPLURT that people liked."
## Proof Of Testing
Tested on local server
(unlike original PR: "Trust me bro")

## Changelog
:cl:
fix: Armored Harness no longer covers body parts; It is now suitable for Nudists as was originally intended
/:cl:
