### PR TITLE
Vortex Anomaly Removal

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/major/major_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/major/major_overrides.dm
@@ -35,6 +35,7 @@
 /datum/round_event_control/anomaly/anomaly_vortex
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE)
+	weight = 0 // SPLURT change: No more "haha fuck you" anomaly
 
 /datum/round_event_control/anomaly/anomaly_pyro
 	track = EVENT_TRACK_MAJOR


### PR DESCRIPTION
## About The Pull Request

I removed the vortex anomaly from rolling.

## Why It's Good For The Game

The vortex anomaly is unnecessarily destructive/lethal, and largely victimizes random players or massively ruins an area (whether through spacing or just structural damage), often leading to much larger issues on stations like Moon. One vortex anomaly and there's a strange film in the air, everywhere. Other stations just mass-space and then you can't navigate anywhere. We don't need random destruction :)

## Proof Of Testing

it works,, promise,,

## Changelog

:cl:

balance: disabled vortex anomalies from rolling

/:cl:


