### PR TITLE
Nerfs xenohybrids

### DIFF
--- a/modular_zzplurt/code/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/human/species/xeno.dm
@@ -2,5 +2,14 @@
 	mutant_organs = list(
 		/obj/item/organ/alien/plasmavessel/roundstart,
 		/obj/item/organ/alien/resinspinner,
-		/obj/item/organ/alien/hivenode,
 		)
+/datum/species/xeno/create_pref_unique_perks()
+	var/list/to_add = list()
+
+	to_add += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = "Sun",
+		SPECIES_PERK_NAME = "Heat Sensitive",
+		SPECIES_PERK_DESC = "Much like their feral ancestors, Xenomorph Hybrids are hypersensitive to heat and burn damage."
+	))
+	return to_add

--- a/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/xeno.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/human/species_types/xeno.dm
@@ -1,4 +1,5 @@
 /datum/species/xeno
+	heatmod = 1.5
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/xenohybrid,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/mutant/xenohybrid,


### PR DESCRIPTION

## About The Pull Request

This PR removes the innate hive node organ, cutting off xenos from the previously antag-only feral xeno hivemind. It also gives xenos a burnmod on-par with that of podpeople. 

## Why It's Good For The Game

Xenohybrids are comically overtuned: You get the ability to eat raw and bloody meat, two hiveminds, a resin spinner, higher movement speed, and xeno faction affiliation for zero cost whatsoever. This PR seeks to, at the very least, cut out some of the chaff and give xenos an actual weakness.

## Proof Of Testing

Builds

## Changelog

:cl:

balance: Xenohybrids now have a weakness to burn damage
balance: Xenohybrids no longer have 2 hiveminds
/:cl:

