### PR TITLE
Fixes gene inheritance

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -288,7 +288,7 @@
 		else
 			seed = new planted_seed.type(null)
 
-		seed.genes = planted_seed.genes.Copy()
+		seed.genes = planted_seed.genes.Copy() // SPLURT EDIT - fixes botany genes
 
 		//we're ASHIE GAMING, we do not concern ourselves with such puny concepts as purity
 		seed.endurance = 100


### PR DESCRIPTION
## About The Pull Request
Ashwalker plants now respect the genes of the planted seed. 
Untested, but should probably work.

## Why It's Good For The Game
Less bug better.

## Changelog

:cl:
fix: ashwalker planting now correctly respects genes of the parent
/:cl:
