### PR TITLE
Small Seedvault Fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
+++ b/_maps/RandomRuins/LavaRuins/zzplurt/lavaland_surface_seed_vault_splurt.dmm
@@ -2318,12 +2318,6 @@
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/catwalk_floor/wood_smooth,
 /area/ruin/powered/seedvault)
-"QG" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "atmos_end_big_lad"
-	},
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "QS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -2901,7 +2895,7 @@ in
 Hx
 rb
 Sa
-QG
+HR
 Sa
 Sa
 Sa


### PR DESCRIPTION
## About The Pull Request

minor edits to the new seedvault changes:
fixes airlock helpers, fixes unconnected tray, removes duplicate water tanks, re-adds botanical clothing vendor, and adds a less dim light to one of the rooms so pods dont starve


## Why It's Good For The Game

QOL fixes

## Changelog

:cl:
fix: seedvault airlocks
fix: fixes unconnected tray in seedvault
qol: botanical clothing vendor in seedvault
qol: atmos shield gens in seedvault
/:cl: