### PR TITLE
Disables OPFORs.

### DIFF
--- a/modular_zzplurt/code/modules/opposing_force/opforoveride.dm
+++ b/modular_zzplurt/code/modules/opposing_force/opforoveride.dm
@@ -1,0 +1,6 @@
+/mob/opposing_force()
+    set name = "Opposing Force"
+    set category = null
+    set hidden = 1
+    to_chat(src, span_warning("Opposing Force is disabled on this server."))
+    return

--- a/modular_zzplurt/code/modules/opposing_force/opforoveride.dm
+++ b/modular_zzplurt/code/modules/opposing_force/opforoveride.dm
@@ -1,6 +1,6 @@
 /mob/opposing_force()
-    set name = "Opposing Force"
-    set category = null
-    set hidden = 1
-    to_chat(src, span_warning("Opposing Force is disabled on this server."))
-    return
+	set name = "Opposing Force"
+	set category = null
+	set hidden = 1
+	to_chat(src, span_warning("Opposing Force is disabled on this server."))
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10469,6 +10469,7 @@
 #include "modular_zzplurt\code\modules\modular_items\misc\toys.dm"
 #include "modular_zzplurt\code\modules\movespeed\modifiers\components.dm"
 #include "modular_zzplurt\code\modules\movespeed\modifiers\innate.dm"
+#include "modular_zzplurt\code\modules\opposing_force\opforoveride.dm"
 #include "modular_zzplurt\code\modules\paperwork\pen.dm"
 #include "modular_zzplurt\code\modules\player_ranks\donator.dm"
 #include "modular_zzplurt\code\modules\plug13\code\client.dm"


### PR DESCRIPTION

## About The Pull Request
These things have been causing nothing but issues. OPFORs as an idea seems good in theory, but often in practice no effort is put into these things and devolve into "give antag and destroy station" ahelps with extra steps. Additionally, they draw away eventmin focus from full events.
## Why It's Good For The Game
Disables OPFORs modularly. OPFOR round are already disabled, so that is not a concern. Hopefully allows eventmin focus to shift away from OPFORs and more towards full events.

## Proof Of Testing
Works on my machine.

</details>

## Changelog
:cl:
del: Removes OPFORs.
/:cl:
