### PR TITLE
CLIMAX_PENIS post_climax fix

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/climax.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/climax.dm
@@ -300,6 +300,8 @@
 			apply_status_effect(/datum/status_effect/climax_cooldown)
 			if(self_orgasm)
 				add_mood_event("orgasm", /datum/mood_event/climaxself)
+			if(climax_interaction && !manual)
+				climax_interaction.post_climax(src, partner, interaction_position)
 			return TRUE
 
 	if(climax_choice == CLIMAX_VAGINA || climax_choice == CLIMAX_BOTH)


### PR DESCRIPTION

## About The Pull Request
`climax` proc returned early and failed to check if `post_climax` proc should be called when `climax_choice == CLIMAX_PENIS`

No interactions currently make use of `post_climax`,
but it is an excellent place to hook `knot_try` for the Scarlet Reach knotting port
## Why It's Good For The Game
Fixes a code oversight
Changes will not be visible in-game until interactions that use `post_climax` are added
## Proof Of Testing
Tested on local server
Used a modified interaction to `log_game` with the involved users when `post_climax` is called
<details>
<summary>Screenshots/Videos</summary>
<img width="425" height="31" alt="image" src="https://github.com/user-attachments/assets/f2809b22-8af5-41ec-b249-e9ac700bd6ed" />

</details>

## Changelog
:cl:
code: `climax` proc no longer fails to call `post_climax` when `climax_choice == CLIMAX_PENIS`
/:cl:
