### PR TITLE
Add 'Bottomshield' to alternative job titles

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -98,7 +98,7 @@
 		"Command Security Specialist",
 		"Command Protection Officer",
 		"Henchman",
-		"Bottomshield",
+		"Bottomshield", //SPLURT ADDITION
 	)
 
 /datum/job/botanist


### PR DESCRIPTION
I have never done this before, pls help
## About The Pull Request

I made or attempted to make 'Bottomshield' into an alternative job title for 'Blueshield'

## Why It's Good For The Game

Funny title for all of our bottoms that play bluey.

## Proof Of Testing

I have no idea how to do this

</details>

## Changelog

:cl:
add: Bottomshield as Blueshield alt job title

/:cl:

