### PR TITLE
Fix Sunwalker Trait Inheritence

### DIFF
--- a/code/modules/antagonists/voidwalker/sunwalker_mob.dm
+++ b/code/modules/antagonists/voidwalker/sunwalker_mob.dm
@@ -36,6 +36,7 @@
 	var/water_damage_cutoff = 10
 
 /mob/living/basic/voidwalker/sunwalker/unique_setup()
+	. = ..() // SPLURT change, allowed inheritence of parent unique setup
 	AddComponent(/datum/component/igniter)
 	AddComponent(/datum/component/vision_hurting, damage_per_second = 0.1, message = null, silent = TRUE)
 	AddComponent(/datum/component/space_dive, /obj/effect/dummy/phased_mob/space_dive/sunwalker)

--- a/modular_zzplurt/code/modules/antagonists/voidwalker/sunwalker_mob.dm
+++ b/modular_zzplurt/code/modules/antagonists/voidwalker/sunwalker_mob.dm
@@ -15,7 +15,10 @@
 	/// Water damage we take on any exposure
 	water_damage = 25 // SPLURT change, increased to 25 from 20
 
-	/datum/action/cooldown/spell/pointed/unsettle/unsettle
+	flags_1 = SUPERMATTER_IGNORES_1
+
+	/// Abilities enabled for kidnapping
+	can_do_abductions = TRUE
 
 /mob/living/basic/voidwalker/sunwalker/unique_setup()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

I enabled kidnapping and unsettle on sunwalker, and increased eye organ damage when looking at a sunwalker. Also reverted their aura buff since it was unnecessary.

## Why It's Good For The Game

Fixes bug, but also makes sunwalker the intended "slightly more powerful voidwalker" by removing the tradeoffs intended for when it was much stronger

## Proof Of Testing

works,,, pawmise

## Changelog

:cl:
add: sunwalker can now kidnap
balance: sunwalker aura temp back to 1000K
balance: increased sunwalker aura volume (it's still below the original value)
fix: sunwalker trait inheritence
/:cl: