### PR TITLE
Suggestion #444 - Pixel Tilt Config Change

### DIFF
--- a/modular_skyrat/modules/pixel_shift/code/pixel_shift_component.dm
+++ b/modular_skyrat/modules/pixel_shift/code/pixel_shift_component.dm
@@ -9,7 +9,7 @@
 	//how tilted the parent is
 	var/how_tilted
 	//the maximum amount of tilt parent can achieve
-	var/maximum_tilt = 45
+	var/maximum_tilt = 180 // SPLURT EDIT - Config change
 	//the maximum amount we/an item can move
 	var/maximum_pixel_shift = 16
 	//If we are shifted


### PR DESCRIPTION

## About The Pull Request
Changes the maximum_tilt value from 45 to 180
## Why It's Good For The Game
This will allow players to tilt their characters in a full 360 degree range (-180 to 180)
This will be particularly useful for allowing Borgs to lay on their backs if they are currently lacking a sprite for it.
## Proof Of Testing
Tested on local server
<details>
<summary>Screenshots/Videos</summary>
<img width="73" height="82" alt="image" src="https://github.com/user-attachments/assets/28cc1cab-e4d0-48ca-8195-48a2bff0a569" />

</details>

## Changelog
:cl:
config: Allowed pixel tilting up to 180 degrees in either direction (was only 45)
/:cl:
