### PR TITLE
Mesmer Eye Adjustments

### DIFF
--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/hypnotic_gaze.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/hypnotic_gaze.dm
@@ -77,7 +77,7 @@
 // Upgraded variant
 /datum/action/cooldown/hypnotize/brainwash
 	name = "Brainwash"
-	desc = "Invade someone's using advanced memetic brainwaves to give them new directives."
+	desc = "Invade someone's mind using advanced memetic brainwaves to give them new directives."
 	cooldown_time = HYPNOEYES_COOLDOWN_BRAINWASH
 
 	// Should this create a brainwashed victim?

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/hypnotic_gaze.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/hypnotic_gaze.dm
@@ -68,7 +68,6 @@
 	button_icon_state = "hypnotize"
 
 	// Should this create a brainwashed victim?
-	// Currently unused in this codebase
 	var/mode_brainwash = FALSE
 
 	// Terminology used
@@ -78,7 +77,7 @@
 // Upgraded variant
 /datum/action/cooldown/hypnotize/brainwash
 	name = "Brainwash"
-	desc = "Stare deeply into someone's eyes, converting them into a loyal mind slave."
+	desc = "Invade someone's using advanced memetic brainwaves to give them new directives."
 	cooldown_time = HYPNOEYES_COOLDOWN_BRAINWASH
 
 	// Should this create a brainwashed victim?
@@ -294,12 +293,23 @@
 		to_chat(action_target, span_notice("[action_owner] stares intensely into your eyes for a moment. You sense nothing out of the ordinary from [action_owner.p_them()]."))
 		return
 
-	// Check if client has denied hypnosis preference
-	if(action_target.client?.prefs.read_preference(/datum/preference/choiced/erp_status_hypno) == "No")
-		// Warn the users, then return
-		to_chat(action_owner, span_warning("You sense that [action_target] is not comfortable with this type of interaction, and decide to respect [action_target.p_their()] preferences."))
-		to_chat(action_target, span_notice("[action_owner] stares into your eyes with a strange conviction, but turns away after a moment."))
-		return
+	// Check if using brainwashing mode
+	if(mode_brainwash)
+		// Then check if target has antagonist turned on
+		if(!action_target.client?.prefs?.read_preference(/datum/preference/toggle/be_antag))
+			// Warn the user, then return
+			to_chat(action_owner, span_warning("[grab_target] is too loyal to the station to accept your orders!"))
+			to_chat(action_target, span_notice("[action_owner] stares intensely at you, but stops after a moment."))
+			return
+
+	// Not using brainwash mode
+	else
+		// Check if client has denied hypnosis preference
+		if(action_target.client?.prefs.read_preference(/datum/preference/choiced/erp_status_hypno) == "No")
+			// Warn the users, then return
+			to_chat(action_owner, span_warning("You sense that [action_target] is not comfortable with this type of interaction, and decide to respect [action_target.p_their()] preferences."))
+			to_chat(action_target, span_notice("[action_owner] stares into your eyes with a strange conviction, but turns away after a moment."))
+			return
 
 	// Check for mindshield implant
 	if(HAS_TRAIT(action_target, TRAIT_MINDSHIELD))
@@ -349,7 +359,7 @@
 	if(!findtext(action_target.client?.prefs.read_preference(/datum/preference/choiced/erp_status_nc), "Yes"))
 		// Non-consensual is NOT enabled
 		// Define warning suffix
-		var/warning_target = (mode_brainwash ? "You will become a brainwashed victim, and be required to follow all orders given. [action_owner] accepts all responsibility for antagonistic orders." : "These are only suggestions, and you may disobey cases that strongly violate your character.")
+		var/warning_target = (mode_brainwash ? "You will become a brainwashed victim, and be required to follow all orders given. This does not make you a full antagonist, and you should not act like one." : "These are only suggestions, and you may disobey cases that strongly violate your character.")
 
 		// Prompt target for consent response
 		input_consent = alert(action_target, "Will you fall into a hypnotic stupor? This will allow [action_owner] to issue hypnotic [term_suggest]s. [warning_target]", "Hypnosis", "Yes", "No")

--- a/modular_zzplurt/code/modules/modular_implants/code/nif_research.dm
+++ b/modular_zzplurt/code/modules/modular_implants/code/nif_research.dm
@@ -1,3 +1,5 @@
+// Brainwash NIF removed
+/*
 // Add NIFs to alien surgery node
 /datum/techweb_node/alien_surgery/New()
 	design_ids += list(
@@ -12,6 +14,7 @@
 	id = "nifsoft_hypno_brainwash"
 	build_path = /obj/item/disk/nifsoft_uploader/dorms/hypnosis/brainwashing
 	//departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+*/
 
 // Design for storage concealment NIFSoft
 /datum/design/nifsoft_hud/nifsoft_storage_concealment

