### PR TITLE
Un-Whitelists Certain Bubber Donor Items

### DIFF
--- a/modular_zubbers/code/modules/loadout/categories/gloves.dm
+++ b/modular_zubbers/code/modules/loadout/categories/gloves.dm
@@ -7,7 +7,7 @@
 /datum/loadout_item/gloves/lace_gloves
 	name = "Lace Gloves"
 	item_path = /obj/item/clothing/gloves/evening/lace
-	//donator_only = TRUE
+	//donator_only = TRUE //Splurt Edit
 
 /datum/loadout_item/gloves/rubber_gloves
 	name = "Long Rubber Gloves"

--- a/modular_zubbers/code/modules/loadout/categories/heads.dm
+++ b/modular_zubbers/code/modules/loadout/categories/heads.dm
@@ -155,7 +155,7 @@
 /datum/loadout_item/head/lace_bow
 	name = "Hair Bow"
 	item_path = /obj/item/clothing/head/costume/hairbow
-	//donator_only = TRUE
+	//donator_only = TRUE //Splurt Edit
 
 /datum/loadout_item/head/tactical_maid_headband //Donor item for skyefree
 	name = "Tactical Maid Headband"

--- a/modular_zubbers/code/modules/loadout/categories/neck.dm
+++ b/modular_zubbers/code/modules/loadout/categories/neck.dm
@@ -3,7 +3,7 @@
 /datum/loadout_item/neck/heart_choker
 	name = "Heart Collar"
 	item_path = /obj/item/clothing/neck/lace_collar
-	//donator_only = TRUE
+	//donator_only = TRUE //Splurt Edit
 
 /datum/loadout_item/neck/ringbell
 	name = "Ringing Bell Collar"

--- a/modular_zubbers/code/modules/loadout/categories/suit.dm
+++ b/modular_zubbers/code/modules/loadout/categories/suit.dm
@@ -125,12 +125,12 @@
 /datum/loadout_item/suit/runner_engi
 	name = "Engineer Runner Jacket"
 	item_path = /obj/item/clothing/suit/jacket/runner/engi
-	//donator_only = TRUE //Dono item for Kan3
+	//donator_only = TRUE //Dono item for Kan3 //Splurt Edit
 
 /datum/loadout_item/suit/runner_syndi
 	name = "Syndicate Runner Jacket"
 	item_path = /obj/item/clothing/suit/jacket/runner/syndicate
-	//donator_only = TRUE //Dono item for Kan3
+	//donator_only = TRUE //Dono item for Kan3 //Splurt Edit
 
 /datum/loadout_item/suit/collared_vest
 	name = "GLP-C 'Úlfur' Vest"

--- a/modular_zubbers/code/modules/loadout/categories/~donator/donator_personal.dm
+++ b/modular_zubbers/code/modules/loadout/categories/~donator/donator_personal.dm
@@ -22,7 +22,7 @@
 /datum/loadout_item/head/idmahelmet
 	name = "IDMA Service Helmet"
 	item_path = /obj/item/clothing/head/helmet/sec/sol/idma_helmet
-	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic")
+	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic") //Splurt Edit
 	restricted_roles = list(JOB_BLUESHIELD, JOB_CAPTAIN, JOB_NT_REP, JOB_HEAD_OF_SECURITY, JOB_RESEARCH_DIRECTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CHIEF_ENGINEER, JOB_HEAD_OF_PERSONNEL, JOB_QUARTERMASTER, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_SECURITY_MEDIC, JOB_DETECTIVE)
 
 /datum/loadout_item/head/unberet
@@ -37,7 +37,7 @@
 /datum/loadout_item/glasses/silk_blindfold
 	name = "Silk Blindfold"
 	item_path = /obj/item/clothing/glasses/trickblindfold/lace
-	//ckeywhitelist = list("thedragmeme")
+	//ckeywhitelist = list("thedragmeme") //Splurt Edit
 
 /*
 *	UNDER
@@ -46,7 +46,7 @@
 /datum/loadout_item/under/formal/lace_dress
 	name = "Lilac Dress"
 	item_path = /obj/item/clothing/under/rank/lace
-	//ckeywhitelist = list("thedragmeme")
+	//ckeywhitelist = list("thedragmeme") //Splurt Edit
 
 /datum/loadout_item/uniform/miscellaneous/diver
 	name = "Black Divers Uniform"
@@ -56,13 +56,13 @@
 /datum/loadout_item/uniform/miscellaneous/idmasnowfatigue
 	name = "IDMA Service Uniform"
 	item_path = /obj/item/clothing/under/rank/security/idma_fatigue
-	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic")
+	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic") //Splurt Edit
 	restricted_roles = list(JOB_BLUESHIELD, JOB_CAPTAIN, JOB_NT_REP, JOB_HEAD_OF_SECURITY, JOB_RESEARCH_DIRECTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CHIEF_ENGINEER, JOB_HEAD_OF_PERSONNEL, JOB_QUARTERMASTER, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_SECURITY_MEDIC, JOB_DETECTIVE)
 
 /datum/loadout_item/uniform/miscellaneous/idmafatigue
 	name = "IDMA Desert Service Uniform"
 	item_path = /obj/item/clothing/under/rank/security/idma_fatigue/alt
-	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic")
+	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic") //Splurt Edit
 	restricted_roles = list(JOB_BLUESHIELD, JOB_CAPTAIN, JOB_NT_REP, JOB_HEAD_OF_SECURITY, JOB_RESEARCH_DIRECTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CHIEF_ENGINEER, JOB_HEAD_OF_PERSONNEL, JOB_QUARTERMASTER, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_SECURITY_MEDIC, JOB_DETECTIVE)
 
 /datum/loadout_item/uniform/miscellaneous/idmautility
@@ -76,18 +76,18 @@
 /datum/loadout_item/suit/idmavest
 	name = "IDMA Combat Vest"
 	item_path = /obj/item/clothing/suit/armor/vest/idma_vest
-	//ckeywhitelist = list ("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic")
+	//ckeywhitelist = list ("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic") //Splurt Edit
 	restricted_roles = list(JOB_BLUESHIELD, JOB_CAPTAIN, JOB_NT_REP, JOB_HEAD_OF_SECURITY, JOB_RESEARCH_DIRECTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CHIEF_ENGINEER, JOB_HEAD_OF_PERSONNEL, JOB_QUARTERMASTER, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_SECURITY_MEDIC, JOB_DETECTIVE)
 
 /datum/loadout_item/suit/idmarsuit
 	name = "IDMA Service Jacket"
 	item_path = /obj/item/clothing/suit/jacket/idma_jacket
-	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic")
+	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic") //Splurt Edit
 
 /datum/loadout_item/suit/idmaarmouredjacket
 	name = "IDMA Service Jacket"
 	item_path = /obj/item/clothing/suit/armor/vest/idma_vest/idma_jacket
-	//ckeywhitelist = list ("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic")
+	//ckeywhitelist = list ("EspeciallyStrange", "Wolf751", "Waterpig", "1Ceres", "Raxraus", "Tecktonic") //Splurt Edit
 	restricted_roles = list(JOB_BLUESHIELD, JOB_CAPTAIN, JOB_NT_REP, JOB_HEAD_OF_SECURITY, JOB_RESEARCH_DIRECTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CHIEF_ENGINEER, JOB_HEAD_OF_PERSONNEL, JOB_QUARTERMASTER, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_SECURITY_MEDIC, JOB_DETECTIVE)
 
 /datum/loadout_item/suit/idmardjacket
@@ -98,12 +98,12 @@
 /datum/loadout_item/suit/runner_winter
 	name = "Winter Runner Jacket"
 	item_path = /obj/item/clothing/suit/jacket/runner/winter
-	//ckeywhitelist = list("kan3")
+	//ckeywhitelist = list("kan3") //Splurt Edit
 
 /datum/loadout_item/suit/shawl
 	name = "Silk Shawl"
 	item_path = /obj/item/clothing/suit/cloak/shawl
-	//ckeywhitelist = list("thedragmeme")
+	//ckeywhitelist = list("thedragmeme") //Splurt Edit
 
 /datum/loadout_item/suit/diver //Donor item for patriot210
 	name = "Black Divers Coat"
@@ -118,7 +118,7 @@
 /datum/loadout_item/suit/flight //Donor item for ironknight060
 	name = "MA-1 flight jacket"
 	item_path = /obj/item/clothing/suit/jacket/flight
-	//ckeywhitelist = list("ironknight060")
+	//ckeywhitelist = list("ironknight060") //Splurt Edit
 
 /*
 *	SHOES
@@ -127,7 +127,7 @@
 /datum/loadout_item/shoes/lace_heels
 	name = "Elegant Heels"
 	item_path = /obj/item/clothing/shoes/heels/drag/lace
-	//ckeywhitelist = list("thedragmeme")
+	//ckeywhitelist = list("thedragmeme") //Splurt Edit
 
 /datum/loadout_item/shoes/diver //Donor item for patriot210
 	name = "Black Divers Boots"
@@ -141,7 +141,7 @@
 /datum/loadout_item/accessory/idmaarmbands
 	name = "IDMA Armband"
 	item_path = /obj/item/clothing/accessory/armband/idmaarmband
-	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "Mishanok", "Raxraus")
+	//ckeywhitelist = list("EspeciallyStrange", "Wolf751", "Waterpig", "Mishanok", "Raxraus") //Splurt Edit
 
 /*
 *	TOYS


### PR DESCRIPTION

## About The Pull Request

This PR frees some bubberstation donor items from the pit that is bloat. Allows them to be used in the loadout.

## Why It's Good For The Game

A majority of these have been/are stuck as bloat sprites and are completely unused. The original users who have a ckey whitelist cannot wear them either, due to the donator status overriding ckey whitelists.

## Changelog

:cl:
qol: unwhitelists specific donor items from bubber
/:cl: