### PR TITLE
removed runed metal from space ruin 'rare material' spawns

### DIFF
--- a/modular_zzplurt/code/game/objects/effects/spawners/random/engineering.dm
+++ b/modular_zzplurt/code/game/objects/effects/spawners/random/engineering.dm
@@ -1,0 +1,9 @@
+// runed metal is utterly useless, and space roles need useful / valuable mats
+/obj/effect/spawner/random/engineering/material_rare
+	loot = list(
+		/obj/item/stack/sheet/mineral/diamond{amount = 15} = 15,
+		/obj/item/stack/sheet/mineral/uranium{amount = 15} = 15,
+		/obj/item/stack/sheet/mineral/plasma{amount = 15} = 15,
+		/obj/item/stack/sheet/mineral/gold{amount = 15} = 15,
+		/obj/item/stack/sheet/plastic/fifty = 5,
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10123,6 +10123,7 @@
 #include "modular_zzplurt\code\game\objects\effects\overlays\packing_peanuts.dm"
 #include "modular_zzplurt\code\game\objects\effects\posters\contraband.dm"
 #include "modular_zzplurt\code\game\objects\effects\spawners\ai_spawner_removal.dm"
+#include "modular_zzplurt\code\game\objects\effects\spawners\random\engineering.dm"
 #include "modular_zzplurt\code\game\objects\items\armor_kits.dm"
 #include "modular_zzplurt\code\game\objects\items\cards_ids.dm"
 #include "modular_zzplurt\code\game\objects\items\emags.dm"


### PR DESCRIPTION
## About The Pull Request

Modularly overrides the rare material spawn loot table so it doesn't spit out useless cult scrap anymore.

## Why It's Good For The Game

'Rare Material' spawners are used to give the black market dealer a slight headstart / something to sell, and as loot in particularly valuable or well stocked areas of space. Despite this, they have a fairly high chance of spitting out _Runed Metal_, a material that the blood cult uses for.. something, I've never played cult. This material is completely and utterly useless to anyone in space, and if memory serves, has no sell value. It's completely out of place in a spawn pool of useful, uncommon materials, and can fuck over players pretty hard if what was supposed to be a stockpile of diamonds, plasma, and gold is all useless scrap metal.

## Proof Of Testing

<img width="212" height="244" alt="image" src="https://github.com/user-attachments/assets/873b4611-2fa0-40a8-adda-6f1258d9f728" />


## Changelog

:cl:
balance: Space Ruins can no longer supply useless materials in place of rare ones.
/:cl:
