### PR TITLE
Slugcat species!

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/slugcat.dm
+++ b/code/modules/mob/living/carbon/human/species_types/slugcat.dm
@@ -1,0 +1,28 @@
+/datum/species/slugcat/
+	name = "Slugcat"
+	id = "SPECIES_SLUGCAT"
+	sexes = TRUE
+	plural_form = "Slugcats"
+	meat = obj/item/food/meat/slab/human/mutant/slugcat
+	inherent_traits = list(
+		TRAIT_AMPHIBIOUS,
+		TRAIT_EASILY_WOUNDED,
+		TRAIT_WET_FOR_LONGER,
+		TRAIT_HATED_BY_DOGS,
+		TRAIT_HIGH_VALUE_RANSOM, //slugcats are rare in EROS, unless they get popular.
+		TRAIT_FERAL_BITER,
+		TRAIT_THROWINGARMS,
+		TRAIT_LIGHT_DRINKER,
+		TRAIT_SKITTISH,
+		TRAIT_CATLIKE_GRACE,
+
+	)
+	//they are wet rodents that bite and throw at you and clean pipes.
+
+/datum/species/proc/get_species_lore()
+	SHOULD_CALL_PARENT(FALSE)
+	RETURN_TYPE(/list)
+
+	//stack_trace("Species [name] ([type]) did not have lore set, and is a selectable roundstart race! Override get_species_lore.") // SKYRAT EDIT REMOVAL
+	return list("No species lore set, file a bug report!")
+// to be continued. *sniff


### PR DESCRIPTION
## About The Pull Request

The plan for this PR is to 
1. Define Slugcats in code. (slugcat.dm)
2. Sprite more slugcat limbs.
3. Add default slugcat sounds.
The plan is just a very basic implementation of the slugcats. *waexclaim

## Why It's Good For The Game

Slugcats are fairly unpopular inside of SPLURT, and this PR as it is worked on will contribute more and more into making slugcats a genuine playable species.

## Proof Of Testing

N/A

## Changelog

:cl:
add: Slugcats as a species.
/:cl:

Contact `teh.saint` for contribution.