### PR TITLE
Adds a stomping mechanics prefence

### DIFF
--- a/modular_zzplurt/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_zzplurt/code/modules/client/preferences/erp_preferences.dm
@@ -157,3 +157,6 @@
 
 /datum/preference/toggle/erp/cumflation
 	savefile_key = "cumflation_pref"
+
+/datum/preference/toggle/erp/stomping
+	savefile_key = "stomp_on_pref"

--- a/modular_zzplurt/code/modules/resize/resizing.dm
+++ b/modular_zzplurt/code/modules/resize/resizing.dm
@@ -41,6 +41,11 @@
 //Stepping on disarm intent -- TO DO, OPTIMIZE ALL OF THIS SHIT
 /mob/living/proc/handle_micro_bump_other(mob/living/target)
 	ASSERT(isliving(target))
+
+// If the target is not in combat mode, if the target has the preference off, stop the interaction.
+	if(target.combat_mode != INTENT_HARM && target.client.prefs?.read_preference(/datum/preference/toggle/erp/stomping) == FALSE)
+		return FALSE
+
 	if(ishuman(src))
 		var/mob/living/carbon/human/user = src
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/splurt/erp_preferences.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/splurt/erp_preferences.tsx
@@ -53,3 +53,10 @@ export const cumflation_pref: FeatureToggle = {
   description: 'Allow your genitals to get cumflated.',
   component: CheckboxInput,
 };
+
+export const stomp_on_pref: FeatureToggle = {
+  name: 'Stomping People',
+  category: 'ERP',
+  description: 'Your character stomps partners.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

Makes the ERP Mechanic of stomping into a preference in game prefence

## Why It's Good For The Game

This PR aims it so people don't accidently use the ERP Stomping mechanic in combat anymore.

## Proof Of Testing

Tried to stomp myself in localhost on push/grab/harm intent, didn't work as intented, can't fully test it as localhost is broken so im winging it.

## Changelog

:cl:
add: Stomping Mechanic Preference
/:cl:
