### PR TITLE
Changes thermal pistol goodie crate access to armory.

### DIFF
--- a/modular_zzplurt/code/modules/cargo/packs/general.dm
+++ b/modular_zzplurt/code/modules/cargo/packs/general.dm
@@ -9,3 +9,8 @@
 	desc = "An extremely expensive solution of shrinking serum known as Diminicillin. Effects are permanent upon consumption, and shrinking is slow."
 	cost = 100000
 	contains = list(/obj/item/reagent_containers/cup/bottle/diminicillin)
+
+//Overrides the thermal pistol pack to change the access level to armory
+/datum/supply_pack/goody/thermal_single
+	access_view = ACCESS_ARMORY
+	access = ACCESS_ARMORY


### PR DESCRIPTION
## About The Pull Request

Makes it so that you require armory access to purchase the thermal pistol goodie pack from cargo.

This is done as apart of a SOP change, and was requested by the staff member @toastewoofs 
## Why It's Good For The Game
Good for more clear SOP
## Proof Of Testing
Works on my machine. 
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: UvvU
balance: Thermal pistol goodie case now requires armory access to purchase.
/:cl:
