### PR TITLE
Return of Xenohybrid Weeds Structures

### DIFF
--- a/modular_zzplurt/code/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/human/species/xeno.dm
@@ -1,0 +1,6 @@
+/datum/species/xeno
+	mutant_organs = list(
+		/obj/item/organ/alien/plasmavessel/roundstart,
+		/obj/item/organ/alien/resinspinner,
+		/obj/item/organ/alien/hivenode,
+		)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10373,6 +10373,7 @@
 #include "modular_zzplurt\code\modules\mob\living\carbon\human\life.dm"
 #include "modular_zzplurt\code\modules\mob\living\carbon\human\physiology.dm"
 #include "modular_zzplurt\code\modules\mob\living\carbon\human\species.dm"
+#include "modular_zzplurt\code\modules\mob\living\carbon\human\species\xeno.dm"
 #include "modular_zzplurt\code\modules\mob\living\carbon\human\species_types\abductors.dm"
 #include "modular_zzplurt\code\modules\mob\living\carbon\human\species_types\android.dm"
 #include "modular_zzplurt\code\modules\mob\living\carbon\human\species_types\arachnid.dm"


### PR DESCRIPTION
## About The Pull Request

This pull request returns xenohybrids the ability to create xenomorph structures, those being:
• Glowing Resin (the node that spreads xenomorph weeds);
• Resin Walls;
• Resin Membranes (glorified windows);
• Resin Nests (glorified beds).

The creation of those structures isn't instantaneous, can be interrupted, and cannot be spammed - each structure requires 55 units of plasma to be created, with the maximum amount of plasma that can be stored being equal to exactly 55. The plasma self-replenishes over time, with the rate of replenishment significantly increasing while standing on the xenomorph weeds. The xenomorph weeds DO NOT heal xenohybrids.

## Why It's Good For The Game

This brings xenohybrids more roleplaying capabilities, as they can now create a "nest" of sorts in maintenance tunnels or a corner in their department - kind of like arachna taurs can do with their web spinners.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="858" height="617" alt="image" src="https://github.com/user-attachments/assets/924b7d78-8a9d-424e-96b4-cce02550e8b2" />


</details>

## Changelog

:cl:
add: Xenohybrids have rediscovered their xenomorph roots, and now can, once more, create resin structures.
/:cl:
