### PR TITLE
Add 'Bottomshield' to alternative job titles + some honorifics

### DIFF
--- a/modular_zzplurt/code/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_zzplurt/code/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -566,6 +566,15 @@
 	LAZYADD(alt_titles, extra_titles)
 	. = ..()
 
+//Honorifics
+/datum/id_trim/job/blueshield/New()
+	var/list/extra_honorific = list(
+		"Blueshield",
+		"Bottomshield",
+	)
+	LAZYADD(honorifics, extra_honorific)
+	. = ..()
+
 /datum/job/nanotrasen_crew_trainer
 	alt_titles = list(
 		"Nanotrasen Crew Trainer",


### PR DESCRIPTION

## About The Pull Request
PR for a friend.

Adds bottomsheild as an alt title, and two honorifics.
"Blueshield",
"Bottomshield",

Made so that https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/pull/913 doesn't have to learn about the horrors of moduarity.
## Why It's Good For The Game
unngg cool title :)
## Proof Of Testing
I actually did test this small change funny enough
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: UvvU
add: Bottomshield as Blueshield alt job title
add: Blueshield and Bottomshield as honorifics
/:cl:
