### PR TITLE
Gives the cirular medal an actual description

### DIFF
--- a/modular_zubbers/code/modules/clothing/accessory/accessory.dm
+++ b/modular_zubbers/code/modules/clothing/accessory/accessory.dm
@@ -165,7 +165,7 @@ Potential future ideas:
 
 /obj/item/clothing/accessory/bubber/acc_medal
 	name = "circle medal"
-	desc = "You shouldn't have this, make a bug report!"
+	desc = "A circular medal, perfect for pinning onto your uniform or suit. Alt-Click to reskin!" //SPLURT EDIT - why the fuck did they have the "you shouldnt have this" text on it man
 	icon = 'icons/map_icons/clothing/accessory.dmi'
 	icon_state = "/obj/item/clothing/accessory/bubber/acc_medal"
 	post_init_icon_state = "medal_alt"


### PR DESCRIPTION

## About The Pull Request
title

## Why It's Good For The Game
gets rid of debug text on a loadout item

## Proof Of Testing
1 line change

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: makes it so the circular medal no longer has debug text
/:cl:

