### PR TITLE
feat: Add bodycams for security and heads

### DIFF
--- a/code/modules/clothing/under/accessories/bodycam.dm
+++ b/code/modules/clothing/under/accessories/bodycam.dm
@@ -1,0 +1,26 @@
+/obj/item/clothing/accessory/bodycam
+	name = "security bodycam"
+	desc = "A small, rugged camera designed to be worn on the chest. Streams video to the station's camera network."
+	icon_state = "press_badge"
+	var/camera_network = "SS13"
+	var/c_tag_prefix = "Bodycam"
+	var/datum/component/simple_bodycam/cam_component
+
+/obj/item/clothing/accessory/bodycam/accessory_equipped(obj/item/clothing/under/clothes, mob/living/user)
+	if(user)
+		cam_component = user.AddComponent(/datum/component/simple_bodycam, \
+			camera_name = "[c_tag_prefix] ([user.real_name])", \
+			c_tag = "[c_tag_prefix] ([user.real_name])", \
+			network = camera_network, \
+			emp_proof = FALSE)
+
+/obj/item/clothing/accessory/bodycam/accessory_dropped(obj/item/clothing/under/clothes, mob/living/user)
+	if(cam_component)
+		qdel(cam_component)
+		cam_component = null
+
+/obj/item/clothing/accessory/bodycam/head
+	name = "command bodycam"
+	desc = "A small, rugged camera designed to be worn on the chest. Streams video to the station's camera network."
+	camera_network = "COMMAND"
+	c_tag_prefix = "Command Bodycam"

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -66,6 +66,7 @@
 	id_trim = /datum/id_trim/job/captain
 	uniform = /obj/item/clothing/under/rank/captain
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace
+	accessory = /obj/item/clothing/accessory/bodycam/head
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/gold = 1,
 		/obj/item/station_charter = 1,

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -66,6 +66,7 @@
 	id = /obj/item/card/id/advanced/silver
 	id_trim = /datum/id_trim/job/chief_engineer
 	uniform = /obj/item/clothing/under/rank/engineering/chief_engineer
+	accessory = /obj/item/clothing/accessory/bodycam/head
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/silver = 1,
 // 		/obj/item/construction/rcd/ce = 1, // BUBBER EDIT -> MOVED TO LOCKER

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -61,6 +61,7 @@
 	uniform = /obj/item/clothing/under/rank/medical/chief_medical_officer
 	suit = /obj/item/clothing/suit/toggle/labcoat/cmo
 	suit_store = /obj/item/flashlight/pen/paramedic
+	accessory = /obj/item/clothing/accessory/bodycam/head
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/silver = 1,
 		)

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -56,6 +56,7 @@
 	id_trim = /datum/id_trim/job/detective
 	uniform = /obj/item/clothing/under/rank/security/detective
 	suit = /obj/item/clothing/suit/toggle/jacket/det_trench
+	accessory = /obj/item/clothing/accessory/bodycam
 	backpack_contents = list(
 		/obj/item/detective_scanner = 1,
 		/obj/item/melee/baton = 1,

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -97,6 +97,7 @@
 	id = /obj/item/card/id/advanced/platinum
 	id_trim = /datum/id_trim/job/head_of_personnel
 	uniform = /obj/item/clothing/under/rank/civilian/head_of_personnel
+	accessory = /obj/item/clothing/accessory/bodycam/head
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/silver = 1,
 		)

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -55,6 +55,7 @@
 	uniform = /obj/item/clothing/under/rank/security/head_of_security
 	suit = /obj/item/clothing/suit/armor/hos/trenchcoat
 	suit_store = /obj/item/gun/energy/e_gun //BUBBER EDIT - REVERTS SKYRAT REMOVAL
+	accessory = /obj/item/clothing/accessory/bodycam/head
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
 		/obj/item/melee/baton/security/loaded/hos = 1,

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -61,6 +61,7 @@
 	id_trim = /datum/id_trim/job/research_director
 	uniform = /obj/item/clothing/under/rank/rnd/research_director/turtleneck
 	suit = /obj/item/clothing/suit/toggle/labcoat/research_director
+	accessory = /obj/item/clothing/accessory/bodycam/head
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/silver = 1,
 		)

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -229,6 +229,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	uniform = /obj/item/clothing/under/rank/security/officer
 	suit = /obj/item/clothing/suit/armor/vest/alt/sec
 	suit_store = /obj/item/gun/energy/e_gun/advtaser //BUBBER EDIT CHANGE - Original: /obj/item/gun/energy/disabler
+	accessory = /obj/item/clothing/accessory/bodycam
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
 		/obj/item/flashlight/seclite = 1, // BUBBER EDIT ADDITION

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -51,6 +51,7 @@
 	uniform = /obj/item/clothing/under/rank/security/warden
 	suit = /obj/item/clothing/suit/armor/vest/warden //SKYRAT EDIT CHANGE - Original: /obj/item/clothing/suit/armor/vest/warden/alt
 	suit_store = /obj/item/gun/energy/e_gun/advtaser //BUBBER EDIT CHANGE - Original: /obj/item/gun/energy/disabler
+	accessory = /obj/item/clothing/accessory/bodycam
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
 		/obj/item/flashlight/seclite = 1, //BUBBER EDIT

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4376,6 +4376,7 @@
 #include "code\modules\clothing\under\accessories\_accessories.dm"
 #include "code\modules\clothing\under\accessories\armbands.dm"
 #include "code\modules\clothing\under\accessories\badges.dm"
+#include "code\modules\clothing\under\accessories\bodycam.dm"
 #include "code\modules\clothing\under\accessories\medals.dm"
 #include "code\modules\clothing\under\accessories\tribal.dm"
 #include "code\modules\clothing\under\accessories\vests.dm"


### PR DESCRIPTION
Resolves #872. Adds `obj/item/clothing/accessory/bodycam` (and a `/head` variant) which attaches the `simple_bodycam` component to the wearer. Bodycams are now equipped by default to all Security roles (Officer, Warden, Detective, HoS) and Command staff (Captain, HoP, CE, CMO, RD) in their accessory slot.