### PR TITLE
Fixes broken sprite when toggling cloak back to its original icon state

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/toggle_base.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/toggle_base.dm
@@ -22,7 +22,10 @@
 	SIGNAL_HANDLER
 
 	toggled = !toggled
-	source.icon_state = (toggled ? toggled_icon_state : initial(source.icon_state))
+	//SPLURT EDIT CHANGE BEGIN	-	Cloak Toggle Fix
+	//source.icon_state = (toggled ? toggled_icon_state : initial(source.icon_state)) //ORIGINAL
+	source.icon_state = (toggled ? toggled_icon_state : (initial(source.post_init_icon_state) ? initial(source.post_init_icon_state) : initial(source.icon_state)))
+	//SPLURT EDIT CHANGE END
 	to_chat(clicker, "You toggle \the [source]!")
 	if(source.loc == clicker)
 		clicker.update_clothing(source.slot_flags)


### PR DESCRIPTION

## About The Pull Request
See title. What was issue here is that some cloaks had icon_state set to path instead of actual icon state and instead used post_init_icon_state, which method didn't count with. So I modified method to also check if there is anything in post_init_icon state.

## Why It's Good For The Game
Bugs bad (excluding moths)

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/aa002826-c9b6-428c-a4c0-dbecca33c921


</details>

## Changelog
:cl:
fix: fixed broken sprite for when you want to toggle cloaks back to their original state
/:cl:
