### PR TITLE
add the red / black / purple kimonos in loadout

### DIFF
--- a/modular_zzplurt/code/modules/client/loadout/under.dm
+++ b/modular_zzplurt/code/modules/client/loadout/under.dm
@@ -231,3 +231,15 @@
 /datum/loadout_item/uniform/jeans_high
 	name = "High Waisted Jeans"
 	item_path = /obj/item/clothing/under/urban/jeans_high
+
+/datum/loadout_item/uniform/red_kimono
+	name = "Red Kimono"
+	item_path = /obj/item/clothing/under/costume/kimono/red
+
+/datum/loadout_item/uniform/black_kimono
+	name = "Black Kimono"
+	item_path = /obj/item/clothing/under/costume/kimono
+
+/datum/loadout_item/uniform/purple_kimono
+	name = "Purple Kimono"
+	item_path = /obj/item/clothing/under/costume/kimono/purple


### PR DESCRIPTION

## About The Pull Request
Noticed there were a few simple-looking kimonos that were just never added to loadout, despite being available in every clothesvend for free in the same category as a lot of loadout items. Now they're there!

## Why It's Good For The Game
Current kimonos are all kind of gaudy and droopy looking, where as these ones are simpler and more formal looking. They'd fit a lot of characters reasonably well, and having to get them from the clothesvend at the interlink or station is annoying and can potentially run you 30 bucks a shift. 

Also makes the character porting process easier for any characters from other servers that had these items in loadout.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="848" height="240" alt="image" src="https://github.com/user-attachments/assets/6abebda8-4cf6-4654-9cf0-442d839911d7" />

</details>

## Changelog
:cl:
add: Red, Purple and Black kimonos are now available in loadout.
/:cl:
