### PR TITLE
Fix flipped consent checker

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/pentacamphor.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/pentacamphor.dm
@@ -24,7 +24,7 @@
 		to_chat(exposed_mob, span_notice("Your mind is free. Your thoughts are pure and innocent once more."))
 		REMOVE_TRAIT(exposed_mob, TRAIT_BIMBO, TRAIT_LEWDCHEM)
 		return
-	if(!HAS_TRAIT(exposed_mob, TRAIT_NEVERBONER) && !exposed_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/forced_neverboner)) // SPLURT EDIT - Added a preference to force neverboner
+	if(!HAS_TRAIT(exposed_mob, TRAIT_NEVERBONER) && exposed_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/forced_neverboner)) // SPLURT EDIT - Added a preference to force neverboner
 		to_chat(exposed_mob, span_notice("You feel like you'll never feel aroused again..."))
 		ADD_TRAIT(exposed_mob, TRAIT_NEVERBONER, TRAIT_LEWDCHEM)
 


### PR DESCRIPTION
## About The Pull Request
It would seem as though the code was making sure you DIDNT consent to what it was about to do, rather then the other way around.
## Why It's Good For The Game
Consent is cool.
## Proof Of Testing
works on my machine
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: UvvU
fix: Neverboner now respects consent
/:cl:
