### PR TITLE
Fixes armor overcoverage by rampart kits

### DIFF
--- a/modular_zzplurt/code/game/objects/items/armor_kits.dm
+++ b/modular_zzplurt/code/game/objects/items/armor_kits.dm
@@ -10,6 +10,7 @@
 	var/target_slot = ITEM_SLOT_OCLOTHING
 	var/change_allowed = TRUE
 	var/list/target_allowed // = GLOB.security_vest_allowed
+	var/target_body_parts_covered = CHEST
 
 	var/armor_text = "standard Nanotrasen security armored vest"
 	var/target_prefix = "rampart"
@@ -26,12 +27,15 @@
 		return NONE
 
 	var/obj/item/target = interacting_with
+	var/obj/item/clothing/C = target
+
+	if(!C)
+		return NONE
 
 	if(!(target.slot_flags & target_slot))
 		to_chat(user, "<span class = 'notice'>You can't reinforce [target] with [src].</span>")
 		return NONE
 
-	var/obj/item/clothing/C = target
 	var/datum/armor/curr_armor = C.get_armor()
 
 	for(var/curr_stat in ARMOR_LIST_DAMAGE())
@@ -42,6 +46,7 @@
 	if(used)
 		if(change_allowed)
 			C.allowed = target_allowed
+		C.body_parts_covered = target_body_parts_covered
 		user.visible_message("<span class = 'notice'>[user] reinforces [C] with [src].</span>", \
 		"<span class = 'notice'>You reinforce [C] with [src], making it as protective as \a [armor_text].</span>")
 		C.name = "[target_prefix] [C.name]"
@@ -59,6 +64,7 @@
 	target_armor = /datum/armor/head_helmet
 	target_slot = ITEM_SLOT_HEAD
 	change_allowed = FALSE
+	target_body_parts_covered = HEAD
 	// target_allowed = GLOB.security_vest_allowed
 
 	armor_text = "standard Nanotrasen security helmet"


### PR DESCRIPTION
## About The Pull Request

Previously, rampart kits simply directly upgraded the armor of whatever you used it on. This did not account for the fact, that the new thing may cover more limbs then the standard sec armor. This made it so that technically, the meta thing to do, was get a weird costume that covered your entire body, then rampart kit it. I've fixed this by making it so that when you use a rampart kit on something, it forces it to only armor the chest, the same area that normal security vests do.
## Why It's Good For The Game
Rampart kits aren't meant to be *better* then normal security armor.
## Proof Of Testing
Works on my machine
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: UvvU
fix: fixed rampart kits allowing you to cover yourself with more armor then you should
/:cl:
