### PR TITLE
fixes the tough quirk Not Doing Anything

### DIFF
--- a/modular_zzplurt/code/datums/quirks/positive_quirks/tough.dm
+++ b/modular_zzplurt/code/datums/quirks/positive_quirks/tough.dm
@@ -11,11 +11,11 @@
 
 /datum/quirk/tough/add(client/client_source)
 	quirk_holder.maxHealth *= 1.1
+	quirk_holder.health = quirk_holder.maxHealth
 
 /datum/quirk/tough/remove()
 	if(!quirk_holder)
 		return
 	quirk_holder.maxHealth *= 0.909 //close enough
-
-
+	quirk_holder.health = quirk_holder.maxHealth
 


### PR DESCRIPTION
## About The Pull Request
Tough increased your maxhp by 10%... without actually setting your health to the new number. Because you didn't have any damage, you could never legitimately get TO the new maxhealth. OOPS!!! It did NOTHING. Your maxhealth would still (effectively) be 120.

## Why It's Good For The Game
Fixes a broken quirk.

## Proof Of Testing
<img width="188" height="25" alt="afbeelding" src="https://github.com/user-attachments/assets/9ad7ea6c-e8f8-4bbf-b7bc-2a7452c4f26b" />

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: Tough actually works now.
/:cl:

