### PR TITLE
Add Announcer Preference

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -209,6 +209,11 @@
 #define ANNOUNCER_WISDOM_COW "announcer_wisdom_cow"
 #define ANNOUNCER_IMMOVABLE_ROD "announcer_immovable_rod"
 #define ANNOUNCER_SCRAMBLER_ANOMALY "announcer_scrambler_anomaly"
+
+
+#define ANNOUNCER_COMMAND_REPORT "announcer_command_report"
+#define ANNOUNCER_RANDOM_ALERT "announcer_random_alert"
+#define ANNOUNCER_RANDOM_WELCOME "announcer_random_welcome"
 // SPLURT EDIT ADDITION END
 
 /// Global list of all of our announcer keys.

--- a/code/__DEFINES/~~~splurt_defines/preferences.dm
+++ b/code/__DEFINES/~~~splurt_defines/preferences.dm
@@ -2,3 +2,14 @@
 #define INFO_COLOR "color"
 
 #define LOADOUT_FLAG_ALLOW_SIMPLE_COLOR (1<<5)
+
+
+GLOBAL_LIST_INIT(announcer_type_keys, list(
+		"Use Station Default" = null,
+		"Tibbets" = /datum/centcom_announcer/intern/tibbets,
+		"Lait" = /datum/centcom_announcer/default/lait,
+		"Dagoth Ur" = /datum/centcom_announcer/dagoth_ur,
+		"Bubber" = /datum/centcom_announcer/default,
+		"TG Intern" = /datum/centcom_announcer/intern,
+		"Medbot" = /datum/centcom_announcer/medbot
+	))

--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -134,7 +134,7 @@
 		payoff = max(PAYOFF_MIN, FLOOR(account.account_balance * 0.80, 1000))
 	var/datum/comm_message/threat = chosen_gang.generate_message(payoff)
 	//send message
-	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
+	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT
 	threat.answer_callback = CALLBACK(src, PROC_REF(pirates_answered), threat, chosen_gang, payoff, world.time)
 	addtimer(CALLBACK(src, PROC_REF(spawn_pirates), threat, chosen_gang), RESPONSE_MAX_TIME)
 	GLOB.communications_controller.send_message(threat, unique = TRUE)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -14,6 +14,8 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	var/list/antag_protected_roles = list()
 	///A list of trait roles that should never be able to roll antag
 	var/list/antag_restricted_roles = list()
+	///Dictionary of singletons
+	var/list/announcers = list() // SPLURT EDIT ADD
 
 	/// Assosciative list of station goal type -> goal instance
 	var/list/datum/station_goal/goals_by_type = list()
@@ -26,7 +28,14 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	//display_lobby_traits() SKYRAT EDIT REMOVAL
 	#endif
 
-	announcer = new announcer() //Initialize the station's announcer datum
+	// SPLURT EDIT ADD
+	//Initialize the station's announcer datums as singletons
+	for(var/announcer_type in subtypesof(/datum/centcom_announcer/))
+		var/datum/centcom_announcer/announce = new announcer_type()
+		announcers[announcer_type] = announce
+
+	announcer = announcers[announcer] // Fetch me
+	// SPLURT EDIT END
 	SSparallax.post_station_setup() //Apply station effects that parallax might have
 
 	return SS_INIT_SUCCESS

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -304,8 +304,25 @@ SUBSYSTEM_DEF(ticker)
 	INVOKE_ASYNC(SSdbcore, TYPE_PROC_REF(/datum/controller/subsystem/dbcore,SetRoundStart))
 
 	to_chat(world, span_notice(span_bold("Welcome to [station_name()], enjoy your stay!")))
-	SEND_SOUND(world, sound(SSstation.announcer.get_rand_welcome_sound()))
 
+	// SPLURT EDIT CHANGE - announcer preferences
+	var/no_preferred_override = FALSE
+	for(var/datum/station_trait/trait in SSstation.station_traits)
+		// have to do this here again because of fucking bullshit
+		if(istype(trait, /datum/station_trait/announcement_intern) || istype(trait, /datum/station_trait/announcement_medbot) || istype(trait, /datum/station_trait/announcement_dagoth)
+		)
+			no_preferred_override = TRUE
+			break
+
+	for(var/mob/target in GLOB.player_list)
+		var/datum/centcom_announcer/preferred_announcer = GLOB.announcer_type_keys[target.client?.prefs.read_preference(/datum/preference/choiced/announcer)]
+		if(preferred_announcer && !no_preferred_override)
+			preferred_announcer = SSstation.announcers[preferred_announcer]
+		else
+			preferred_announcer = SSstation.announcer
+
+		SEND_SOUND(target, sound(preferred_announcer.get_rand_welcome_sound()))
+	// SPLURT EDIT CHANGE END
 	current_state = GAME_STATE_PLAYING
 	Master.SetRunLevel(RUNLEVEL_GAME)
 

--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -115,7 +115,7 @@ GLOBAL_DATUM_INIT(communications_controller, /datum/communciations_controller, n
 				there are currently no credible threats to [station_name()]. \
 				All station construction projects have been authorized. Have a secure shift!",
 			"Security Report",
-			SSstation.announcer.get_rand_report_sound(),
+			ANNOUNCER_COMMAND_REPORT, // SPLURT EDIT
 			color_override = "green",
 		)
 	else if(CONFIG_GET(flag/roundstart_blue_alert))
@@ -132,7 +132,7 @@ GLOBAL_DATUM_INIT(communications_controller, /datum/communciations_controller, n
 		priority_announce(
 			"A summary of the station's situation has been copied and printed to all communications consoles.",
 			"Security Report",
-			SSstation.announcer.get_rand_report_sound(),
+			ANNOUNCER_COMMAND_REPORT, // SPLURT EDIT
 		)
 
 #endif

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -321,7 +321,7 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 			nuke_request(reason, user)
 			to_chat(user, span_notice("Request sent."))
 			user.log_message("has requested the nuclear codes from CentCom with reason \"[reason]\"", LOG_SAY)
-			priority_announce("The codes for the on-station nuclear self-destruct have been requested by [user]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self-Destruct Codes Requested", SSstation.announcer.get_rand_report_sound())
+			priority_announce("The codes for the on-station nuclear self-destruct have been requested by [user]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self-Destruct Codes Requested", ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT
 			playsound(src, 'sound/machines/terminal/terminal_prompt.ogg', 50, FALSE)
 			COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
 		if ("restoreBackupRoutingData")

--- a/code/modules/admin/verbs/anonymousnames.dm
+++ b/code/modules/admin/verbs/anonymousnames.dm
@@ -78,7 +78,7 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
  * it's in a proc so it can be a non-constant expression.
  */
 /datum/anonymous_theme/proc/announce_to_all_players()
-	priority_announce("A recent bureaucratic error in the Organic Resources Department has resulted in a necessary full recall of all identities and names until further notice.", "Identity Loss", SSstation.announcer.get_rand_alert_sound())
+	priority_announce("A recent bureaucratic error in the Organic Resources Department has resulted in a necessary full recall of all identities and names until further notice.", "Identity Loss", ANNOUNCER_RANDOM_ALERT) // SPLURT EDIT
 
 /**
  * anonymous_all_players: sets all crewmembers on station anonymous.
@@ -106,7 +106,7 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
  * called when the anonymous theme is removed regardless of extra theming
  */
 /datum/anonymous_theme/proc/restore_all_players()
-	priority_announce("Names and Identities have been restored.", "Identity Restoration", SSstation.announcer.get_rand_alert_sound())
+	priority_announce("Names and Identities have been restored.", "Identity Restoration", ANNOUNCER_RANDOM_ALERT) // SPLURT EDIT
 	for(var/mob/living/player in GLOB.player_list)
 		if(!player.mind || (!ishuman(player) && !issilicon(player)) || player.mind.assigned_role.faction != FACTION_STATION)
 			continue
@@ -151,7 +151,7 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
 	name = "Employees"
 
 /datum/anonymous_theme/employees/announce_to_all_players()
-	priority_announce("As punishment for this station's poor productivity when compared to neighbor stations, names and identities will be restricted until further notice.", "Finance Report", SSstation.announcer.get_rand_alert_sound())
+	priority_announce("As punishment for this station's poor productivity when compared to neighbor stations, names and identities will be restricted until further notice.", "Finance Report", ANNOUNCER_RANDOM_ALERT) // SPLURT EDIT
 
 /datum/anonymous_theme/employees/anonymous_name(mob/target)
 	var/is_head_of_staff = target.mind.assigned_role.job_flags & JOB_HEAD_OF_STAFF
@@ -184,7 +184,7 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
 	player.put_in_hands(new random_path())
 
 /datum/anonymous_theme/wizards/announce_to_all_players()
-	priority_announce("Your station has been caught by a Wizard Federation Memetic Hazard. You are not y0urself, and yo% a2E 34!NOT4--- Welcome to the Academy, apprentices!", "Memetic Hazard", SSstation.announcer.get_rand_alert_sound())
+	priority_announce("Your station has been caught by a Wizard Federation Memetic Hazard. You are not y0urself, and yo% a2E 34!NOT4--- Welcome to the Academy, apprentices!", "Memetic Hazard", ANNOUNCER_RANDOM_ALERT) // SPLURT EDIT
 
 /datum/anonymous_theme/wizards/anonymous_name(mob/target)
 	var/wizard_name_first = pick(GLOB.wizard_first)
@@ -201,7 +201,7 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
 	return "[pick(GLOB.ninja_titles)] [pick(GLOB.ninja_names)]"
 
 /datum/anonymous_theme/spider_clan/announce_to_all_players()
-	priority_announce("Your station has been sold out to the Spider Clan. Your new designations will be applied now.", "New Management", SSstation.announcer.get_rand_alert_sound())
+	priority_announce("Your station has been sold out to the Spider Clan. Your new designations will be applied now.", "New Management", ANNOUNCER_RANDOM_ALERT) // SPLURT EDIT
 
 /datum/anonymous_theme/spider_clan/anonymous_ai_name(is_ai = FALSE)
 	var/posibrain_name = pick(GLOB.posibrain_names)

--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -148,7 +148,7 @@ ADMIN_VERB(create_command_report, R_ADMIN, "Create Command Report", "Create a co
 	/// The sound we're going to play on report.
 	var/report_sound = played_sound
 	if(played_sound == DEFAULT_ANNOUNCEMENT_SOUND)
-		report_sound = SSstation.announcer.get_rand_report_sound()
+		report_sound = ANNOUNCER_COMMAND_REPORT // SPLURT EDIT
 
 	if(announce_contents)
 		var/chosen_color = announcement_color

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -348,7 +348,7 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 					airlock.req_access = list()
 					airlock.req_one_access = list()
 			message_admins("[key_name_admin(holder)] activated Egalitarian Station mode")
-			priority_announce("CentCom airlock control override activated. Please take this time to get acquainted with your coworkers.", null, SSstation.announcer.get_rand_report_sound())
+			priority_announce("CentCom airlock control override activated. Please take this time to get acquainted with your coworkers.", null, ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT
 		if("ancap")
 			if(!is_funmin)
 				return
@@ -356,9 +356,9 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 			SSeconomy.full_ancap = !SSeconomy.full_ancap
 			message_admins("[key_name_admin(holder)] toggled Anarcho-capitalist mode")
 			if(SSeconomy.full_ancap)
-				priority_announce("The NAP is now in full effect.", null, SSstation.announcer.get_rand_report_sound())
+				priority_announce("The NAP is now in full effect.", null, ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT
 			else
-				priority_announce("The NAP has been revoked.", null, SSstation.announcer.get_rand_report_sound())
+				priority_announce("The NAP has been revoked.", null, ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT
 		if("send_shuttle_back")
 			if (!is_funmin)
 				return

--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -28,7 +28,7 @@
 	var/insurance_evaluation = 0
 
 /datum/round_event/shuttle_insurance/announce(fake)
-	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.event_sounds[ANNOUNCER_SHUTTLE_INSURANCE] || SSstation.announcer.get_rand_report_sound()) // SPLURT EDIT - ORIGINAL: priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
+	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.event_sounds[ANNOUNCER_SHUTTLE_INSURANCE] || ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT - ORIGINAL: priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", ANNOUNCER_COMMAND_REPORT)
 
 /datum/round_event/shuttle_insurance/setup()
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "rogue_names"))

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -7,7 +7,7 @@
 	var/report_message = "Complete this goal."
 
 /datum/station_goal/proc/send_report()
-	priority_announce("Priority Nanotrasen directive received. Project \"[name]\" details inbound.", "Incoming Priority Message", SSstation.announcer.get_rand_report_sound())
+	priority_announce("Priority Nanotrasen directive received. Project \"[name]\" details inbound.", "Incoming Priority Message", ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT
 	print_command_report(get_report(),"Nanotrasen Directive [pick(GLOB.phonetic_alphabet)] \Roman[rand(1,50)]", announce=FALSE)
 	on_report()
 

--- a/modular_skyrat/modules/central_command_module/code/computers/command_report_computer.dm
+++ b/modular_skyrat/modules/central_command_module/code/computers/command_report_computer.dm
@@ -71,7 +71,7 @@
 		return
 
 	if(!report_sound)
-		report_sound = SSstation.announcer.get_rand_report_sound()
+		report_sound = ANNOUNCER_COMMAND_REPORT // SPLURT EDIT
 
 	if(announce_contents)
 		priority_announce(command_report_content, command_report_title, report_sound, sender_override = command_name, has_important_message = TRUE)

--- a/modular_zubbers/code/modules/storyteller/divergency_report.dm
+++ b/modular_zubbers/code/modules/storyteller/divergency_report.dm
@@ -23,7 +23,7 @@
 	<p style=\"color: grey; text-align: justify;\">This label certifies an Intern has reviewed the above before sending. This document is the property of Nanotrasen Corporation.</p>"
 
 	print_command_report(., "Central Command Status Summary", announce = FALSE)
-	priority_announce("Hello, crew of [station_name()]. Our intern has finished their shift-start divergency and goals evaluation, which has been sent to your communications console. Have a secure shift!", "Divergency Report", SSstation.announcer.get_rand_report_sound())
+	priority_announce("Hello, crew of [station_name()]. Our intern has finished their shift-start divergency and goals evaluation, which has been sent to your communications console. Have a secure shift!", "Divergency Report", ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT
 
 
 

--- a/modular_zubbers/code/modules/storyteller/event_defines/major/pirates.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/major/pirates.dm
@@ -46,7 +46,7 @@
 		payoff = max(PAYOFF_MIN, FLOOR(account.account_balance * 0.80, 1000))
 	var/datum/comm_message/threat = chosen_gang.generate_message(payoff)
 	//send message
-	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
+	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", ANNOUNCER_COMMAND_REPORT) // SPLURT EDIT
 	threat.answer_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pirates_answered), threat, chosen_gang, payoff, world.time)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_pirates), threat, chosen_gang), RESPONSE_MAX_TIME)
 	GLOB.communications_controller.send_message(threat, unique = TRUE)

--- a/modular_zzplurt/code/controllers/subsystem/processing/station.dm
+++ b/modular_zzplurt/code/controllers/subsystem/processing/station.dm
@@ -3,7 +3,7 @@
 
 /datum/controller/subsystem/processing/station/proc/set_announcer(datum/centcom_announcer/new_announcer)
 	QDEL_NULL(announcer)
-	announcer = new new_announcer()
+	announcer = announcers[new_announcer]
 
 ADMIN_VERB(set_announcer, R_FUN, "Set announcer", "Sets the station announcer to a new type", ADMIN_CATEGORY_FUN)
 	var/list/announcer_choices = subtypesof(/datum/centcom_announcer)

--- a/modular_zzplurt/code/modules/client/preferences/announcer.dm
+++ b/modular_zzplurt/code/modules/client/preferences/announcer.dm
@@ -1,0 +1,19 @@
+
+/datum/preference/choiced/announcer
+	savefile_key = "preferred_announcer"
+	savefile_identifier = PREFERENCE_PLAYER
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+
+/datum/preference/choiced/announcer/init_possible_values()
+	return list(
+		"Use Station Default",
+		"Tibbets",
+		"Lait",
+		"Dagoth Ur",
+		"Bubber",
+		"TG Intern",
+		"Medbot"
+	)
+
+/datum/preference/choiced/announcer/create_default_value()
+	return "Use Station Default"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10219,6 +10219,7 @@
 #include "modular_zzplurt\code\modules\client\loadout\donator\second_tier.dm"
 #include "modular_zzplurt\code\modules\client\loadout\donator\third_tier.dm"
 #include "modular_zzplurt\code\modules\client\preferences\_preference.dm"
+#include "modular_zzplurt\code\modules\client\preferences\announcer.dm"
 #include "modular_zzplurt\code\modules\client\preferences\body_size.dm"
 #include "modular_zzplurt\code\modules\client\preferences\clothing.dm"
 #include "modular_zzplurt\code\modules\client\preferences\colored_blood.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/splurt/sound.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/splurt/sound.tsx
@@ -1,0 +1,11 @@
+import {
+  type FeatureChoiced,
+} from '../../base';
+import { FeatureDropdownInput } from '../../dropdowns';
+
+export const preferred_announcer: FeatureChoiced = {
+  name: 'Announcer Preference',
+  category: 'SOUND',
+  description: 'Choose which announcer you\'d like hear.',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request

Adds a preference choice for players to choose from a set of announcers
This preference will be overwritten by station traits

## Why It's Good For The Game

People don't like to listen to weird stuff at times.

## Proof Of Testing

I compiled it I tested it I heard it. It works.

<img width="970" height="210" alt="grafik" src="https://github.com/user-attachments/assets/c18b978f-680b-4da2-ba40-85116bd8a187" />


## Changelog

:cl: Bam4000
add: Added a preference choice to choose a preferred announcer
/:cl:
