### PR TITLE
Clown Oral Honk Fix

### DIFF
--- a/modular_zzplurt/code/modules/lewd/interaction_menu/interaction_datum.dm
+++ b/modular_zzplurt/code/modules/lewd/interaction_menu/interaction_datum.dm
@@ -38,7 +38,7 @@
 			"<b>%OWNER%</b>'s honkers produce a loud squeak!",
 			"\The <b>%OWNER%</b>'s breasts honk[pick(" loudly", "")]!"
 		),
-		ORGAN_SLOT_MOUTH = list(
+		"mouth" = list(
 			"<b>%OWNER%</b>'s mouth honks[pick(" loudly", "")]!",
 			"<b>%OWNER%</b>'s throat squeaks[pick(" loudly", "")]!"
 		)
@@ -247,6 +247,22 @@
 				message = replacetext(message, "%OWNER%", target)
 				target.visible_message(span_lewd(message))
 				playsound(target, 'sound/items/bikehorn.ogg', 40, TRUE, -1)
+
+	// Handle mouths for clowns
+	for(var/requirement in interaction_requires)
+		switch(requirement)
+			if(INTERACTION_REQUIRE_SELF_MOUTH)
+				if(is_user_clown)
+					var/message = pick(clown_genital_messages["mouth"])
+					message = replacetext(message, "%OWNER%", user)
+					user.visible_message(span_lewd(message))
+					playsound(user, 'sound/items/bikehorn.ogg', 40, TRUE, -1)
+			if(INTERACTION_REQUIRE_TARGET_MOUTH)
+				if(is_target_clown)
+					var/message = pick(clown_genital_messages["mouth"])
+					message = replacetext(message, "%OWNER%", target)
+					target.visible_message(span_lewd(message))
+					playsound(target, 'sound/items/bikehorn.ogg', 40, TRUE, -1)
 
 // Called when either the user or target is cumming from the interaction, makes the interaction text
 /datum/interaction/proc/show_climax(mob/living/cumming, mob/living/came_in, position)


### PR DESCRIPTION

## About The Pull Request
Interactions involving a clown's mouth now use the intended clown related messages and produce the intended honk sound, in line with other clown genitals.

This bug was caused by the attempted usage of `ORGAN_SLOT_MOUTH` instead of `INTERACTION_REQUIRE_SELF_MOUTH` and `INTERACTION_REQUIRE_TARGET_MOUTH`
## Why It's Good For The Game
HONK!
Fixes a minor bug
## Proof Of Testing
Tested on local server
<details>
<summary>Screenshots/Videos</summary>
<img width="397" height="51" alt="image" src="https://github.com/user-attachments/assets/7ea66723-9724-4ab5-8a35-634d91061eaa" />

</details>

## Changelog
:cl:
fix: Clown oral now sends the correct clown related message and Honk sound
/:cl:
