### PR TITLE
Ashwalker slaves have ashtongue again

### DIFF
--- a/modular_zzplurt/code/modules/mob_spawn/ghost_roles/ash_walkers_slave.dm
+++ b/modular_zzplurt/code/modules/mob_spawn/ghost_roles/ash_walkers_slave.dm
@@ -30,7 +30,7 @@
 		new_spawn.put_in_hands(new /obj/item/stock_parts/power_store/cell/infinite/abductor(new_spawn))
 
 	new_spawn.grant_language(/datum/language/draconic, source = LANGUAGE_SPAWNER)
-	//new_spawn.grant_language(/datum/language/ashtongue, source = LANGUAGE_SPAWNER) // bubber got rid of ashtongue but will probably be reverted
+	new_spawn.grant_language(/datum/language/ashtongue, source = LANGUAGE_SPAWNER)
 	new_spawn.remove_language(/datum/language/common)
 
 	new_spawn.mind.add_antag_datum(/datum/antagonist/ashwalker, team)


### PR DESCRIPTION
See name, this was meant to be a temporary comment out that lasted a bit too long

## Proof Of Testing

It's one line, and it builds.

## Changelog
:cl:
fix: Ashie slaves can speak ashtongue again
/:cl:
