### PR TITLE
Removes the Centrobe from being a maint spawn

### DIFF
--- a/code/game/objects/effects/spawners/random/engineering.dm
+++ b/code/game/objects/effects/spawners/random/engineering.dm
@@ -120,8 +120,8 @@
 	icon_state = "vending_restock"
 	loot = list(
 		/obj/effect/spawner/random/engineering/vending_restock/common = 935,
-		/obj/effect/spawner/random/engineering/vending_restock/rare = 60,
-		/obj/effect/spawner/random/engineering/vending_restock/oddity = 5,
+		/obj/effect/spawner/random/engineering/vending_restock/rare = 65, // SPLURT EDIT - Original 60, moving the 5 from oddity to rare
+		//obj/effect/spawner/random/engineering/vending_restock/oddity = 5, //SPLURT EDIT - Oddity Vendors Too OP
 	)
 
 /obj/effect/spawner/random/engineering/vending_restock/wardrobe

--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_uncommon.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_uncommon.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/vending_refill/wardrobe/atmos_wardrobe = 1,
 		/obj/item/vending_refill/wardrobe/bar_wardrobe = 1,
 		/obj/item/vending_refill/wardrobe/cargo_wardrobe = 1,
-		/obj/item/vending_refill/wardrobe/cent_wardrobe = 1,
+		//obj/item/vending_refill/wardrobe/cent_wardrobe = 1, //SPLURT EDIT - No Centcom Wardrobe
 		/obj/item/vending_refill/wardrobe/chap_wardrobe = 1,
 		/obj/item/vending_refill/wardrobe/chef_wardrobe = 1,
 		/obj/item/vending_refill/wardrobe/chem_wardrobe = 1,


### PR DESCRIPTION

## About The Pull Request
title. It also kills the OP gun vendor and the actual wizard vendor from being able to spawn.
## Why It's Good For The Game
<img width="556" height="92" alt="afbeelding" src="https://github.com/user-attachments/assets/aedaa6e9-431b-4092-9921-6d19b87ce9d8" />

I was told to do it so I did it.
## Proof Of Testing
Its commenting out the 2 lines that allow it to spawn.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: Centdrobes, Wizard Vendors, and Gun Vendors are no longer are able to spawn in maints.
/:cl:
