### PR TITLE
Disables heretic from rolling

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -4,7 +4,7 @@
 
 	antag_flag = ROLE_HERETIC
 	antag_datum = /datum/antagonist/heretic
-	weight = 0 //SPLURT EDIT - No Heretic
+	weight = 0 //SPLURT EDIT - No Heretic (upstream weight = 5)
 	min_players = 30
 
 	maximum_antags_global = 2


### PR DESCRIPTION

## About The Pull Request
Title. No more naturally spawning heretics. They can still be opfor'd for
## Why It's Good For The Game
Their entire kit is based around murder.
All their objectives are murder.
Their grand reward for completing all objectives? More murder.
How do they get more of their abilities? Murder.

This is not conductive to a RP environment.

Also kate wants it gone.
## Proof Of Testing
weight = 0
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: Heretic no longer rolls through storyteller.
/:cl:
