### PR TITLE
Disables maroon + martyr for traitors

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -359,7 +359,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 // Progression traitor defines
 
 /// Chance that the traitor could roll hijack if the pop limit is met.
-#define HIJACK_PROB 0 //SPLURT EDIT - No more hijack, from 10 > 0
+#define HIJACK_PROB 10
 /// Hijack is unavailable as a random objective below this player count.
 #define HIJACK_MIN_PLAYERS 30
 


### PR DESCRIPTION
## About The Pull Request
No more Die A Glorious Death + Hijack, as well as maroon.

## Why It's Good For The Game
Maroon is something that is typically interpreted as round-removal permission.

Die a glorious death is kinda against our rules? How are you gonna die gloriously without also killing a bazillion people.

## Proof Of Testing
numbers changes

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Maroon/Martyr objectives no longer show up for traitors
/:cl:

