### PR TITLE
Added blank cig pack made from cardboard

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -675,7 +675,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 		new /datum/stack_recipe("drinking glasses box", /obj/item/storage/box/drinkingglasses, crafting_flags = NONE, category = CAT_CONTAINERS), \
 		new /datum/stack_recipe("paper cups box", /obj/item/storage/box/cups, crafting_flags = NONE, category = CAT_CONTAINERS), \
 		new /datum/stack_recipe("cigar case", /obj/item/storage/fancy/cigarettes/cigars, crafting_flags = NONE, category = CAT_CONTAINERS), \
-		new /datum/stack_recipe("cigarette packet", /obj/item/storage/fancy/cigarettes/cigpack_cardboard, 1, crafting_flags = NONE, category = CAT_CONTAINERS),
+		new /datum/stack_recipe("cigarette packet", /obj/item/storage/fancy/cigarettes/cigpack_cardboard, 1, crafting_flags = NONE, category = CAT_CONTAINERS), // SPLURT EDIT ADDITION
 		null, \
 
 		new /datum/stack_recipe("lethal ammo box", /obj/item/storage/box/lethalshot, crafting_flags = NONE, category = CAT_CONTAINERS), \

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -465,20 +465,6 @@
 	spawn_coupon = FALSE
 	open_status = FANCY_CONTAINER_OPEN
 
-/obj/item/storage/fancy/cigarettes/cigpack_cardboard
-	name = "\improper Cardboard packet"
-	desc = "A handmade box for cigs. A bit bent and wrinkly."
-	icon_state = "base"
-	base_icon_state = "base"
-	spawn_type = /obj/item/cigarette/space_cigarette
-	spawn_count = 0
-	spawn_coupon = FALSE
-
-/obj/item/storage/fancy/cigarettes/cigpack_cardboard/empty
-	spawn_count = 0
-	spawn_coupon = FALSE
-	open_status = FANCY_CONTAINER_OPEN
-
 /obj/item/storage/fancy/cigarettes/flash_powder
 	spawn_type = /obj/item/cigarette/flash_powder
 

--- a/modular_zzplurt/code/game/objects/items/storage/fancy.dm
+++ b/modular_zzplurt/code/game/objects/items/storage/fancy.dm
@@ -1,0 +1,13 @@
+/obj/item/storage/fancy/cigarettes/cigpack_cardboard
+	name = "\improper Cardboard packet"
+	desc = "A handmade box for cigs. A bit bent and wrinkly."
+	icon_state = "base"
+	base_icon_state = "base"
+	spawn_type = /obj/item/cigarette/space_cigarette
+	spawn_count = 0
+	spawn_coupon = FALSE
+
+/obj/item/storage/fancy/cigarettes/cigpack_cardboard/empty
+	spawn_count = 0
+	spawn_coupon = FALSE
+	open_status = FANCY_CONTAINER_OPEN

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10149,6 +10149,7 @@
 #include "modular_zzplurt\code\game\objects\items\storage\backpack.dm"
 #include "modular_zzplurt\code\game\objects\items\storage\belt.dm"
 #include "modular_zzplurt\code\game\objects\items\storage\duffelbags.dm"
+#include "modular_zzplurt\code\game\objects\items\storage\fancy.dm"
 #include "modular_zzplurt\code\game\objects\items\storage\sixpack.dm"
 #include "modular_zzplurt\code\game\objects\items\storage\boxes\clothes_boxes.dm"
 #include "modular_zzplurt\code\game\objects\structures\billboard.dm"


### PR DESCRIPTION

## About The Pull Request

Added a blank cigarette packet that can be made from cardboard.

## Why It's Good For The Game

Allows botanists to package and sell cigarettes and rollies as efficiently as the packs from vending machines.

## Proof Of Testing
<img width="369" height="419" alt="8DkkfGhhHc" src="https://github.com/user-attachments/assets/3386aa5b-d716-45ad-86dd-9d1d3d20f571" />

<img width="69" height="91" alt="dreamseeker_WfnSF9ahU3" src="https://github.com/user-attachments/assets/f8ba7e0b-3263-49ac-8ac1-8bf7e7748f63" />

<img width="66" height="90" alt="dreamseeker_UgAOH5uJNT" src="https://github.com/user-attachments/assets/c2ec9b2b-d4ba-43f6-9f95-340b17aeaac6" />

<img width="65" height="82" alt="dreamseeker_n1bgRw8IJs" src="https://github.com/user-attachments/assets/d543e023-5aed-4115-93d9-68b16eb1ae21" />

</details>



## Changelog

Changed fancy.dm to define blank cigarette package.
Changed sheet_types to set cardboard recipe for blank cigarette package. (unable to use modular system)
Empty cig packets without a coupon now breakdown into 1 sheet of cardboard
:cl: Lilac
add: Added more things
qol: made something easier to use
code: changed some code
/:cl:
