### PR TITLE
Fix issue 660 - loadout item bitflag conflict

### DIFF
--- a/code/__DEFINES/~~~splurt_defines/preferences.dm
+++ b/code/__DEFINES/~~~splurt_defines/preferences.dm
@@ -1,4 +1,4 @@
 /// Loadout simple item color (changes color var directly)
 #define INFO_COLOR "color"
 
-#define LOADOUT_FLAG_ALLOW_SIMPLE_COLOR (1<<2)
+#define LOADOUT_FLAG_ALLOW_SIMPLE_COLOR (1<<5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes [Issue #660](https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/issues/660)
changes the bit for the LOADOUT_FLAG_ALLOW_SIMPLE_COLOR flag from 2 to 5 to avoid conflict with LOADOUT_FLAG_GREYSCALING_ALLOWED flag

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Fixes a bug that caused almost every loadout item to be recolorable when most should have been only simple recolorable

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

Tested on local server

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed loadout item recoloring
code: changed loadout item flag LOADOUT_FLAG_ALLOW_SIMPLE_COLOR from bit 2 to bit 5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
