### PR TITLE
Fix stray null causing drink dispenser to be missing an upgrade

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -686,7 +686,7 @@
 		/datum/reagent/consumable/tonic,
 		/datum/reagent/water,
 	)
-
+	// upgrade_reagents = null // SPLURT REMOVAL. Fixes Bug where upgrade_reagents being null instead of empty list causes upgrades to not apply
 	/// The default list of emagged reagents dispensable by the soda dispenser
 	var/static/list/drink_emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,


### PR DESCRIPTION

## About The Pull Request
Fixes missing berry juice upgrade from dispensers. Fixes: #733
## Why It's Good For The Game
Fixes bug causing missing drink ingredients.
## Proof Of Testing

<img width="761" height="665" alt="image" src="https://github.com/user-attachments/assets/799956dc-ff24-41b1-9fbf-ae320d971942" />


## Changelog
:cl:
fix: Fix missing drinks dispenser upgrades
/:cl:
