### PR TITLE
Fixes rampart kits even more.

### DIFF
--- a/modular_zzplurt/code/game/objects/items/armor_kits.dm
+++ b/modular_zzplurt/code/game/objects/items/armor_kits.dm
@@ -46,6 +46,10 @@
 
 	var/datum/armor/curr_armor = C.get_armor()
 
+	if(istype(curr_armor, /datum/armor/mod_theme))
+		to_chat(user, "<span class = 'notice'>You can't reinforce MODsuit parts with [src].</span>")
+		return NONE
+
 	for(var/curr_stat in ARMOR_LIST_DAMAGE())
 		if(curr_armor.get_rating(curr_stat) < actual_armor.get_rating(curr_stat))
 			used = TRUE


### PR DESCRIPTION
## About The Pull Request
Quite frankly, I must restrain myself as I talk about how rampart kits were initially coded. It would appear as though they were implemented poorly, with no, or at the very least, insanely small amounts of testing. Even basic features that could be tested with a single click did not function. Some of the comments even just straight up lies. 

Regardless, with the small rant out of the way, I've gone and cleaned it up and fixed it myself. The list of fixes are as such:

Rampart kit now actually checks if it can add armor properly, instead of just always adding it except for in very specific situations. IE, you can now no longer waste infinite rampart kits on the same item.

Armor is now simply set to be the same as the armor we're mirroring. Previously, a for loop would go through and check if the armor we want to add is greater then the armor we already have on the clothing, and only add it if it was. This means that no matter what any additional armor was never removed. This could lead to incredibly busted situations like this, a piece of sacrificial armor upgraded with a rampart kit:

<img width="444" height="229" alt="image" src="https://github.com/user-attachments/assets/dc8836bc-9e35-4d5e-b05f-389997b38fdb" />

We now check if the thing we are trying to reinforce is a mod suit, and if it is we disallow reinforcing it. The reasons for this should be pretty obvious.

We now transfer all the tags from the base armor to the new one. Some tags that aren't initially set by the base armor aren't transferred, allowing the new armor to keep it, however I can't think of a nice way to solve that and I don't care all that much right now, so I'm settling for this.
## Why It's Good For The Game
It's not, it's actually horrible and will drive our entire player base away.
## Proof Of Testing
My terminal calls me a slur when I try to compile this.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: UvvU
fix: fixed ramparts not removing armor it should
fix: mod suits can no longer be reinforced via rampart kits
fix: some tags are now transferred to the targeted clothing when a rampart kit is used on them
fix: rampart kits now actually check if they can reinforce something more, instead of always being used up
/:cl:
