### PR TITLE
Fixed the stacking console being in the wrong place on tarkon

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -81,9 +81,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "aw" = (
-/obj/machinery/mineral/stacking_machine{
-	id_tag = "tarkon"
-	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/cargo)
@@ -13711,6 +13708,7 @@
 	id = "tarkonrecycle";
 	dir = 1
 	},
+/obj/machinery/mineral/stacking_machine,
 /turf/open/floor/plating/reinforced,
 /area/ruin/space/has_grav/port_tarkon/cargo)
 "VU" = (


### PR DESCRIPTION
## About The Pull Request

I moved the stacking console from the floor it was on to the conveyor where it needs to be.

## Why It's Good For The Game

It fixes the conveyor for trash in Tarkon

##Changelog

:cl:
map: Moved the stacking console on tarkon to the correct place
/:cl:

