### PR TITLE
Removes reagent handcuffs

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/crafting_bench.dm
+++ b/modular_skyrat/modules/reagent_forging/code/crafting_bench.dm
@@ -30,7 +30,7 @@
 		/datum/crafting_bench_recipe/horse_shoes,
 		/datum/crafting_bench_recipe/ring,
 		/datum/crafting_bench_recipe/collar,
-		/datum/crafting_bench_recipe/handcuffs,
+		// /datum/crafting_bench_recipe/handcuffs, // SPLURT REMOVAL - Maybe cuffs that keep you permanently asleep aren't fun.
 		/datum/crafting_bench_recipe/borer_cage,
 		/datum/crafting_bench_recipe/pavise,
 		/datum/crafting_bench_recipe/buckler,

--- a/modular_skyrat/modules/reagent_forging/code/crafting_bench_recipes.dm
+++ b/modular_skyrat/modules/reagent_forging/code/crafting_bench_recipes.dm
@@ -76,6 +76,7 @@
 	resulting_item = /obj/item/clothing/neck/collar/reagent_clothing
 	required_good_hits = 6
 
+/* SPLURT REMOVAL START - Maybe cuffs that keep you permanently asleep aren't fun.
 /datum/crafting_bench_recipe/handcuffs
 	recipe_name = "handcuffs"
 	recipe_requirements = list(
@@ -83,6 +84,7 @@
 	)
 	resulting_item = /obj/item/restraints/handcuffs/reagent_clothing
 	required_good_hits = 10
+SPLURT REMOVAL END */
 
 /datum/crafting_bench_recipe/borer_cage
 	recipe_name = "cortical borer cage"

--- a/modular_skyrat/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_clothing.dm
@@ -160,6 +160,8 @@
 	. = ..()
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_NECK)
 
+
+/* SPLURT REMOVAL START - Maybe cuffs that keep you permanently asleep aren't fun.
 /obj/item/restraints/handcuffs/reagent_clothing
 	name = "reagent handcuffs"
 	desc = "A pair of handcuffs that are ready to keep someone captive."
@@ -169,3 +171,4 @@
 /obj/item/restraints/handcuffs/reagent_clothing/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_HANDCUFFED)
+SPLURT REMOVAL END */


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game
While the rest of the reagent gear is mostly used to amplify the wearer, or create unique weapons, this just has the potential to perma-stunlock someone with 0 escape (haloperidol lol). It Is Not Fun To Fight. It's like regular handcuffs, which already instantly win a fight upon stun (which is fine), but 10x as powerful depending on the chemical. (not fine)

Also staff wanted it gone.

## Proof Of Testing
if it compiles it werks

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
del: Removed reagent smithing's handcuffs.
/:cl:

