### PR TITLE
[FIX] Restore Library Admin Console controls and tools

### DIFF
--- a/tgui/packages/tgui/interfaces/LibraryAdmin/BookListing.tsx
+++ b/tgui/packages/tgui/interfaces/LibraryAdmin/BookListing.tsx
@@ -3,7 +3,7 @@ import { Box, NoticeBox, Stack } from 'tgui-core/components';
 import { useBackend } from '../../backend';
 import { Window } from '../../layouts';
 import { PageSelect } from '../LibraryConsole/components/PageSelect';
-import { SearchAndDisplay } from './Search';
+import { SearchAndDisplay } from './Search'; // SPLURT EDIT: FIX ADMIN CONSOLE
 import type { LibraryAdminData } from './types';
 
 export function BookListing(props) {


### PR DESCRIPTION

## About The Pull Request
This fixes the Admin Library Console missing its expected controls (filters, Raw/All toggle, Delete/Restore actions).
Switch import to ./Search, restoring the correct admin UI.
## Why It's Good For The Game
## Proof Of Testing
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/7c2e2416-ecf5-4ff8-900f-8dc04db9c6f8" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
admin: Restored missing controls in the Library Admin Console (filters, Raw/All toggle, Delete/Restore).
/:cl:
