### PR TITLE
Crocin/Hexacrocin capitalization fixes. Fixes for the Isolation Cell drink.

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/crocin.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/crocin.dm
@@ -1,6 +1,6 @@
 // Crocin. Basic aphrodisiac with no consequences
 /datum/reagent/drug/aphrodisiac/crocin
-	name = "crocin"
+	name = "Crocin"
 	description = "Naturally found in the crocus and gardenia flowers, this drug acts as a natural and safe aphrodisiac."
 	taste_description = "strawberries"
 	color = "#FFADFF"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/hexacrocin.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/hexacrocin.dm
@@ -2,7 +2,7 @@
 
 // Hexacrocin. Advanced aphrodisiac that can cause brain traumas.
 /datum/reagent/drug/aphrodisiac/crocin/hexacrocin
-	name = "hexacrocin"
+	name = "Hexacrocin"
 	description = "Chemically condensed form of basic crocin. This aphrodisiac is extremely powerful and addictive for most animals.\
 					Addiction withdrawals can cause brain damage and shortness of breath. Overdose can lead to brain traumas."
 	taste_description = "liquid desire"

--- a/modular_zzplurt/code/controllers/subsystem/interactions.dm
+++ b/modular_zzplurt/code/controllers/subsystem/interactions.dm
@@ -129,7 +129,7 @@ PROCESSING_SUBSYSTEM_DEF(interactions)
 		/datum/reagent/consumable/ethanol/hellfire,
 		/datum/reagent/consumable/ethanol/hotlime_miami,
 		/datum/reagent/consumable/ethanol/crevice_spike,
-		/datum/reagent/consumable/ethanol/isloation_cell/morphine,
+		/datum/reagent/consumable/ethanol/isolation_cell/morphine,
 		/datum/reagent/consumable/ethanol/chemical_ex,
 		/datum/reagent/consumable/ethanol/heart_of_gold,
 		/datum/reagent/consumable/ethanol/moth_in_chief,

--- a/modular_zzplurt/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
+++ b/modular_zzplurt/code/modules/food_and_drinks/recipes/drinks/drinks_alcoholic.dm
@@ -20,22 +20,6 @@
 	results = list(/datum/reagent/consumable/ethanol/mech_rider = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/absinthe = 1, /datum/reagent/consumable/ethanol/hcider = 1, /datum/reagent/consumable/ethanol/syndicatebomb = 1, /datum/reagent/consumable/coffee = 1)
 
-/datum/chemical_reaction/drink/isloation_cell
-	results = list(/datum/reagent/consumable/ethanol/isloation_cell = 5)
-	required_reagents = list(
-		/datum/reagent/drug/aphrodisiac = 1,
-		/datum/reagent/medicine/synaptizine = 2,
-		/datum/reagent/consumable/ethanol/hippies_delight = 2
-	)
-
-/datum/chemical_reaction/drink/isloation_cell/morphine
-	results = list(/datum/reagent/consumable/ethanol/isloation_cell/morphine = 5)
-	required_reagents = list(
-		/datum/reagent/drug/aphrodisiac/crocin = 1,
-		/datum/reagent/medicine/morphine = 2,
-		/datum/reagent/consumable/ethanol/hippies_delight = 2
-	)
-
 /datum/chemical_reaction/drink/chemical_ex
 	results = list(/datum/reagent/consumable/ethanol/chemical_ex = 5)
 	required_reagents = list(
@@ -216,19 +200,19 @@
 	mix_message = "The mixture gives off a concerning aroma..."
 
 /datum/chemical_reaction/drink/isolation_cell
-	results = list(/datum/reagent/consumable/ethanol/isloation_cell = 10)
+	results = list(/datum/reagent/consumable/ethanol/isolation_cell = 10)
 	required_reagents = list(
 		/datum/reagent/consumable/ice = 3,
-		/datum/reagent/drug/aphrodisiac = 2,
+		/datum/reagent/drug/aphrodisiac/crocin = 2,
 		/datum/reagent/consumable/ethanol/vodka = 3,
 		/datum/reagent/consumable/ethanol/gin = 2
 	)
 	mix_message = "The mixture chills to an unsettling temperature..."
 
 /datum/chemical_reaction/drink/isolation_cell_morphine
-	results = list(/datum/reagent/consumable/ethanol/isloation_cell/morphine = 10)
+	results = list(/datum/reagent/consumable/ethanol/isolation_cell/morphine = 10)
 	required_reagents = list(
-		/datum/reagent/consumable/ethanol/isloation_cell = 5,
+		/datum/reagent/consumable/ethanol/isolation_cell = 5,
 		/datum/reagent/medicine/morphine = 2,
 		/datum/reagent/consumable/ethanol/hippies_delight = 3
 	)

--- a/modular_zzplurt/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/modular_zzplurt/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -66,24 +66,24 @@
 	quality = DRINK_GOOD
 	taste_description = "the sweat of a certain Mauler pilot"
 
-/datum/reagent/consumable/ethanol/isloation_cell
+/datum/reagent/consumable/ethanol/isolation_cell
 	name = "Isolation Cell"
 	description = "Ice cubes in a padded Cell."
 	color = "#b4b4b4"
 	quality = DRINK_FANTASTIC
 	taste_description = "cloth dissolved in sulphuric acid."
 
-/datum/reagent/consumable/ethanol/isloation_cell/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
+/datum/reagent/consumable/ethanol/isolation_cell/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
 	if(!(current_cycle % 10)) //Every 10 cycles
 		drinker.reagents.add_reagent(/datum/reagent/drug/aphrodisiac, 2)
 
-/datum/reagent/consumable/ethanol/isloation_cell/morphine
+/datum/reagent/consumable/ethanol/isolation_cell/morphine
 	name = "Isolation Cell (Morphine)"
 	description = "It has a distinct, sour smell, much like morphine."
 	taste_description = "cloth dissolved in sulphuric acid. Something feels off about it."
 
-/datum/reagent/consumable/ethanol/isloation_cell/morphine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
+/datum/reagent/consumable/ethanol/isolation_cell/morphine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
 	if(!(current_cycle % 10)) //Every 10 cycles
 		drinker.reagents.add_reagent_list(list(/datum/reagent/medicine/morphine = 2, /datum/reagent/consumable/ethanol/hippies_delight = 1))

--- a/modular_zzplurt/code/modules/reagents/chemistry/reagents/drinks/glass_styles/alcohol.dm
+++ b/modular_zzplurt/code/modules/reagents/chemistry/reagents/drinks/glass_styles/alcohol.dm
@@ -47,15 +47,15 @@
 	icon = 'modular_zzplurt/icons/obj/drinks/drinks.dmi'
 	icon_state = "mech_rider_bottle"
 
-/datum/glass_style/drinking_glass/isloation_cell
-	required_drink_type = /datum/reagent/consumable/ethanol/isloation_cell
+/datum/glass_style/drinking_glass/isolation_cell
+	required_drink_type = /datum/reagent/consumable/ethanol/isolation_cell
 	name = "Isolation Cell"
 	desc = "Ice cubes in a padded Cell"
 	icon = 'modular_zzplurt/icons/obj/drinks/drinks.dmi'
 	icon_state = "isolationcell"
 
-/datum/glass_style/drinking_glass/isloation_cell/morphine
-	required_drink_type = /datum/reagent/consumable/ethanol/isloation_cell/morphine
+/datum/glass_style/drinking_glass/isolation_cell/morphine
+	required_drink_type = /datum/reagent/consumable/ethanol/isolation_cell/morphine
 	name = "Isolation Cell"
 	desc = "It has a distinct, sour smell, much like morphine."
 	icon = 'modular_zzplurt/icons/obj/drinks/drinks.dmi'


### PR DESCRIPTION

## About The Pull Request

Crocin and Hexacrocin are properly capitalized now, so they won't show up uncapitalized in the chemmaster or in drink recipes. Isolation Cell is no longer defined as 'isloation_cell'. Removed the Synaptizine based recipe and a redundant copy of the Morphine version. Fixed the Isolation Cell recipe to use Crocin instead of the unobtainable and base definition aphrodisiac chem of 'Liquid ERP'.

## Why It's Good For The Game

Typos are bad. Redundant recipes, also bad. Using the base aphrodisiac chem instead of the intended chem is, unsurprisingly, bad. Fixing sloppy work is good though.

## Proof Of Testing

It worked. I tested it. The recipes I removed no longer show up, and everything else worked fine.

## Changelog

:cl:
fix: Isolation Cell no longer requires the very essence of ERP itself to make, and instead uses the much more readily available Crocin
fix: Chemmasters and other chemical identifiers recognize Crocin and Hexacrocin with the proper capitalization they deserve
/:cl: