### PR TITLE
Make Extended non-voteable but keep it as fallback

### DIFF
--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
@@ -1,4 +1,4 @@
 /datum/storyteller/extended
 	population_max = null
-	votable = TRUE
+	votable = FALSE
 	storyteller_type = STORYTELLER_TYPE_EXTENDED


### PR DESCRIPTION
## About The Pull Request

A simple non-destructive Variable Change to remove the extended Storyteller from voteable options.

## Why It's Good For The Game

Extended (No Chaos) has the nickname Sextended for a reason. Because arranging an ERP is literally the only thing you can do in that Storyteller.
Having it pop up regularly leads to players getting turned off at the door, which then only perpetuates the likelihood of more extended shifts in a row.
Keeping it on as a default/fallback but removing it from votes will ensure that it does still come up when population is too low to justify any chaos, but disables players from simply dictating this very polarizing storyteller.

# 1. It's designed as a low-pop Fallback

In the original bubber code that this storyteller stems from it literally says:
"Extended is the absence of a Storyteller. It will not spawn a single event of any sort, or run any Antagonists. Best for rounds where the population is so low that not even peaceful storytellers are low enough."
Confirming that it was never intended to be used as a regular voteable storyteller, but rather as an option when basically even just running the station with extremely low pop becomes a challenge in itself.

# 2. Promoting Options instead of forcing a majority into no-chaos

Let's assume our playerbase is split 50/50 between extended enjoyers who just wanna ERP undisturbed, and the others who like chaos and spice on the station regardless of ERP.
When joining a round, the average extended enjoyer has the option to either spawn as a variety of ghost roles, ghost cafe, or just move to infinidorms at any point even during regular station gameplay. Enabling them to have that quiet undisturbed scene they want *regardless of storyteller*.
On the other hand the average chaos enjoyer would be completely at the mercy of the fact that it is gonna be no chaos for the next X hours. They don't exactly get a fallback or ghost role to go to if they wanna have some normal space station gameplay.
We should promote better usage of infinidorms and ghost roles, as they enable a public scene environment just like the main station does, which players who prefer extended shouldn't find lacking in any way.

# 3. Less Apathy and idling

I have seen many extended shifts with fully staffed departments, which will set up their initial things and then slowly dwindle into either being SSD, having sex, or straight up cryo.
Because once again Extended is simply not designed for anything but low to no-pop.
Engineering will have nothing to do apart from setting up the SM.
Security will have nothing to do apart from clobbering the occasional rowdy NRPer at the bar.
Medical will have nothing to do other than saving Intern Miners, Tram Accidents and filtering out Alcohol Overdoses.
The only departments hauling ass on these shifts would be service, tending an overflowing bar, the chef filling the kitchen counter with more mass-produced food that you can visually process, and the Janitor maybe cleaning up public cum puddles if they haven't given up yet.
While Cargo maybe ships some personal goodie orders.
This kind of cripples the game dynamic of ss13, and leads to a lot of players simply getting bored, and lots of departments being pointless to play.

# 4. Less pent-up sec/antag mains during other storytellers

Inversely to the previous point - if many shifts make it pointless to play something like Security due to lack of antags - then the shifts that DO promise some chaos will have all the sec players just frothing at the mouth to jump the first antag they see.
Which then in turn also gives antagonists a harder time, especially those that are new to antagging. Because there's barely any middle ground between an antag versus a fully staffed sec department who absolutely cannot wait for their chance to catch someone on High-Chaos, or simply no antags and no sec.
The bottom line here is that this sort of extreme polarization to play sec or be antag on High Chaos would only work to worsen the gap between Extended-enjoyers and Chaos-enjoyers.

# In summary
I think making Extended unvoteable would drastically improve our server quality.
I'm aware that it's a remnant of previous SPLURT Culture where Extended was the norm. But we simply aren't that anymore. We took a lot of the niché that Bubber used to cater to, which is 'Furry TG with ERP' and I love how much more open our ERP Culture is.
But I think we should lean into that niché instead of alienating it with old culture and turning off players who would like some gameplay.

## Proof Of Testing

Works locally.
Extended Storyteller triggers as extended if there are no Votes or pop is extremely low.

<details>
<summary>Screenshots/Videos</summary>
<img width="331" height="208" alt="extended snip" src="https://github.com/user-attachments/assets/7614f279-fd99-4213-b49f-973e7f40b3fd" />

</details>

## Changelog

:cl:
config: Changed Extended Storyteller to be unvoteable
/:cl:

