### PR TITLE
Emote sounds for mutes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -405,8 +405,11 @@
 			to_chat(user, span_warning("You cannot use your hands to [key] right now!"))
 			return FALSE
 
-	if(HAS_TRAIT(user, TRAIT_EMOTEMUTE))
-		return FALSE
+//splurt REMOVAL
+	/*
+		if(HAS_TRAIT(user, TRAIT_MUTE))
+			return FALSE
+	*/
 
 	//SKYRAT EDIT BEGIN
 	if(allowed_species && ishuman(user))
@@ -429,8 +432,13 @@
  */
 /datum/emote/proc/should_play_sound(mob/user, intentional = FALSE)
 	if(emote_type & EMOTE_AUDIBLE && !hands_use_check)
+
+//splurt REMOVAL
+	/*
 		if(HAS_TRAIT(user, TRAIT_MUTE))
 			return FALSE
+	*/
+
 		if(ishuman(user))
 			var/mob/living/carbon/human/loud_mouth = user
 			if(HAS_MIND_TRAIT(loud_mouth, TRAIT_MIMING)) // vow of silence prevents outloud noises


### PR DESCRIPTION
Changes four lines of code effectively removing them to allow mute chars emotes to have sound


## About The Pull Request

For a while now mute chars from the quirk couldn't make sounds with their emotes it always bothered me, so now copying the work of https://github.com/IrisSS13/IrisStation/pull/179/changes/3dc74205592e4b1cf7beac1dd77cacb62c9d6643 they can!



## Why It's Good For The Game

Rp is the biggest reason, this allows a breadth of rp options for people that want to play mute chars. Maybe your char only can communicate by moos in a langauge native to their people or any other combo of sounds. It allows you the freedom to make your own langauges via emotes.  Mute also only ever mentions that you lose your speech it never felt right that you lost emotes nor did it make sense.

## Proof Of Testing
I tested it locally and the char did bark baa and more!




https://github.com/user-attachments/assets/c747a3df-bc7d-42a5-bf0e-5e2b3533dcc8