--- a/modular_zzplurt/code/modules/modular_implants/code/nifsofts/brainwashing.dm
+++ b/modular_zzplurt/code/modules/modular_implants/code/nifsofts/brainwashing.dm
@@ -6,7 +6,7 @@
 // More advanced variant for full brainwashing
 /datum/nifsoft/action_granter/hypnosis/brainwashing
 	name = "Mesmer Eye"
-	program_desc = "Based on illegal abductor technology, the Mesmer Eye NIFSoft allows the user to completely control others actions. Unlike Libidine Eye, victims are unable to resist once given an order. You will be held responsible for your target's actions."
+	program_desc = "Based on illegal abductor technology, the Mesmer Eye NIFSoft allows programming new directives into a target. Victims may still resist being given an order without proper persuasion. ((This is not the intended tool for ERP hypnosis. Use Libidine Eye instead.))"
 
 	// Has a cost
 	active_cost = 0.1
@@ -17,3 +17,18 @@
 
 	// Grants different action
 	action_to_grant = /datum/action/cooldown/hypnotize/brainwash
+
+// Performed when installing the NIF
+/obj/item/disk/nifsoft_uploader/dorms/hypnosis/brainwashing/attempt_software_install(mob/living/carbon/human/target)
+	. = ..()
+
+	// Check parent return
+	if(. == FALSE)
+		// Do nothing
+		return
+
+	// Provide warning text
+	to_chat(target, span_doyourjobidiot("\
+		Do not use the Mesmer Eye to convert other crew members into antagonists.\
+		Neither you nor the target are exempt from normal server standards. Act accordingly."
+	))

--- a/modular_zzplurt/code/modules/modular_implants/code/nifsofts/brainwashing.dm
+++ b/modular_zzplurt/code/modules/modular_implants/code/nifsofts/brainwashing.dm
@@ -28,7 +28,5 @@
 		return
 
 	// Provide warning text
-	to_chat(target, span_doyourjobidiot("\
-		Do not use the Mesmer Eye to convert other crew members into antagonists.\
-		Neither you nor the target are exempt from normal server standards. Act accordingly."
-	))
+	to_chat(target, span_doyourjobidiot("Do not use the Mesmer Eye to convert other crew members into antagonists.\
+		Neither you nor the target are exempt from normal server standards. Act accordingly."))

--- a/modular_zzplurt/code/modules/uplink/uplink_items/implant.dm
+++ b/modular_zzplurt/code/modules/uplink/uplink_items/implant.dm
@@ -1,0 +1,6 @@
+// Brainwashing NIF
+/datum/uplink_item/implants/mesmereye
+	name = "Mesmer Eye Software"
+	desc = "An experimental NIF program capable of brainwashing other sapient creatures. Individuals that are especially strong-willed or loyal to the station will be immune."
+	item = /obj/item/disk/nifsoft_uploader/dorms/hypnosis/brainwashing
+	cost = 2

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10607,6 +10607,7 @@
 #include "modular_zzplurt\code\modules\thirst\mob_mood.dm"
 #include "modular_zzplurt\code\modules\thirst\reagents.dm"
 #include "modular_zzplurt\code\modules\thirst\screen_hud.dm"
+#include "modular_zzplurt\code\modules\uplink\uplink_items\implant.dm"
 #include "modular_zzplurt\code\modules\vending\autodrobe.dm"
 #include "modular_zzplurt\code\modules\vending\boozeomat.dm"
 #include "modular_zzplurt\code\modules\vending\clothmate.dm"


### PR DESCRIPTION
## About The Pull Request
This PR is intended to reduce potential misuse of the Mesmer Eye NIF program, and reduce the overlap with its ERP counterpart. The item is now only available from from an antagonist uplink, rather than being printed from a protolathe. Additional warnings and checks have been added to discourage misuse.

Changes
- Added check for "Be Antagonist" toggle
- Added warning text when installing the NIF disk
- Added uplink entry for the NIF disk under implants
- Removed Mesmer Eye techweb entry and protolathe recipe
- Updated flavor text and user messages

## Why It's Good For The Game
This restricts an item capable of creating "fake antagonists" to players who have already been given an antagonist role. Jobs that cannot become antagonists will have no longer have immediate access to it. Additional warnings and clearer text may reduce accidental misuse.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
Tested in a local server.
</details>

## Changelog

:cl:
add: Added Mesmer Eye NIFSoft to the traitor uplink
add: Added more warning text to the Mesmer Eye NIFSoft
add: Mesmer Eye now requires the target to have Be Antagonist enabled
del: Removed Mesmer Eye techweb entry and protolathe recipe
/:cl:
