### PR TITLE
Makes antfarms actually work with a 1 tile gap

### DIFF
--- a/modular_zzplurt/code/modules/ashwalkers/code/items/antfarm.dm
+++ b/modular_zzplurt/code/modules/ashwalkers/code/items/antfarm.dm
@@ -23,10 +23,7 @@
 
 // Override the nearby‑farm check logic inside Initialize()
 /obj/structure/antfarm/Initialize(mapload)
-	. = ..()
-	if(. == INITIALIZE_HINT_QDEL)
-		return INITIALIZE_HINT_QDEL
-
+	. = ..(INITIALIZE_HINT_LATELOAD)
 	if(!mapload)
 		var/turf/src_turf = get_turf(src)
 		if(!src_turf.GetComponent(/datum/component/simple_farm))
@@ -34,7 +31,7 @@
 			return INITIALIZE_HINT_QDEL
 
 		// Modified range
-		for(var/obj/structure/antfarm/found_farm in range(0, get_turf(src)))
+		for(var/obj/structure/antfarm/found_farm in range(1, get_turf(src)))
 			if(found_farm == src)
 				continue
 


### PR DESCRIPTION

## About The Pull Request
#737 tried to make it so they could be placed directly adjacent but had errors in its logic which meant it never actually happened. no gap between them at all would also allow like, 25 to be in a 5x5 area (lag city), so we decided for it to be a 1 tile gap, leaving only 9 in an area.
## Why It's Good For The Game
bugfix and talked with the guy who had the original bounty and he also agreed that a 1 tile gap is probably more reasonable than a 0 tile gap.
## Proof Of Testing
<img width="367" height="238" alt="afbeelding" src="https://github.com/user-attachments/assets/5a53d965-955f-4abc-8771-2d2ea8164712" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Antfarms now can ACTUALLY be placed with a 1 tile gap.
/:cl:
