### PR TITLE
Limits the minimum character size to 0.5

### DIFF
--- a/code/__DEFINES/~~~splurt_defines/DNA.dm
+++ b/code/__DEFINES/~~~splurt_defines/DNA.dm
@@ -12,7 +12,7 @@
 #ifdef BODY_SIZE_MIN_OVERRIDE
 	#define BODY_SIZE_MIN BODY_SIZE_MIN_OVERRIDE
 #else
-	#define BODY_SIZE_MIN 0.1
+	#define BODY_SIZE_MIN 0.5
 #endif
 
 //genitals


### PR DESCRIPTION

## About The Pull Request
You can't make chars below 50% size anymore.

## Why It's Good For The Game
Headmin ruling said "no more characters below 50% no matter what", might as well have it be set in stone in the character creator.

## Proof Of Testing

i tested it
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: The minimum character size is now 0.5, instead of the prior 0.1.
/:cl:

