### PR TITLE
Stomp pref

### DIFF
--- a/modular_zzplurt/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_zzplurt/code/modules/client/preferences/erp_preferences.dm
@@ -157,3 +157,7 @@
 
 /datum/preference/toggle/erp/cumflation
 	savefile_key = "cumflation_pref"
+
+/datum/preference/toggle/erp/stomping
+
+	savefile_key = "stomp_on_pref"

--- a/modular_zzplurt/code/modules/resize/resizing.dm
+++ b/modular_zzplurt/code/modules/resize/resizing.dm
@@ -41,6 +41,11 @@
 //Stepping on disarm intent -- TO DO, OPTIMIZE ALL OF THIS SHIT
 /mob/living/proc/handle_micro_bump_other(mob/living/target)
 	ASSERT(isliving(target))
+
+	// if the target has the preference off, stop the interaction.
+	if(target.client.prefs?.read_preference(/datum/preference/toggle/erp/stomping) == FALSE)
+		return FALSE
+
 	if(ishuman(src))
 		var/mob/living/carbon/human/user = src
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/splurt/erp_preferences.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/splurt/erp_preferences.tsx
@@ -1,4 +1,4 @@
-import { CheckboxInput, FeatureToggle } from '../../base';
+import { CheckboxInput, type FeatureToggle } from '../../base';
 
 export const butt_enlargement_pref: FeatureToggle = {
   name: 'Butt enlargement',
@@ -51,5 +51,12 @@ export const cumflation_pref: FeatureToggle = {
   name: 'Cumflation',
   category: 'ERP',
   description: 'Allow your genitals to get cumflated.',
+  component: CheckboxInput,
+};
+
+export const stomp_on_pref: FeatureToggle = {
+  name: 'Stomping',
+  category: 'ERP',
+  description: 'Allows your character to get stomped.',
   component: CheckboxInput,
 };


### PR DESCRIPTION

## About The Pull Request
stomping pref, can't be stomped if you have it set to no

## Why It's Good For The Game
Stomping issssss... annoying if you dont want it to happen. 1.0 size? nah get stomped by a macro. 

## Proof Of Testing
Tested it locally with 2 accounts and it worked.

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
add: Stomping preference, preventing you from being stomped on unless it's enabled.
/:cl:

