### PR TITLE
Fixes slimepeople getting stunlocked

### DIFF
--- a/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -65,11 +65,13 @@
 				playsound(owner, 'modular_zzplurt/sound/effects/changed_transfur.ogg', 50)
 				puddle_effect.color = sanitize_hexcolor(mutcolor)
 				puddle_effect.transform = H.transform
+
+				// Save original mobility flags BEFORE stunning
+				original_mobility_flags = H.mobility_flags
 				H.Stun(in_transformation_duration, ignore_canstun = TRUE)
 
 				ADD_TRAIT(H, TRAIT_PARALYSIS_L_ARM, SLIMEPUDDLE_TRAIT)
 				ADD_TRAIT(H, TRAIT_PARALYSIS_R_ARM, SLIMEPUDDLE_TRAIT)
-				original_mobility_flags = H.mobility_flags
 				H.mobility_flags &= ~MOBILITY_PICKUP
 				H.mobility_flags &= ~MOBILITY_USE
 				H.mobility_flags &= ~MOBILITY_REST


### PR DESCRIPTION

## About The Pull Request
slime people no longer get stunlocked when un-puddling
## Why It's Good For The Game
fix good
## Proof Of Testing

https://github.com/user-attachments/assets/dd2cef1d-5306-4072-a59f-921c178af786
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: slimepeople no longer get stunlocked upon un-puddling
/:cl:
