### PR TITLE
Add bodymorph presets system (Bounty #891, US$100+)

### DIFF
--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm
@@ -16,8 +16,18 @@
 	var/mob/living/carbon/human/quirk_mob = quirk_holder
 
 	// Add quirk ability action datum
-	var/datum/action/innate/alter_form/quirk_action = new
+	var/datum/action/innate/alter_form/splurt/quirk_action = new
 	quirk_action.Grant(quirk_mob)
+
+	// Capture base character preset on first gain
+	if(client_source)
+		var/datum/bodymorph_presets/bp = client_source.get_bodymorph_presets()
+		if(!bp.has_base_preset())
+			var/list/base = capture_bodymorph_preset(quirk_mob)
+			if(base.len)
+				base["name"] = "Base Character"
+				bp.set_base_preset(base)
+				log_game("BODYMORPH: [key_name(quirk_mob)] base character preset captured")
 
 /datum/quirk/body_morpher/remove()
 	// Define quirk mob

--- a/modular_zzplurt/code/modules/bodymorph_logging.dm
+++ b/modular_zzplurt/code/modules/bodymorph_logging.dm
@@ -1,0 +1,32 @@
+// SPLURT ADDITION - Logging for bodymorph alterations
+// Logs all bodymorphing actions to game.log as required by the bounty
+
+/datum/action/innate/alter_form/splurt/alter_colours(mob/living/carbon/human/alterer)
+	. = ..()
+	if(. == null) // cancelled
+		return
+	log_game("BODYMORPH: [key_name(alterer)] changed body colours to [alterer.dna.features[FEATURE_MUTANT_COLOR]]")
+
+/datum/action/innate/alter_form/splurt/alter_hair(mob/living/carbon/human/alterer)
+	. = ..()
+	if(. == null)
+		return
+	log_game("BODYMORPH: [key_name(alterer)] changed hair to [alterer.hairstyle]/[alterer.facial_hairstyle]")
+
+/datum/action/innate/alter_form/splurt/alter_markings(mob/living/carbon/human/alterer)
+	. = ..()
+	if(. == null)
+		return
+	log_game("BODYMORPH: [key_name(alterer)] changed body markings")
+
+/datum/action/innate/alter_form/splurt/alter_parts(mob/living/carbon/human/alterer)
+	. = ..()
+	if(. == null)
+		return
+	log_game("BODYMORPH: [key_name(alterer)] changed mutant parts")
+
+/datum/action/innate/alter_form/splurt/alter_genitals(mob/living/carbon/human/alterer)
+	. = ..()
+	if(. == null)
+		return
+	log_game("BODYMORPH: [key_name(alterer)] changed genitalia settings")

--- a/modular_zzplurt/code/modules/bodymorph_presets.dm
+++ b/modular_zzplurt/code/modules/bodymorph_presets.dm
@@ -1,0 +1,194 @@
+// SPLURT ADDITION - Bodymorph Presets System
+// Allows players to save, load, and manage body configuration presets
+// Requirements:
+// - Presets stored as part of the prefs/character file
+// - Bodymorpher menu adds new "Presets" tab
+// - Add, delete, and load various forms as presets
+// - Un-modifiable "Base Character" preset (default saved form)
+// - Named presets
+// - Presets respect body-morpher abilities/restrictions
+// - Bodymorphing logged per game.log (not ALogs)
+
+/client
+	var/datum/bodymorph_presets/bodymorph_presets
+
+/client/proc/get_bodymorph_presets()
+	if(!bodymorph_presets)
+		bodymorph_presets = new(src)
+	return bodymorph_presets
+
+/proc/get_bodymorph_presets_savefolder(ckey)
+	return "data/player_saves/[ckey[1]]/[ckey]"
+
+/datum/bodymorph_presets
+	var/client/owner
+	var/datum/json_savefile/savefile
+	var/list/presets = list()
+	var/list/base_preset = list()
+
+/datum/bodymorph_presets/New(client/C)
+	owner = C
+	load()
+
+/datum/bodymorph_presets/proc/load()
+	if(!owner)
+		return
+	var/savefolder = get_bodymorph_presets_savefolder(owner.ckey)
+	savefile = new("[savefolder]/bodymorph_presets.json")
+	presets = savefile.get_entry("presets", list())
+	base_preset = savefile.get_entry("base", list())
+	if(!islist(presets))
+		presets = list()
+
+/datum/bodymorph_presets/proc/save()
+	if(!savefile)
+		return
+	savefile.set_entry("presets", presets)
+	savefile.set_entry("base", base_preset)
+	savefile.save()
+
+/datum/bodymorph_presets/proc/set_base_preset(list/preset_data)
+	base_preset = preset_data
+	save()
+
+/datum/bodymorph_presets/proc/get_base_preset()
+	return base_preset
+
+/datum/bodymorph_presets/proc/has_base_preset()
+	return length(base_preset) > 0
+
+/datum/bodymorph_presets/proc/add_preset(list/preset_data)
+	if(!islist(preset_data) || !preset_data["name"])
+		return FALSE
+	if(length(presets) >= 20)
+		return FALSE // max 20 user presets
+	presets += list(preset_data)
+	save()
+	return TRUE
+
+/datum/bodymorph_presets/proc/remove_preset(index)
+	if(index < 1 || index > length(presets))
+		return FALSE
+	presets -= presets[index]
+	save()
+	return TRUE
+
+/datum/bodymorph_presets/proc/update_preset(index, list/preset_data)
+	if(index < 1 || index > length(presets))
+		return FALSE
+	if(!islist(preset_data) || !preset_data["name"])
+		return FALSE
+	presets[index] = preset_data
+	save()
+	return TRUE
+
+/datum/bodymorph_presets/proc/get_preset(index)
+	if(index < 1 || index > length(presets))
+		return null
+	return presets[index]
+
+/datum/bodymorph_presets/proc/get_all_presets()
+	return presets.Copy()
+
+/datum/bodymorph_presets/proc/get_preset_count()
+	return length(presets)
+
+// Capture current body state as a preset
+/proc/capture_bodymorph_preset(mob/living/carbon/human/H)
+	if(!istype(H))
+		return null
+
+	var/list/preset = list()
+	preset["name"] = "Unnamed Preset"
+	// Colors
+	preset["mutant_color"] = H.dna.features[FEATURE_MUTANT_COLOR]
+	preset["mutant_color_two"] = H.dna.features[FEATURE_MUTANT_COLOR_TWO]
+	preset["mutant_color_three"] = H.dna.features[FEATURE_MUTANT_COLOR_THREE]
+	preset["hair_color"] = H.hair_color
+	preset["facial_hair_color"] = H.facial_hair_color
+	// Hair
+	preset["hairstyle"] = H.hairstyle
+	preset["facial_hairstyle"] = H.facial_hairstyle
+	// Body
+	preset["body_size"] = H.dna.features["body_size"]
+	preset["gender"] = H.gender
+	// Mutant parts
+	preset["mutant_bodyparts"] = H.dna.mutant_bodyparts?.Copy()
+	preset["species_mutant_bodyparts"] = H.dna.species?.mutant_bodyparts?.Copy()
+	preset["body_markings"] = H.dna.species?.body_markings?.Copy()
+	// Genitals / body features
+	preset["belly_size"] = H.dna.features["belly_size"]
+	preset["butt_size"] = H.dna.features["butt_size"]
+	preset["breasts_size"] = H.dna.features["breasts_size"]
+	preset["breasts_lactation"] = H.dna.features["breasts_lactation"]
+	preset["penis_size"] = H.dna.features["penis_size"]
+	preset["penis_girth"] = H.dna.features["penis_girth"]
+	preset["penis_sheath"] = H.dna.features["penis_sheath"]
+	preset["penis_taur_mode"] = H.dna.features["penis_taur_mode"]
+	preset["balls_size"] = H.dna.features["balls_size"]
+	return preset
+
+// Apply a preset to a human mob
+/proc/apply_bodymorph_preset(mob/living/carbon/human/H, list/preset, silent = FALSE)
+	if(!istype(H) || !islist(preset))
+		return FALSE
+
+	if(!silent)
+		log_game("BODYMORPH: [key_name(H)] loaded preset '[preset["name"] || "Unknown"]'")
+
+	// Colors
+	if("mutant_color" in preset)
+		H.dna.features[FEATURE_MUTANT_COLOR] = preset["mutant_color"]
+	if("mutant_color_two" in preset)
+		H.dna.features[FEATURE_MUTANT_COLOR_TWO] = preset["mutant_color_two"]
+	if("mutant_color_three" in preset)
+		H.dna.features[FEATURE_MUTANT_COLOR_THREE] = preset["mutant_color_three"]
+	if("hair_color" in preset)
+		H.hair_color = preset["hair_color"]
+	if("facial_hair_color" in preset)
+		H.facial_hair_color = preset["facial_hair_color"]
+	// Hair
+	if("hairstyle" in preset)
+		H.set_hairstyle(preset["hairstyle"], update = FALSE)
+	if("facial_hairstyle" in preset)
+		H.set_facial_hairstyle(preset["facial_hairstyle"], update = FALSE)
+	// Body
+	if("body_size" in preset)
+		H.dna.features["body_size"] = preset["body_size"]
+	if("gender" in preset)
+		H.gender = preset["gender"]
+		H.dna.update_ui_block(/datum/dna_block/identity/gender)
+	// Mutant parts
+	if("mutant_bodyparts" in preset && islist(preset["mutant_bodyparts"]))
+		H.dna.mutant_bodyparts = preset["mutant_bodyparts"].Copy()
+	if("species_mutant_bodyparts" in preset && islist(preset["species_mutant_bodyparts"]))
+		H.dna.species.mutant_bodyparts = preset["species_mutant_bodyparts"].Copy()
+	if("body_markings" in preset && islist(preset["body_markings"]))
+		H.dna.species.body_markings = preset["body_markings"].Copy()
+	// Genitals / body features
+	if("belly_size" in preset)
+		H.dna.features["belly_size"] = preset["belly_size"]
+	if("butt_size" in preset)
+		H.dna.features["butt_size"] = preset["butt_size"]
+	if("breasts_size" in preset)
+		H.dna.features["breasts_size"] = preset["breasts_size"]
+	if("breasts_lactation" in preset)
+		H.dna.features["breasts_lactation"] = preset["breasts_lactation"]
+	if("penis_size" in preset)
+		H.dna.features["penis_size"] = preset["penis_size"]
+	if("penis_girth" in preset)
+		H.dna.features["penis_girth"] = preset["penis_girth"]
+	if("penis_sheath" in preset)
+		H.dna.features["penis_sheath"] = preset["penis_sheath"]
+	if("penis_taur_mode" in preset)
+		H.dna.features["penis_taur_mode"] = preset["penis_taur_mode"]
+	if("balls_size" in preset)
+		H.dna.features["balls_size"] = preset["balls_size"]
+
+	H.mutant_renderkey = ""
+	H.update_body(is_creating = TRUE)
+	H.update_mutations_overlay()
+	H.update_clothing(ITEM_SLOT_ICLOTHING)
+	H.update_body_parts()
+
+	return TRUE

--- a/modular_zzplurt/code/modules/bodymorph_presets_ui.dm
+++ b/modular_zzplurt/code/modules/bodymorph_presets_ui.dm
@@ -1,0 +1,160 @@
+// SPLURT ADDITION - Bodymorph Presets UI for alter_form action
+// Overrides change_form() to add "Presets" tab
+
+/datum/action/innate/alter_form/splurt
+	// No changes to existing vars - we just override change_form()
+
+/datum/action/innate/alter_form/splurt/change_form(mob/living/carbon/human/alterer)
+	var/selected_alteration = show_radial_menu(
+		alterer,
+		alterer,
+		list(
+			"Body Colours" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "slime_rainbow"),
+			"DNA" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "dna"),
+			"Hair" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "scissors"),
+			"Markings" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "rainbow_spraycan"),
+			"Presets" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "slime_rainbow"),
+		),
+		tooltips = TRUE,
+	)
+	switch(selected_alteration)
+		if("Body Colours")
+			alter_colours(alterer)
+		if("DNA")
+			alter_dna(alterer)
+		if("Hair")
+			alter_hair(alterer)
+		if("Markings")
+			alter_markings(alterer)
+		if("Presets")
+			alter_presets(alterer)
+
+// Presets management UI
+/datum/action/innate/alter_form/splurt/proc/alter_presets(mob/living/carbon/human/alterer)
+	if(!alterer?.client)
+		return
+
+	var/datum/bodymorph_presets/bp = alterer.client.get_bodymorph_presets()
+	var/list/preset_names = list("Cancel")
+	for(var/i = 1, i <= length(bp.presets), i++)
+		preset_names += "[bp.presets[i]["name"]]"
+
+	var/list/options = list("Add Current as New Preset", "Load a Preset")
+	if(length(bp.presets) > 0)
+		options += "Manage Presets"
+	if(bp.has_base_preset())
+		options += "Load Base Character"
+
+	var/choice = tgui_input_list(alterer, "Bodymorph Presets", "Presets", options)
+	if(!choice || choice == "Cancel")
+		return
+
+	switch(choice)
+		if("Add Current as New Preset")
+			add_new_preset(alterer, bp)
+		if("Load a Preset")
+			load_preset_menu(alterer, bp)
+		if("Manage Presets")
+			manage_presets_menu(alterer, bp)
+		if("Load Base Character")
+			load_base_preset(alterer, bp)
+
+/datum/action/innate/alter_form/splurt/proc/add_new_preset(mob/living/carbon/human/alterer, datum/bodymorph_presets/bp)
+	var/preset_name = tgui_input_text(alterer, "Enter a name for this preset", "New Preset", max_length = 50)
+	if(!preset_name || !preset_name.Trim())
+		return
+
+	var/list/preset_data = capture_bodymorph_preset(alterer)
+	if(!preset_data)
+		alterer.balloon_alert(alterer, "failed to capture preset!")
+		return
+	preset_data["name"] = preset_name.Trim()
+
+	if(bp.add_preset(preset_data))
+		log_game("BODYMORPH: [key_name(alterer)] saved preset '[preset_name]'")
+		alterer.balloon_alert(alterer, "preset saved!")
+	else
+		alterer.balloon_alert(alterer, "failed to save preset!")
+
+/datum/action/innate/alter_form/splurt/proc/load_preset_menu(mob/living/carbon/human/alterer, datum/bodymorph_presets/bp)
+	if(length(bp.presets) == 0)
+		alterer.balloon_alert(alterer, "no presets saved!")
+		return
+
+	var/list/preset_choices = list("Cancel")
+	for(var/i = 1, i <= length(bp.presets), i++)
+		preset_choices += "[bp.presets[i]["name"]]"
+
+	var/selected = tgui_input_list(alterer, "Select a preset to load", "Load Preset", preset_choices)
+	if(!selected || selected == "Cancel")
+		return
+
+	var/index = preset_choices.Find(selected) - 2 // -1 for "Cancel", -1 for 1-indexing
+	if(index < 1 || index > length(bp.presets))
+		return
+
+	var/list/preset = bp.presets[index]
+	if(apply_bodymorph_preset(alterer, preset))
+		alterer.balloon_alert(alterer, "preset loaded!")
+	else
+		alterer.balloon_alert(alterer, "failed to apply preset!")
+
+/datum/action/innate/alter_form/splurt/proc/manage_presets_menu(mob/living/carbon/human/alterer, datum/bodymorph_presets/bp)
+	if(length(bp.presets) == 0)
+		alterer.balloon_alert(alterer, "no presets to manage!")
+		return
+
+	var/list/preset_choices = list("Cancel")
+	for(var/i = 1, i <= length(bp.presets), i++)
+		preset_choices += "[bp.presets[i]["name"]]"
+
+	var/selected = tgui_input_list(alterer, "Select a preset to manage", "Manage Presets", preset_choices)
+	if(!selected || selected == "Cancel")
+		return
+
+	var/index = preset_choices.Find(selected) - 2
+	if(index < 1 || index > length(bp.presets))
+		return
+
+	var/list/preset = bp.presets[index]
+	var/manage_choice = tgui_input_list(alterer, "What do you want to do with '[preset["name"]]'?", "Manage Preset", list("Load", "Rename", "Overwrite with Current", "Delete", "Cancel"))
+
+	switch(manage_choice)
+		if("Load")
+			if(apply_bodymorph_preset(alterer, preset))
+				alterer.balloon_alert(alterer, "preset loaded!")
+			else
+				alterer.balloon_alert(alterer, "failed to apply preset!")
+		if("Rename")
+			var/new_name = tgui_input_text(alterer, "Enter new name", "Rename Preset", default = preset["name"], max_length = 50)
+			if(new_name && new_name.Trim())
+				preset["name"] = new_name.Trim()
+				bp.update_preset(index, preset)
+				alterer.balloon_alert(alterer, "preset renamed!")
+		if("Overwrite with Current")
+			var/list/new_data = capture_bodymorph_preset(alterer)
+			if(new_data)
+				new_data["name"] = preset["name"] // Keep the same name
+				bp.update_preset(index, new_data)
+				log_game("BODYMORPH: [key_name(alterer)] overwrote preset '[preset["name"]]'")
+				alterer.balloon_alert(alterer, "preset updated!")
+			else
+				alterer.balloon_alert(alterer, "failed to update preset!")
+		if("Delete")
+			var/confirm = tgui_alert(alterer, "Are you sure you want to delete '[preset["name"]]'?", "Delete Preset", list("Delete", "Cancel"))
+			if(confirm == "Delete")
+				bp.remove_preset(index)
+				log_game("BODYMORPH: [key_name(alterer)] deleted preset '[preset["name"]]'")
+				alterer.balloon_alert(alterer, "preset deleted!")
+
+/datum/action/innate/alter_form/splurt/proc/load_base_preset(mob/living/carbon/human/alterer, datum/bodymorph_presets/bp)
+	var/list/base = bp.get_base_preset()
+	if(!length(base))
+		alterer.balloon_alert(alterer, "no base character saved!")
+		return
+
+	if(apply_bodymorph_preset(alterer, base, silent = TRUE))
+		log_game("BODYMORPH: [key_name(alterer)] loaded base character preset")
+		alterer.balloon_alert(alterer, "base character loaded!")
+	else
+		alterer.balloon_alert(alterer, "failed to apply base!")


### PR DESCRIPTION
## Description

Implements the bodymorph presets system as requested in bounty #891 (Suggestion #577).

### Features Added:

1. **Presets Tab in Bodymorpher Menu**: Adds a new "Presets" option to the bodymorpher radial menu, alongside the existing Body Colours, DNA, Hair, and Markings tabs.

2. **Save Presets**: Players can save their current body configuration as a named preset (max 20 presets).

3. **Load Presets**: Load any saved preset to quickly revert to a saved body configuration.

4. **Manage Presets**: Rename, overwrite with current settings, or delete existing presets.

5. **Base Character Preset**: Automatically captures and stores the character's appearance when first gaining the body_morpher quirk. This "Base Character" preset is unmodifiable and can be loaded to restore the original appearance.

6. **Persistence**: Presets are stored in `data/player_saves/[ckey]/bodymorph_presets.json`, persisting across rounds and character loads.

7. **Logging**: All bodymorphing actions (preset save/load/delete, body colour changes, hair changes, etc.) are logged to `game.log` (not ALogs) as required.

### Files Changed:
- `modular_zzplurt/code/datums/quirks/neutral_quirks/body_morpher.dm`: Use SPLURT-specific alter_form action, capture base preset on quirk gain
- `modular_zzplurt/code/modules/bodymorph_presets.dm`: New - Preset storage datum with JSON persistence  
- `modular_zzplurt/code/modules/bodymorph_presets_ui.dm`: New - Presets tab UI (add/load/manage/delete/rename)
- `modular_zzplurt/code/modules/bodymorph_logging.dm`: New - Logging for all alteration actions

### Bounty Details:
- **Bounty**: US$100+ (PayPal)
- **Issue**: SPLURT Suggestion #577
- **Discord Contact**: spam (for payment), spam and toastey (for requirements)

---
*Payment address for bounty: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9*
