### PR TITLE
fixed poisoning of loot list for bitrunner and miner boss loot tables

### DIFF
--- a/code/modules/bitrunning/util/virtual_megafauna.dm
+++ b/code/modules/bitrunning/util/virtual_megafauna.dm
@@ -6,8 +6,23 @@
 
 	true_spawn = FALSE
 
+//// -----------SPLURT EDIT BELOW FULL REMAKE-----------
+
+
+	// Creates an instance-local shallow copy of `loot`
+	if(loot)
+		var/list/new_loot = list()
+		for(var/key in loot)
+			new_loot[key] = loot[key]
+		loot = new_loot
 	loot.Cut()
 	loot += /obj/structure/closet/crate/secure/bitrunning/encrypted
 
+	// Creates an instance-local shallow copy of `crusher_loot`
+	if(crusher_loot)
+		var/list/new_crusher = list()
+		for(var/key in crusher_loot)
+			new_crusher[key] = crusher_loot[key]
+		crusher_loot = new_crusher
 	crusher_loot.Cut()
 	crusher_loot += /obj/structure/closet/crate/secure/bitrunning/encrypted


### PR DESCRIPTION
a proc was mutating the boss loot lists in-place. Because those lists are declared at prototype scope and shared by default, mutating them on one instance (the virtual boss) changes the same list object every other instance reads


basically it was fucking up loot spawn for miners to give them the cache.

#738 