### PR TITLE
Prevents infinidorms from being affected by vendor uprisings.

### DIFF
--- a/modular_zzplurt/code/modules/events/brand_intelligence.dm
+++ b/modular_zzplurt/code/modules/events/brand_intelligence.dm
@@ -1,0 +1,19 @@
+//Modular override of brand_intelligence.dm to prevent vendors in hilberts hotel from being selected.
+
+/datum/round_event/brand_intelligence/setup()
+	//select our origin machine (which will also be the type of vending machine affected.)
+	for(var/obj/machinery/vending/vendor as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/vending))
+		if(!vendor.onstation)
+			continue
+		if(!vendor.density)
+			continue
+		if(chosen_vendor_type && !istype(vendor, chosen_vendor_type))
+			continue
+		var/area/vendor_area = get_area(vendor)
+		if(vendor_area?.area_flags & HIDDEN_AREA)
+			continue
+		vending_machines.Add(vendor)
+	if(!length(vending_machines)) //If somehow there are still no elligible vendors, give up.
+		kill()
+		return
+	origin_machine = pick_n_take(vending_machines)


### PR DESCRIPTION

## About The Pull Request
Things like brand intelligence could roll in infinidorms because it's technically onstation through a flag (so that the vendors cost money). My edit makes it so that hidden_area flags (hilbert hotel/infinidorm has this) prevents it from rolling on them.

## Why It's Good For The Game
People don't get griefed by vendor during ERP

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
Fix: Vendors can no longer rise up against you whilst you're in the middle of an ERP scene.
/:cl:

