### PR TITLE
Add Empty DIY Apartment/Mortician's Office to Hilbert's Hotel

### DIFF
--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -4592,6 +4592,9 @@
 	pixel_x = 0;
 	pixel_y = -6
 	},
+/obj/item/storage/box/lights/tubes,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/stack/cable_coil/thirty,
 /turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "Ld" = (

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -3073,12 +3073,6 @@
 	icon_state = "26,20"
 	},
 /area/misc/hilbertshotel)
-"xt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
-/area/misc/hilbertshotel)
 "xu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -5351,7 +5345,7 @@
 	name = "Cosmo's Apartment";
 	locked = 1
 	},
-/turf/closed/wall,
+/turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "RX" = (
 /obj/effect/abstract/marker{
@@ -6881,7 +6875,7 @@ lQ
 lQ
 lQ
 lQ
-xt
+lQ
 lQ
 lQ
 lQ

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -6,6 +6,14 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -93,17 +101,8 @@
 	},
 /area/misc/hilbertshotel)
 "aK" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "24,20"
-	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "aL" = (
 /obj/effect/abstract/marker{
@@ -220,17 +219,10 @@
 	},
 /area/misc/hilbertshotel)
 "ck" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "21,21"
-	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "cn" = (
 /obj/effect/abstract/marker{
@@ -316,6 +308,11 @@
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
+	},
+/obj/item/paper{
+	pixel_x = -7;
+	pixel_y = 11;
+	default_raw_text = "The details matters, even if the demograph is undesirable."
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -546,6 +543,12 @@
 	icon_state = "27,10"
 	},
 /area/misc/hilbertshotel)
+"eO" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
 "eS" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -584,6 +587,12 @@
 	base_icon_state = "0,34";
 	icon_state = "29,16"
 	},
+/area/misc/hilbertshotel)
+"fp" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "fx" = (
 /obj/effect/abstract/marker{
@@ -747,6 +756,14 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -770,30 +787,14 @@
 	},
 /area/misc/hilbertshotel)
 "hb" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "25,20"
-	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "hd" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "22,20"
-	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "hf" = (
 /obj/effect/abstract/marker{
@@ -944,6 +945,9 @@
 	dir = 4
 	},
 /obj/machinery/griddle,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "hR" = (
@@ -990,7 +994,8 @@
 	all_products_free = 1;
 	scan_id = 0;
 	pixel_x = 0;
-	pixel_y = -5
+	pixel_y = -5;
+	shut_up = 1
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
@@ -1007,7 +1012,7 @@
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "elevatorshaft";
 	color = "#878787";
-	dir = 3
+	dir = 6
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -1276,25 +1281,10 @@
 	},
 /area/misc/hilbertshotel)
 "kH" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "20,20"
-	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "kK" = (
 /obj/effect/abstract/marker{
@@ -1353,6 +1343,9 @@
 	pixel_x = -1;
 	pixel_y = -1
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "kY" = (
@@ -1383,6 +1376,9 @@
 /area/misc/hilbertshotel)
 "ld" = (
 /obj/structure/table,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "li" = (
@@ -1450,6 +1446,15 @@
 	name = "long way down"
 	},
 /area/misc/hilbertshotel)
+"mp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/games{
+	shut_up = 1;
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/turf/closed/wall,
+/area/misc/hilbertshotel)
 "ms" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -1464,17 +1469,24 @@
 	},
 /area/misc/hilbertshotel)
 "mz" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	anchored = 1;
+	dir = 9
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "20,21"
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
 	},
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "mF" = (
 /obj/effect/abstract/marker{
@@ -1532,6 +1544,7 @@
 	pixel_x = 0;
 	pixel_y = -31
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "nb" = (
@@ -1540,6 +1553,12 @@
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	icon = 'icons/turf/decals.dmi';
+	dir = 3;
+	color = "#878787"
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2002,11 +2021,29 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "22,22"
 	},
+/area/misc/hilbertshotel)
+"qD" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "qE" = (
 /obj/effect/abstract/marker{
@@ -2106,6 +2143,7 @@
 	anchored = 1;
 	name = "speaker"
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "qU" = (
@@ -2315,7 +2353,8 @@
 	name = "built-in NiCola Apartmental Vending Machine";
 	desc = "It's almost as if those housing companies intentionally leave zero space for proper kitchens to force you to buy from those built-in vendors...";
 	pixel_x = 0;
-	pixel_y = -4
+	pixel_y = -4;
+	shut_up = 1
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
@@ -2353,6 +2392,9 @@
 "sD" = (
 /obj/machinery/oven/range,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "sH" = (
@@ -2526,11 +2568,11 @@
 	},
 /area/misc/hilbertshotel)
 "tK" = (
-/obj/machinery/vending/dorms{
-	pixel_x = 0;
-	pixel_y = 5
+/obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "tR" = (
 /obj/structure/decorative{
@@ -2837,17 +2879,10 @@
 	},
 /area/misc/hilbertshotel)
 "vT" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "22,21"
-	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "ws" = (
 /obj/effect/abstract/marker{
@@ -3458,6 +3493,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "BW" = (
@@ -3491,17 +3529,10 @@
 	},
 /area/misc/hilbertshotel)
 "Ca" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "24,21"
-	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Cd" = (
 /obj/effect/abstract/marker{
@@ -3738,17 +3769,10 @@
 	},
 /area/misc/hilbertshotel)
 "EY" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "21,20"
-	},
+/turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "Fi" = (
 /obj/effect/abstract/marker{
@@ -3868,6 +3892,14 @@
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4087,6 +4119,9 @@
 /area/misc/hilbertshotel)
 "It" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "Iz" = (
@@ -4199,6 +4234,9 @@
 	pixel_x = -7;
 	pixel_y = 11;
 	default_raw_text = "Don't use this to get free shit, we're logging you - the sky wizards union."
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
@@ -4368,20 +4406,16 @@
 	},
 /area/misc/hilbertshotel)
 "Kq" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "25,21"
-	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Ks" = (
 /obj/structure/fireplace,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Kx" = (
@@ -4485,7 +4519,6 @@
 	},
 /area/misc/hilbertshotel)
 "Lb" = (
-/obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/wall{
 	pixel_x = -31;
 	pixel_y = 0
@@ -4782,6 +4815,14 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4814,25 +4855,27 @@
 	},
 /area/misc/hilbertshotel)
 "NF" = (
-/obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/siding/dark{
-	dir = 1
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/survival_pod{
 	name = "Restroom"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/hilbertshotel)
 "NQ" = (
@@ -4896,17 +4939,16 @@
 	},
 /area/misc/hilbertshotel)
 "NZ" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "23,20"
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"Og" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
 	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Oj" = (
 /obj/effect/abstract/marker{
@@ -4961,22 +5003,20 @@
 	},
 /area/misc/hilbertshotel)
 "Pk" = (
+/obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/machinery/door/morgue{
 	name = "Bedroom"
 	},
@@ -5118,6 +5158,9 @@
 	pixel_y = -3
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "Qh" = (
@@ -5411,6 +5454,7 @@
 /obj/machinery/room_controller/directional/south{
 	pixel_y = 32
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "Tm" = (
@@ -5484,6 +5528,14 @@
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5714,8 +5766,10 @@
 	},
 /area/misc/hilbertshotel)
 "Wy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/decorative{
-	icon_state = "siding_plain";
+	icon_state = "siding_plain_corner";
 	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "elevatorshaft";
@@ -5723,8 +5777,6 @@
 	dir = 1;
 	anchored = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
 /area/misc/hilbertshotel)
 "WI" = (
@@ -5793,6 +5845,9 @@
 	pixel_y = 9
 	},
 /obj/structure/marker_beacon/indigo,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Xg" = (
@@ -5892,6 +5947,7 @@
 	anchored = 1;
 	name = "speaker"
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Yy" = (
@@ -5921,11 +5977,12 @@
 	},
 /area/misc/hilbertshotel)
 "YD" = (
-/obj/machinery/door/airlock/survival_pod{
-	name = "Cosmo's Apartment";
-	locked = 1
+/obj/machinery/vending/dorms{
+	pixel_x = -6;
+	pixel_y = 0;
+	shut_up = 1
 	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "YL" = (
 /obj/effect/abstract/marker{
@@ -6029,17 +6086,10 @@
 	},
 /area/misc/hilbertshotel)
 "ZB" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "23,21"
-	},
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "ZC" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -6406,9 +6456,9 @@ rT
 Ja
 gF
 gF
-rT
-rT
-rT
+ZB
+vT
+NZ
 gF
 gF
 gF
@@ -6435,7 +6485,7 @@ gF
 gF
 Ks
 rT
-rT
+aK
 gF
 gF
 gF
@@ -6460,9 +6510,9 @@ rT
 gF
 gF
 gF
+Ca
 rT
-rT
-rT
+aK
 gF
 gF
 gF
@@ -6487,10 +6537,10 @@ Pk
 gF
 gF
 gF
+Ca
 rT
-rT
-rT
-rT
+Og
+vT
 Xe
 gF
 gF
@@ -6510,11 +6560,11 @@ tR
 Xs
 rd
 lQ
-rT
+kH
 gF
-rT
-rT
-rT
+ZB
+vT
+ck
 rT
 rT
 rT
@@ -6537,9 +6587,9 @@ qJ
 LM
 CP
 lQ
-QO
-rT
-rT
+qD
+vT
+ck
 rT
 rT
 rT
@@ -6564,14 +6614,14 @@ tR
 rf
 wu
 NF
+Ca
 rT
 rT
 rT
 rT
 rT
-rT
-rT
-rT
+hb
+hd
 Bz
 gF
 xu
@@ -6591,13 +6641,13 @@ tR
 ZH
 Ss
 lQ
+Ca
 rT
 rT
 rT
 rT
 rT
-rT
-rT
+aK
 gF
 VC
 gF
@@ -6613,18 +6663,18 @@ eA
 sA
 Nk
 mz
-kH
+GY
 Wy
 lQ
 lQ
 lQ
 IS
-rT
-qp
-rT
-rT
-rT
-rT
+hd
+tK
+hd
+hd
+hd
+Kq
 gF
 VC
 gF
@@ -6639,8 +6689,8 @@ mM
 cv
 fT
 GC
-ck
-EY
+tR
+gF
 lQ
 gF
 gF
@@ -6648,8 +6698,8 @@ gF
 QI
 gF
 gF
-zY
-zY
+eO
+fp
 ld
 Qd
 VC
@@ -6666,8 +6716,8 @@ IG
 cW
 UX
 qu
-vT
-hd
+tR
+gF
 lQ
 iu
 Lb
@@ -6675,7 +6725,7 @@ fK
 xW
 gF
 hZ
-zY
+EY
 zY
 zY
 na
@@ -6693,14 +6743,14 @@ up
 Jc
 qM
 TT
-ZB
-NZ
+tR
+gF
 lQ
 gF
 SQ
 xW
 uc
-tK
+gF
 su
 It
 hQ
@@ -6720,13 +6770,13 @@ OZ
 Yy
 if
 gz
-Ca
-aK
+tR
+gF
 lQ
 gF
 gF
 YD
-xu
+mp
 gF
 gF
 gF
@@ -6747,8 +6797,8 @@ Uw
 Wf
 pc
 ah
-Kq
-hb
+tR
+gF
 lQ
 lQ
 lQ

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -1,23 +1,19 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ah" = (
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/obj/structure/marker_beacon/violet,
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "25,22"
+	icon_state = "9,12"
 	},
 /area/misc/hilbertshotel)
 "ai" = (
@@ -27,6 +23,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -56,7 +53,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,14"
+	icon_state = "9,18"
 	},
 /area/misc/hilbertshotel)
 "aC" = (
@@ -66,16 +63,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 1
-	},
-/obj/structure/marker_beacon/violet,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -90,9 +78,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -124,10 +110,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/billboard/cvr{
-	pixel_x = 2;
-	pixel_y = -2
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -142,10 +125,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
-/obj/structure/marker_beacon/violet,
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -160,32 +140,25 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "4,17"
 	},
 /area/misc/hilbertshotel)
-"bz" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,17"
-	},
-/area/misc/hilbertshotel)
 "bG" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -206,6 +179,10 @@
 	},
 /area/misc/hilbertshotel)
 "bV" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -264,29 +241,20 @@
 	},
 /area/misc/hilbertshotel)
 "cx" = (
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "8,12"
-	},
-/area/misc/hilbertshotel)
-"cK" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,13"
 	},
 /area/misc/hilbertshotel)
 "cO" = (
@@ -309,15 +277,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/item/paper{
-	pixel_x = -7;
-	pixel_y = 11;
-	default_raw_text = "The details matters, even if the demograph is undesirable."
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,21"
+	icon_state = "11,16"
 	},
 /area/misc/hilbertshotel)
 "cU" = (
@@ -330,7 +293,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,6"
+	icon_state = "11,19"
 	},
 /area/misc/hilbertshotel)
 "cW" = (
@@ -366,11 +329,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing{
-	dir = 4;
-	pixel_y = 0
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -385,6 +344,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -418,12 +378,21 @@
 	},
 /area/misc/hilbertshotel)
 "dP" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -431,12 +400,19 @@
 	},
 /area/misc/hilbertshotel)
 "dV" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -455,19 +431,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "12,24"
-	},
-/area/misc/hilbertshotel)
-"ec" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,20"
 	},
 /area/misc/hilbertshotel)
 "eg" = (
@@ -504,19 +467,6 @@
 	icon_state = "20,24"
 	},
 /area/misc/hilbertshotel)
-"eB" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "26,17"
-	},
-/area/misc/hilbertshotel)
 "eD" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -540,7 +490,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,10"
+	icon_state = "10,13"
 	},
 /area/misc/hilbertshotel)
 "eO" = (
@@ -556,6 +506,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -661,10 +612,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -672,6 +619,14 @@
 	},
 /area/misc/hilbertshotel)
 "gb" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -691,6 +646,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -756,18 +712,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "24,22"
+	icon_state = "11,13"
 	},
 /area/misc/hilbertshotel)
 "gF" = (
@@ -780,6 +728,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -803,6 +752,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -855,23 +805,11 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "11,22"
-	},
-/area/misc/hilbertshotel)
-"hv" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,11"
 	},
 /area/misc/hilbertshotel)
 "hw" = (
@@ -905,21 +843,22 @@
 	},
 /area/misc/hilbertshotel)
 "hK" = (
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -928,12 +867,17 @@
 	},
 /area/misc/hilbertshotel)
 "hP" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -999,27 +943,6 @@
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
-"ia" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 6
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "19,20"
-	},
-/area/misc/hilbertshotel)
 "ib" = (
 /obj/structure/medieval/bed_2x2{
 	dir = 8;
@@ -1028,6 +951,15 @@
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "if" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -1037,7 +969,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "24,23"
+	icon_state = "10,8"
 	},
 /area/misc/hilbertshotel)
 "ij" = (
@@ -1047,23 +979,11 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "4,15"
-	},
-/area/misc/hilbertshotel)
-"ir" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,21"
 	},
 /area/misc/hilbertshotel)
 "iu" = (
@@ -1092,6 +1012,14 @@
 	},
 /area/misc/hilbertshotel)
 "iI" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -1156,19 +1084,6 @@
 	icon_state = "7,25"
 	},
 /area/misc/hilbertshotel)
-"jM" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "26,5"
-	},
-/area/misc/hilbertshotel)
 "jU" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -1189,23 +1104,11 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "6,22"
-	},
-/area/misc/hilbertshotel)
-"kl" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,15"
 	},
 /area/misc/hilbertshotel)
 "km" = (
@@ -1215,22 +1118,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "13,20"
+	icon_state = "11,18"
 	},
 /area/misc/hilbertshotel)
 "ks" = (
@@ -1266,18 +1157,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "12,20"
+	icon_state = "9,17"
 	},
 /area/misc/hilbertshotel)
 "kH" = (
@@ -1299,31 +1182,6 @@
 	icon_state = "8,27"
 	},
 /area/misc/hilbertshotel)
-"kL" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "17,20"
-	},
-/area/misc/hilbertshotel)
 "kN" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -1331,6 +1189,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1355,6 +1214,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1386,19 +1246,6 @@
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
 	icon_state = "15,14";
 	dir = 8
-	},
-/area/misc/hilbertshotel)
-"lk" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "26,19"
 	},
 /area/misc/hilbertshotel)
 "lD" = (
@@ -1439,6 +1286,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -1462,6 +1310,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1510,12 +1359,21 @@
 	},
 /area/misc/hilbertshotel)
 "mK" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/marker_beacon/burgundy{
+	pixel_x = 17;
+	pixel_y = 16
+	},
+/obj/structure/railing{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1556,12 +1414,21 @@
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "nb" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1588,6 +1455,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1608,12 +1476,21 @@
 	},
 /area/misc/hilbertshotel)
 "np" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1640,6 +1517,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1653,6 +1531,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -1667,6 +1546,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1680,6 +1560,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1693,6 +1574,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1713,12 +1595,17 @@
 	},
 /area/misc/hilbertshotel)
 "oz" = (
+/obj/structure/billboard/azik{
+	pixel_y = -4;
+	pixel_x = -20
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1755,7 +1642,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,14"
+	icon_state = "11,9"
 	},
 /area/misc/hilbertshotel)
 "oM" = (
@@ -1764,6 +1651,9 @@
 /turf/closed/wall,
 /area/misc/hilbertshotel)
 "oX" = (
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -1773,20 +1663,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,9"
-	},
-/area/misc/hilbertshotel)
-"pc" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "25,23"
+	icon_state = "9,10"
 	},
 /area/misc/hilbertshotel)
 "pe" = (
@@ -1802,20 +1679,16 @@
 	icon_state = "9,25"
 	},
 /area/misc/hilbertshotel)
-"ph" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,16"
-	},
-/area/misc/hilbertshotel)
 "ps" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -1825,7 +1698,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "12,21"
+	icon_state = "10,12"
 	},
 /area/misc/hilbertshotel)
 "pu" = (
@@ -1901,16 +1774,22 @@
 	},
 /area/misc/hilbertshotel)
 "pM" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -1919,12 +1798,18 @@
 	},
 /area/misc/hilbertshotel)
 "pT" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 4;
+	pixel_y = 0
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1970,21 +1855,23 @@
 	},
 /area/misc/hilbertshotel)
 "qi" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 4
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,5"
 	},
-/turf/open/indestructible/tram,
 /area/misc/hilbertshotel)
 "qk" = (
 /obj/effect/abstract/marker{
@@ -2017,19 +1904,19 @@
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "qu" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
 	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "elevatorshaft";
 	color = "#878787";
-	dir = 3
+	dir = 6
+	},
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2054,14 +1941,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2124,7 +2004,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "23,23"
+	icon_state = "11,17"
 	},
 /area/misc/hilbertshotel)
 "qN" = (
@@ -2185,6 +2065,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2224,10 +2105,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/billboard/azik{
-	pixel_y = -4;
-	pixel_x = -20
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2251,47 +2129,21 @@
 "rT" = (
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
-"sa" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,21"
-	},
-/area/misc/hilbertshotel)
 "sc" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
 /obj/effect/light_emitter/interlink{
 	light_color = "#ffe7cf";
 	light_power = 1.5
+	},
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "12,26"
-	},
-/area/misc/hilbertshotel)
-"sh" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "26,10"
 	},
 /area/misc/hilbertshotel)
 "si" = (
@@ -2327,6 +2179,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2367,10 +2220,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing{
-	dir = 8
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2400,12 +2250,21 @@
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "sH" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2413,6 +2272,11 @@
 	},
 /area/misc/hilbertshotel)
 "sK" = (
+/obj/item/paper{
+	pixel_x = -7;
+	pixel_y = 11;
+	default_raw_text = "The details matters, even if the demograph is undesirable."
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -2445,16 +2309,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	dir = 4;
-	color = "#878787";
-	pixel_x = -32
-	},
 /turf/open/indestructible/tram{
-	color = "#d6d6d6"
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,11"
 	},
 /area/misc/hilbertshotel)
 "ta" = (
@@ -2497,12 +2355,22 @@
 	},
 /area/misc/hilbertshotel)
 "tp" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2517,15 +2385,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2543,7 +2403,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,9"
+	icon_state = "9,13"
 	},
 /area/misc/hilbertshotel)
 "tI" = (
@@ -2553,15 +2413,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2646,19 +2498,19 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,11"
+	icon_state = "9,16"
 	},
 /area/misc/hilbertshotel)
 "um" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
-	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2686,7 +2538,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/railing,
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2701,6 +2553,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2708,6 +2561,12 @@
 	},
 /area/misc/hilbertshotel)
 "uJ" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -2717,7 +2576,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,23"
+	icon_state = "10,7"
 	},
 /area/misc/hilbertshotel)
 "uM" = (
@@ -2727,6 +2586,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2747,12 +2607,21 @@
 	},
 /area/misc/hilbertshotel)
 "vo" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2773,18 +2642,19 @@
 	},
 /area/misc/hilbertshotel)
 "vs" = (
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2825,10 +2695,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2868,6 +2734,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2899,6 +2766,10 @@
 /turf/open/floor/iron/white/diagonal,
 /area/misc/hilbertshotel)
 "ww" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -2908,7 +2779,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "19,21"
+	icon_state = "10,19"
 	},
 /area/misc/hilbertshotel)
 "wH" = (
@@ -2918,6 +2789,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2931,6 +2803,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2944,6 +2817,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2951,6 +2825,9 @@
 	},
 /area/misc/hilbertshotel)
 "wT" = (
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -2960,7 +2837,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,23"
+	icon_state = "9,8"
 	},
 /area/misc/hilbertshotel)
 "wX" = (
@@ -2970,6 +2847,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3026,7 +2904,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,20"
+	icon_state = "11,8"
 	},
 /area/misc/hilbertshotel)
 "xu" = (
@@ -3040,6 +2918,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3053,27 +2932,11 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "4,16"
-	},
-/area/misc/hilbertshotel)
-"xP" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,8"
 	},
 /area/misc/hilbertshotel)
 "xW" = (
@@ -3104,6 +2967,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3135,6 +2999,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3149,6 +3014,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3195,12 +3061,25 @@
 	},
 /area/misc/hilbertshotel)
 "zr" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3240,26 +3119,17 @@
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
-"zH" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,13"
-	},
-/area/misc/hilbertshotel)
 "zN" = (
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3296,25 +3166,23 @@
 /turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "Ad" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 4
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,11"
 	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
-/turf/open/indestructible/tram,
 /area/misc/hilbertshotel)
 "Ag" = (
 /obj/effect/abstract/marker{
@@ -3367,7 +3235,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "16,21"
+	icon_state = "9,9"
 	},
 /area/misc/hilbertshotel)
 "AC" = (
@@ -3377,6 +3245,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3384,59 +3253,34 @@
 	},
 /area/misc/hilbertshotel)
 "AD" = (
+/obj/structure/railing,
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "7,17"
 	},
 /area/misc/hilbertshotel)
-"AH" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "16,20"
-	},
-/area/misc/hilbertshotel)
 "AI" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/structure/fluff/metalpole{
+	dir = 8
 	},
 /obj/structure/fluff/metalpole{
 	dir = 4
 	},
-/obj/structure/fluff/metalpole{
-	dir = 8
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
 	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3451,23 +3295,11 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "9,21"
-	},
-/area/misc/hilbertshotel)
-"AU" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,10"
 	},
 /area/misc/hilbertshotel)
 "AZ" = (
@@ -3477,7 +3309,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/railing,
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3521,10 +3353,6 @@
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
-	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3574,7 +3402,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "14,21"
+	icon_state = "11,6"
 	},
 /area/misc/hilbertshotel)
 "CD" = (
@@ -3597,10 +3425,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/billboard/starway{
-	pixel_y = 0;
-	pixel_x = -34
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3619,19 +3444,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "3,20"
-	},
-/area/misc/hilbertshotel)
-"CM" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "26,13"
 	},
 /area/misc/hilbertshotel)
 "CO" = (
@@ -3691,7 +3503,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,15"
+	icon_state = "9,7"
 	},
 /area/misc/hilbertshotel)
 "DR" = (
@@ -3708,12 +3520,21 @@
 	},
 /area/misc/hilbertshotel)
 "Eh" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3785,6 +3606,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3792,12 +3614,21 @@
 	},
 /area/misc/hilbertshotel)
 "Fs" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3817,19 +3648,6 @@
 	icon_state = "29,18"
 	},
 /area/misc/hilbertshotel)
-"FU" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "26,7"
-	},
-/area/misc/hilbertshotel)
 "FX" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -3844,25 +3662,9 @@
 	},
 /area/misc/hilbertshotel)
 "FY" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "15,20"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "Gc" = (
 /obj/effect/abstract/marker{
@@ -3871,6 +3673,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3891,12 +3694,6 @@
 	},
 /area/misc/hilbertshotel)
 "GC" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
 	pixel_y = 0;
@@ -3904,6 +3701,12 @@
 	base_icon_state = "elevatorshaft";
 	color = "#878787";
 	dir = 3
+	},
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3918,14 +3721,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,7"
+	icon_state = "9,15"
 	},
 /area/misc/hilbertshotel)
 "GP" = (
@@ -3980,12 +3779,19 @@
 	},
 /area/misc/hilbertshotel)
 "Hh" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4007,6 +3813,14 @@
 	},
 /area/misc/hilbertshotel)
 "Ht" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -4020,12 +3834,14 @@
 	},
 /area/misc/hilbertshotel)
 "Hw" = (
+/obj/structure/railing,
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4046,6 +3862,14 @@
 	},
 /area/misc/hilbertshotel)
 "HE" = (
+/obj/structure/fluff/metalpole{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -4055,7 +3879,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,12"
+	icon_state = "10,9"
 	},
 /area/misc/hilbertshotel)
 "HO" = (
@@ -4072,22 +3896,13 @@
 	},
 /area/misc/hilbertshotel)
 "HW" = (
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4108,19 +3923,6 @@
 	icon_state = "29,10"
 	},
 /area/misc/hilbertshotel)
-"Is" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,5"
-	},
-/area/misc/hilbertshotel)
 "It" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /obj/effect/turf_decal/siding/white{
@@ -4138,33 +3940,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,6"
-	},
-/area/misc/hilbertshotel)
-"IC" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,16"
-	},
-/area/misc/hilbertshotel)
-"IF" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,19"
+	icon_state = "11,14"
 	},
 /area/misc/hilbertshotel)
 "IG" = (
@@ -4200,6 +3976,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4207,6 +3984,12 @@
 	},
 /area/misc/hilbertshotel)
 "IP" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -4216,7 +3999,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,22"
+	icon_state = "10,6"
 	},
 /area/misc/hilbertshotel)
 "IR" = (
@@ -4249,6 +4032,14 @@
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Jc" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -4281,14 +4072,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4309,20 +4093,13 @@
 	},
 /area/misc/hilbertshotel)
 "JV" = (
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
-/obj/structure/marker_beacon/violet,
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4350,6 +4127,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4371,17 +4149,25 @@
 	},
 /area/misc/hilbertshotel)
 "Kj" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 4
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "15,21"
-	},
+/turf/open/indestructible/tram,
 /area/misc/hilbertshotel)
 "Kl" = (
 /obj/effect/abstract/marker{
@@ -4393,7 +4179,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,5"
+	icon_state = "10,18"
 	},
 /area/misc/hilbertshotel)
 "Km" = (
@@ -4429,14 +4215,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,22"
+	icon_state = "10,17"
 	},
 /area/misc/hilbertshotel)
 "KA" = (
@@ -4453,12 +4235,17 @@
 	},
 /area/misc/hilbertshotel)
 "KF" = (
+/obj/structure/billboard/starway{
+	pixel_y = 0;
+	pixel_x = -34
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4466,12 +4253,17 @@
 	},
 /area/misc/hilbertshotel)
 "KL" = (
+/obj/structure/billboard/cvr{
+	pixel_x = 2;
+	pixel_y = -2
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4512,9 +4304,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 1
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4552,18 +4342,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "18,20"
+	icon_state = "11,10"
 	},
 /area/misc/hilbertshotel)
 "Lg" = (
@@ -4576,7 +4358,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,9"
+	icon_state = "10,15"
 	},
 /area/misc/hilbertshotel)
 "Lh" = (
@@ -4593,15 +4375,15 @@
 	},
 /area/misc/hilbertshotel)
 "Ll" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
-	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4630,12 +4412,18 @@
 /turf/closed/wall,
 /area/misc/hilbertshotel)
 "Lu" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 4;
+	pixel_y = 0
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4666,19 +4454,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "29,19"
-	},
-/area/misc/hilbertshotel)
-"LD" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,14"
 	},
 /area/misc/hilbertshotel)
 "LF" = (
@@ -4770,7 +4545,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,18"
+	icon_state = "9,6"
 	},
 /area/misc/hilbertshotel)
 "MJ" = (
@@ -4783,7 +4558,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,12"
+	icon_state = "9,5"
 	},
 /area/misc/hilbertshotel)
 "MW" = (
@@ -4799,26 +4574,7 @@
 	icon_state = "3,27"
 	},
 /area/misc/hilbertshotel)
-"Ne" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "18,21"
-	},
-/area/misc/hilbertshotel)
 "Nk" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
 	pixel_y = 0;
@@ -4826,6 +4582,16 @@
 	base_icon_state = "elevatorshaft";
 	color = "#878787";
 	dir = 3
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4889,23 +4655,11 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "4,19"
-	},
-/area/misc/hilbertshotel)
-"NU" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,18"
 	},
 /area/misc/hilbertshotel)
 "NV" = (
@@ -4918,28 +4672,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,11"
-	},
-/area/misc/hilbertshotel)
-"NY" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "14,20"
+	icon_state = "11,11"
 	},
 /area/misc/hilbertshotel)
 "NZ" = (
@@ -4964,7 +4697,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,18"
+	icon_state = "9,19"
 	},
 /area/misc/hilbertshotel)
 "OP" = (
@@ -4974,6 +4707,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5033,6 +4767,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5072,14 +4807,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/marker_beacon/burgundy{
-	pixel_x = 17;
-	pixel_y = 16
-	},
-/obj/structure/railing{
-	dir = 8
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5094,12 +4822,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5117,7 +4840,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,16"
+	icon_state = "10,16"
 	},
 /area/misc/hilbertshotel)
 "PY" = (
@@ -5134,12 +4857,23 @@
 	},
 /area/misc/hilbertshotel)
 "Qb" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5181,12 +4915,22 @@
 	},
 /area/misc/hilbertshotel)
 "Qi" = (
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5230,7 +4974,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "17,21"
+	icon_state = "11,15"
 	},
 /area/misc/hilbertshotel)
 "QW" = (
@@ -5266,6 +5010,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5295,7 +5040,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,8"
+	icon_state = "11,5"
 	},
 /area/misc/hilbertshotel)
 "RQ" = (
@@ -5312,12 +5057,21 @@
 	},
 /area/misc/hilbertshotel)
 "RX" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/obj/structure/marker_beacon/violet,
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5332,6 +5086,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5339,12 +5094,23 @@
 	},
 /area/misc/hilbertshotel)
 "Si" = (
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
+/obj/structure/marker_beacon/violet,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5375,19 +5141,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "17,26"
-	},
-/area/misc/hilbertshotel)
-"So" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "26,23"
 	},
 /area/misc/hilbertshotel)
 "Ss" = (
@@ -5444,9 +5197,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5533,18 +5284,10 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "23,22"
+	icon_state = "11,7"
 	},
 /area/misc/hilbertshotel)
 "Ub" = (
@@ -5554,11 +5297,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing{
-	dir = 4;
-	pixel_y = 0
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5599,6 +5338,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5606,15 +5346,15 @@
 	},
 /area/misc/hilbertshotel)
 "Vn" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
-	},
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5623,6 +5363,14 @@
 	},
 /area/misc/hilbertshotel)
 "Vv" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -5630,9 +5378,7 @@
 	name = "rain"
 	},
 /turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,22"
+	color = "#d6d6d6"
 	},
 /area/misc/hilbertshotel)
 "Vy" = (
@@ -5655,6 +5401,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5666,17 +5413,21 @@
 /turf/closed/wall,
 /area/misc/hilbertshotel)
 "VO" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 4
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,19"
-	},
+/turf/open/indestructible/tram,
 /area/misc/hilbertshotel)
 "VX" = (
 /obj/machinery/atmospherics/components/tank/air{
@@ -5698,6 +5449,14 @@
 	},
 /area/misc/hilbertshotel)
 "Wf" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -5717,30 +5476,12 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	icon_state = "4,7";
 	name = "long way down"
-	},
-/area/misc/hilbertshotel)
-"Wr" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "27,15"
 	},
 /area/misc/hilbertshotel)
 "Ws" = (
@@ -5790,6 +5531,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5816,6 +5558,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5823,18 +5566,19 @@
 	},
 /area/misc/hilbertshotel)
 "WQ" = (
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5861,14 +5605,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 3
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5885,7 +5622,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,7"
+	icon_state = "11,12"
 	},
 /area/misc/hilbertshotel)
 "Xs" = (
@@ -5918,6 +5655,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5931,6 +5669,7 @@
 	alpha = 100;
 	name = "rain"
 	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5955,6 +5694,14 @@
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Yy" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -5968,6 +5715,15 @@
 	},
 /area/misc/hilbertshotel)
 "YB" = (
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -5977,7 +5733,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "26,12"
+	icon_state = "10,10"
 	},
 /area/misc/hilbertshotel)
 "YD" = (
@@ -6002,6 +5758,9 @@
 	},
 /area/misc/hilbertshotel)
 "YM" = (
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -6011,20 +5770,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "27,20"
-	},
-/area/misc/hilbertshotel)
-"YN" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "13,21"
+	icon_state = "9,14"
 	},
 /area/misc/hilbertshotel)
 "YT" = (
@@ -6034,15 +5780,7 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/fluff/metalpole{
-	dir = 4
-	},
-/obj/structure/fluff/metalpole{
-	dir = 8
-	},
-/obj/structure/fluff/metalpole/anchor{
-	dir = 1
-	},
+/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -6064,6 +5802,10 @@
 	},
 /area/misc/hilbertshotel)
 "Zj" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
 	icon_state = "rain";
@@ -6073,20 +5815,7 @@
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
-	icon_state = "28,6"
-	},
-/area/misc/hilbertshotel)
-"Zk" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "28,17"
+	icon_state = "10,14"
 	},
 /area/misc/hilbertshotel)
 "ZB" = (
@@ -6156,19 +5885,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "17,27"
-	},
-/area/misc/hilbertshotel)
-"ZT" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "26,8"
 	},
 /area/misc/hilbertshotel)
 
@@ -6371,21 +6087,21 @@ aL
 Ru
 AL
 JF
-Ak
-oJ
-ZC
-ZC
-oJ
-Ls
+Oj
+av
+kA
+uf
+GN
+YM
+tz
+ah
 sZ
-sZ
-sZ
-sZ
-sZ
-sZ
-sZ
-sZ
-sZ
+oX
+Aq
+wT
+DC
+MC
+MJ
 ys
 "}
 (9,1,1) = {"
@@ -6398,20 +6114,20 @@ ff
 dd
 gf
 Xg
-tR
-QQ
-tS
-ib
-yD
-pU
-qi
-qi
+ww
+Kl
+Kx
+PR
+Lg
+Zj
+eL
+ps
 Ad
-qi
-qi
-qi
-qi
-qi
+YB
+HE
+if
+uJ
+IP
 qi
 ys
 "}
@@ -6425,6 +6141,85 @@ QJ
 hu
 kN
 qE
+cU
+km
+qM
+cQ
+QV
+Iz
+gz
+Xq
+NV
+Ld
+oL
+xs
+TT
+CB
+RO
+ys
+"}
+(11,1,1) = {"
+ys
+Sk
+sc
+WM
+dX
+Lh
+dP
+Ak
+oJ
+ZC
+ZC
+oJ
+Ls
+Vv
+Vv
+Vv
+Vv
+Vv
+Vv
+Vv
+Vv
+Vv
+Vv
+Vv
+ys
+"}
+(12,1,1) = {"
+ys
+fD
+sj
+gs
+zO
+pI
+np
+tR
+QQ
+tS
+ib
+yD
+pU
+VO
+VO
+Kj
+VO
+VO
+VO
+VO
+VO
+VO
+VO
+VO
+ys
+"}
+(13,1,1) = {"
+ys
+me
+nJ
+vv
+xo
+yZ
+sH
 tR
 QO
 rT
@@ -6440,18 +6235,18 @@ GY
 GY
 GY
 GY
+GY
+GY
 ys
 "}
-(11,1,1) = {"
+(14,1,1) = {"
 ys
-Sk
-sc
-WM
-dX
-Lh
-dP
-ps
-kA
+rL
+ub
+jU
+JT
+BX
+Eh
 NC
 rT
 rT
@@ -6467,18 +6262,18 @@ gF
 gF
 gF
 gF
+gF
+gF
 ys
 "}
-(12,1,1) = {"
+(15,1,1) = {"
 ys
-fD
-sj
-gs
-zO
-pI
-np
-YN
-km
+zv
+ks
+vr
+CO
+ek
+zr
 NC
 rT
 rT
@@ -6494,18 +6289,18 @@ gF
 gF
 gF
 gF
+gF
+gF
 ys
 "}
-(13,1,1) = {"
+(16,1,1) = {"
 ys
-me
-nJ
-vv
-xo
-yZ
-sH
-CB
-NY
+ZM
+Sn
+LF
+pB
+vI
+Fs
 tR
 fN
 eg
@@ -6521,18 +6316,18 @@ gF
 gF
 gF
 gF
+gF
+gF
 ys
 "}
-(14,1,1) = {"
+(17,1,1) = {"
 ys
-rL
-ub
-jU
-JT
-BX
-Eh
-Kj
-FY
+jv
+qk
+QW
+vm
+Ho
+vo
 tR
 xu
 lQ
@@ -6548,18 +6343,18 @@ vT
 Xe
 gF
 gF
+gF
+gF
 ys
 "}
-(15,1,1) = {"
+(18,1,1) = {"
 ys
-zv
-ks
-vr
-CO
-ek
-zr
-Aq
-AH
+kx
+PH
+NB
+JX
+Wu
+nb
 tR
 Xs
 rd
@@ -6575,18 +6370,18 @@ rT
 qN
 gF
 gF
+gF
+gF
 ys
 "}
-(16,1,1) = {"
+(19,1,1) = {"
 ys
-ZM
-Sn
-LF
-pB
-vI
-Fs
-QV
-kL
+Rb
+dh
+Sy
+eA
+sA
+Nk
 qJ
 LM
 CP
@@ -6602,18 +6397,18 @@ rT
 Ym
 xu
 xu
+xu
+xu
 ys
 "}
-(17,1,1) = {"
+(20,1,1) = {"
 ys
-jv
-qk
-QW
-vm
-Ho
-vo
-Ne
-Ld
+qU
+gm
+mM
+cv
+fT
+GC
 tR
 rf
 wu
@@ -6628,19 +6423,19 @@ hb
 hd
 Bz
 gF
+gF
+gF
 xu
 ys
 "}
-(18,1,1) = {"
+(21,1,1) = {"
 ys
-kx
-PH
-NB
-JX
-Wu
-nb
-ww
-ia
+yX
+HA
+IG
+cW
+UX
+qu
 tR
 ZH
 Ss
@@ -6655,17 +6450,17 @@ aK
 gF
 VC
 gF
+gF
+gF
 xu
 ys
 "}
-(19,1,1) = {"
+(22,1,1) = {"
 ys
-Rb
-dh
-Sy
-eA
-sA
-Nk
+aj
+HO
+up
+Jc
 mz
 GY
 Wy
@@ -6682,17 +6477,17 @@ Kq
 gF
 VC
 gF
+gF
+gF
 xu
 ys
 "}
-(20,1,1) = {"
+(23,1,1) = {"
 ys
-qU
-gm
-mM
-cv
-fT
-GC
+Ag
+um
+OZ
+Yy
 tR
 gF
 lQ
@@ -6709,17 +6504,17 @@ Qd
 VC
 VC
 gF
+gF
+gF
 xu
 ys
 "}
-(21,1,1) = {"
+(24,1,1) = {"
 ys
-yX
-HA
-IG
-cW
-UX
-qu
+hR
+hk
+Uw
+Wf
 tR
 gF
 lQ
@@ -6735,18 +6530,18 @@ zY
 na
 gF
 VC
+VC
+FY
 lQ
 lQ
 ys
 "}
-(22,1,1) = {"
+(25,1,1) = {"
 ys
-aj
-HO
-up
-Jc
-qM
-TT
+RG
+gh
+pu
+gb
 tR
 gF
 lQ
@@ -6761,19 +6556,19 @@ hQ
 sD
 kO
 gF
+gF
+gF
 zy
 pH
 lQ
 ys
 "}
-(23,1,1) = {"
+(26,1,1) = {"
 ys
-Ag
-um
-OZ
-Yy
-if
-gz
+fx
+Ep
+hi
+Ht
 tR
 gF
 lQ
@@ -6788,19 +6583,19 @@ xu
 gF
 gF
 gF
+gF
+gF
 VX
 hx
 lQ
 ys
 "}
-(24,1,1) = {"
+(27,1,1) = {"
 ys
-hR
-hk
-Uw
-Wf
-pc
-ah
+pL
+xp
+cn
+iI
 tR
 gF
 lQ
@@ -6815,90 +6610,11 @@ lQ
 lQ
 lQ
 lQ
+oM
 lQ
 lQ
 lQ
-ys
-"}
-(25,1,1) = {"
-ys
-RG
-gh
-pu
-gb
-So
-Kx
-cQ
-xs
-lk
-MC
-eB
-PR
-DC
-av
-CM
-YB
-uf
-sh
-oX
-ZT
-FU
-cU
-jM
-ys
-"}
-(26,1,1) = {"
-ys
-fx
-Ep
-hi
-Ht
-uJ
-IP
-sa
-YM
-IF
-NU
-bz
-ph
-Wr
-LD
-cK
-MJ
-hv
-eL
-tz
-xP
-Xq
-Iz
-Kl
-ys
-"}
-(27,1,1) = {"
-ys
-pL
-xp
-cn
-iI
-wT
-Vv
-ir
-ec
-VO
-Oj
-Zk
-IC
-kl
-oL
-zH
-HE
-NV
-AU
-Lg
-RO
-GN
-Zj
-Is
+lQ
 ys
 "}
 (28,1,1) = {"

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -1,0 +1,7054 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ah" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,22"
+	},
+/area/misc/hilbertshotel)
+"ai" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,22"
+	},
+/area/misc/hilbertshotel)
+"aj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,27"
+	},
+/area/misc/hilbertshotel)
+"av" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,14"
+	},
+/area/misc/hilbertshotel)
+"aC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
+/obj/structure/marker_beacon/violet,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,10";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"aG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,6";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"aK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,20"
+	},
+/area/misc/hilbertshotel)
+"aL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,23"
+	},
+/area/misc/hilbertshotel)
+"aY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/billboard/cvr{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,7";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"bm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/obj/structure/marker_beacon/violet,
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,8";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"bu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,17"
+	},
+/area/misc/hilbertshotel)
+"bz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,17"
+	},
+/area/misc/hilbertshotel)
+"bG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,18"
+	},
+/area/misc/hilbertshotel)
+"bJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,14"
+	},
+/area/misc/hilbertshotel)
+"bV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,22"
+	},
+/area/misc/hilbertshotel)
+"ck" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,21"
+	},
+/area/misc/hilbertshotel)
+"cn" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,25"
+	},
+/area/misc/hilbertshotel)
+"cq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,7"
+	},
+/area/misc/hilbertshotel)
+"cv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,24"
+	},
+/area/misc/hilbertshotel)
+"cx" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,12"
+	},
+/area/misc/hilbertshotel)
+"cG" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"cK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,13"
+	},
+/area/misc/hilbertshotel)
+"cO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,25"
+	},
+/area/misc/hilbertshotel)
+"cQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,21"
+	},
+/area/misc/hilbertshotel)
+"cU" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,6"
+	},
+/area/misc/hilbertshotel)
+"cW" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,24"
+	},
+/area/misc/hilbertshotel)
+"cZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,26"
+	},
+/area/misc/hilbertshotel)
+"da" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,12";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"dd" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,22"
+	},
+/area/misc/hilbertshotel)
+"dh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "20,26"
+	},
+/area/misc/hilbertshotel)
+"dv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,26"
+	},
+/area/misc/hilbertshotel)
+"dP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,22"
+	},
+/area/misc/hilbertshotel)
+"dV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,9";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"dX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,24"
+	},
+/area/misc/hilbertshotel)
+"ec" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,20"
+	},
+/area/misc/hilbertshotel)
+"eg" = (
+/obj/structure/mirror/directional/east,
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"ek" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,23"
+	},
+/area/misc/hilbertshotel)
+"eA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "20,24"
+	},
+/area/misc/hilbertshotel)
+"eB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,17"
+	},
+/area/misc/hilbertshotel)
+"eD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,24"
+	},
+/area/misc/hilbertshotel)
+"eL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,10"
+	},
+/area/misc/hilbertshotel)
+"eS" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,14"
+	},
+/area/misc/hilbertshotel)
+"ff" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,23"
+	},
+/area/misc/hilbertshotel)
+"fh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,16"
+	},
+/area/misc/hilbertshotel)
+"fx" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,27"
+	},
+/area/misc/hilbertshotel)
+"fA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,24"
+	},
+/area/misc/hilbertshotel)
+"fD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,27"
+	},
+/area/misc/hilbertshotel)
+"fK" = (
+/obj/structure/closet/secure_closet/wall{
+	pixel_x = -31;
+	pixel_y = 0
+	},
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/paperframes/twenty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/cloth/ten,
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/hilbertshotel)
+"fN" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"fT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,23"
+	},
+/area/misc/hilbertshotel)
+"gb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,24"
+	},
+/area/misc/hilbertshotel)
+"gf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,21"
+	},
+/area/misc/hilbertshotel)
+"gh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,26"
+	},
+/area/misc/hilbertshotel)
+"gm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,26"
+	},
+/area/misc/hilbertshotel)
+"gs" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,25"
+	},
+/area/misc/hilbertshotel)
+"gw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,24"
+	},
+/area/misc/hilbertshotel)
+"gz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,22"
+	},
+/area/misc/hilbertshotel)
+"gF" = (
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"gN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,20"
+	},
+/area/misc/hilbertshotel)
+"hb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,20"
+	},
+/area/misc/hilbertshotel)
+"hd" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,20"
+	},
+/area/misc/hilbertshotel)
+"hf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,21"
+	},
+/area/misc/hilbertshotel)
+"hi" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,25"
+	},
+/area/misc/hilbertshotel)
+"hk" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,26"
+	},
+/area/misc/hilbertshotel)
+"hr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,5"
+	},
+/area/misc/hilbertshotel)
+"hu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,22"
+	},
+/area/misc/hilbertshotel)
+"hv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,11"
+	},
+/area/misc/hilbertshotel)
+"hw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,20"
+	},
+/area/misc/hilbertshotel)
+"hx" = (
+/obj/machinery/telecomms/relay/preset/auto,
+/turf/open/space/basic,
+/area/misc/hilbertshotel)
+"hE" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,27"
+	},
+/area/misc/hilbertshotel)
+"hK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,8";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"hP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,16"
+	},
+/area/misc/hilbertshotel)
+"hQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/griddle,
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"hR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,27"
+	},
+/area/misc/hilbertshotel)
+"hT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,24"
+	},
+/area/misc/hilbertshotel)
+"hW" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,26"
+	},
+/area/misc/hilbertshotel)
+"hZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,8"
+	},
+/area/misc/hilbertshotel)
+"ia" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "19,20"
+	},
+/area/misc/hilbertshotel)
+"ib" = (
+/obj/structure/medieval/bed_2x2{
+	dir = 8;
+	anchored = 1
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"if" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,23"
+	},
+/area/misc/hilbertshotel)
+"ij" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,15"
+	},
+/area/misc/hilbertshotel)
+"ir" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,21"
+	},
+/area/misc/hilbertshotel)
+"iu" = (
+/obj/structure/wargame_hologram/ship_marker/large/alternate{
+	pixel_x = 0;
+	pixel_y = -8;
+	name = "lock marker";
+	desc = "Do not disturb."
+	},
+/turf/closed/indestructible/hoteldoor{
+	icon_state = "fake_door";
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi'
+	},
+/area/misc/hilbertshotel)
+"iD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "9,10";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"iG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,26"
+	},
+/area/misc/hilbertshotel)
+"iI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,24"
+	},
+/area/misc/hilbertshotel)
+"jv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "18,27"
+	},
+/area/misc/hilbertshotel)
+"jw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "3,11";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"jD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,19"
+	},
+/area/misc/hilbertshotel)
+"jK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,25"
+	},
+/area/misc/hilbertshotel)
+"jM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,5"
+	},
+/area/misc/hilbertshotel)
+"jU" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,25"
+	},
+/area/misc/hilbertshotel)
+"jX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,22"
+	},
+/area/misc/hilbertshotel)
+"kl" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,15"
+	},
+/area/misc/hilbertshotel)
+"km" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,20"
+	},
+/area/misc/hilbertshotel)
+"ks" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,26"
+	},
+/area/misc/hilbertshotel)
+"kx" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "19,27"
+	},
+/area/misc/hilbertshotel)
+"kA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,20"
+	},
+/area/misc/hilbertshotel)
+"kH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "20,20"
+	},
+/area/misc/hilbertshotel)
+"kK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,27"
+	},
+/area/misc/hilbertshotel)
+"kL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "17,20"
+	},
+/area/misc/hilbertshotel)
+"kN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,21"
+	},
+/area/misc/hilbertshotel)
+"kO" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"kY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,20"
+	},
+/area/misc/hilbertshotel)
+"lb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,23"
+	},
+/area/misc/hilbertshotel)
+"ld" = (
+/obj/structure/table,
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"li" = (
+/obj/structure/curtain/bounty,
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
+	icon_state = "15,14";
+	dir = 8
+	},
+/area/misc/hilbertshotel)
+"lk" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,19"
+	},
+/area/misc/hilbertshotel)
+"lD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,23"
+	},
+/area/misc/hilbertshotel)
+"lQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"me" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,27"
+	},
+/area/misc/hilbertshotel)
+"mo" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,11";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"ms" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,20"
+	},
+/area/misc/hilbertshotel)
+"mz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "20,21"
+	},
+/area/misc/hilbertshotel)
+"mF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,23"
+	},
+/area/misc/hilbertshotel)
+"mK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,15"
+	},
+/area/misc/hilbertshotel)
+"mM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,25"
+	},
+/area/misc/hilbertshotel)
+"na" = (
+/obj/structure/table,
+/obj/item/kitchen/rollingpin{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/rag{
+	pixel_x = -4
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/structure/sink/kitchen/directional/north{
+	pixel_x = 0;
+	pixel_y = -31
+	},
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"nb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "19,22"
+	},
+/area/misc/hilbertshotel)
+"ne" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,23"
+	},
+/area/misc/hilbertshotel)
+"nf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,19"
+	},
+/area/misc/hilbertshotel)
+"nm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,18"
+	},
+/area/misc/hilbertshotel)
+"np" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,22"
+	},
+/area/misc/hilbertshotel)
+"nJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,26"
+	},
+/area/misc/hilbertshotel)
+"nK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,14"
+	},
+/area/misc/hilbertshotel)
+"nN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,9";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"nO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,14"
+	},
+/area/misc/hilbertshotel)
+"oo" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,22"
+	},
+/area/misc/hilbertshotel)
+"ov" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,19"
+	},
+/area/misc/hilbertshotel)
+"oy" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,27"
+	},
+/area/misc/hilbertshotel)
+"oz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,13"
+	},
+/area/misc/hilbertshotel)
+"oJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,18"
+	},
+/area/misc/hilbertshotel)
+"oL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,14"
+	},
+/area/misc/hilbertshotel)
+"oM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,18"
+	},
+/area/misc/hilbertshotel)
+"oX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,9"
+	},
+/area/misc/hilbertshotel)
+"pc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,23"
+	},
+/area/misc/hilbertshotel)
+"pe" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,25"
+	},
+/area/misc/hilbertshotel)
+"ph" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,16"
+	},
+/area/misc/hilbertshotel)
+"ps" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,21"
+	},
+/area/misc/hilbertshotel)
+"pu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,25"
+	},
+/area/misc/hilbertshotel)
+"py" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,11"
+	},
+/area/misc/hilbertshotel)
+"pB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "17,24"
+	},
+/area/misc/hilbertshotel)
+"pH" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 8;
+	volume_rate = 200
+	},
+/turf/open/space/basic,
+/area/misc/hilbertshotel)
+"pI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,23"
+	},
+/area/misc/hilbertshotel)
+"pL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,27"
+	},
+/area/misc/hilbertshotel)
+"pM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,10";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"pT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,16"
+	},
+/area/misc/hilbertshotel)
+"pU" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	pixel_y = 32;
+	icon = 'icons/turf/decals.dmi';
+	dir = 2;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"pX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,17"
+	},
+/area/misc/hilbertshotel)
+"pZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,18"
+	},
+/area/misc/hilbertshotel)
+"qi" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram,
+/area/misc/hilbertshotel)
+"qk" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "18,26"
+	},
+/area/misc/hilbertshotel)
+"qm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,21"
+	},
+/area/misc/hilbertshotel)
+"qp" = (
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"qu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,22"
+	},
+/area/misc/hilbertshotel)
+"qE" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,20"
+	},
+/area/misc/hilbertshotel)
+"qG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,24"
+	},
+/area/misc/hilbertshotel)
+"qI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,11"
+	},
+/area/misc/hilbertshotel)
+"qJ" = (
+/obj/structure/curtain/bounty,
+/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
+	icon_state = "1,12";
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"qK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,21"
+	},
+/area/misc/hilbertshotel)
+"qM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,23"
+	},
+/area/misc/hilbertshotel)
+"qN" = (
+/obj/structure/table/bronze,
+/obj/machinery/status_display{
+	pixel_y = 6;
+	pixel_x = 16;
+	name = "TV screen";
+	desc = "An ancient, though still half-decent television screen, model M0-LDB."
+	},
+/obj/structure/decorative{
+	icon_state = "iron_catwalk";
+	pixel_y = 5;
+	icon = 'icons/obj/tiles.dmi';
+	base_icon_state = "iron_catwalk";
+	dir = 8;
+	pixel_x = -3;
+	anchored = 1;
+	name = "speaker"
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"qU" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,27"
+	},
+/area/misc/hilbertshotel)
+"rd" = (
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 8
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/hilbertshotel)
+"rf" = (
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/hilbertshotel)
+"rC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,5"
+	},
+/area/misc/hilbertshotel)
+"rL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,27"
+	},
+/area/misc/hilbertshotel)
+"rN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,15"
+	},
+/area/misc/hilbertshotel)
+"rP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/billboard/azik{
+	pixel_y = -4;
+	pixel_x = -20
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,9";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"rR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,27"
+	},
+/area/misc/hilbertshotel)
+"rT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"sa" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,21"
+	},
+/area/misc/hilbertshotel)
+"sc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,26"
+	},
+/area/misc/hilbertshotel)
+"sh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,10"
+	},
+/area/misc/hilbertshotel)
+"si" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,9"
+	},
+/area/misc/hilbertshotel)
+"sj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,26"
+	},
+/area/misc/hilbertshotel)
+"sq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,5";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"sr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,5"
+	},
+/area/misc/hilbertshotel)
+"su" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 5
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram,
+/area/misc/hilbertshotel)
+"sx" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,12";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"sA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "20,23"
+	},
+/area/misc/hilbertshotel)
+"sD" = (
+/obj/machinery/oven/range,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"sH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,22"
+	},
+/area/misc/hilbertshotel)
+"sK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,21"
+	},
+/area/misc/hilbertshotel)
+"sW" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,19"
+	},
+/area/misc/hilbertshotel)
+"sZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,5"
+	},
+/area/misc/hilbertshotel)
+"ta" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,24"
+	},
+/area/misc/hilbertshotel)
+"te" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,6"
+	},
+/area/misc/hilbertshotel)
+"ti" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,26"
+	},
+/area/misc/hilbertshotel)
+"tp" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,12";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"ts" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,8";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"tz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,9"
+	},
+/area/misc/hilbertshotel)
+"tI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,10";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"tK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/vending/dorms{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/hilbertshotel)
+"tR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,18"
+	},
+/area/misc/hilbertshotel)
+"tS" = (
+/obj/structure/decorative{
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	icon_state = "access_button_cycle";
+	pixel_x = 0;
+	pixel_y = 32;
+	dir = 1
+	},
+/obj/machinery/button/curtain{
+	pixel_y = 32;
+	id = "apartments_curtain_jerry";
+	alpha = 20;
+	color = "#FFFFFF"
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"tT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,13"
+	},
+/area/misc/hilbertshotel)
+"ub" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,26"
+	},
+/area/misc/hilbertshotel)
+"uc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 5
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,13"
+	},
+/area/misc/hilbertshotel)
+"uf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,11"
+	},
+/area/misc/hilbertshotel)
+"um" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,26"
+	},
+/area/misc/hilbertshotel)
+"up" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,25"
+	},
+/area/misc/hilbertshotel)
+"uu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/railing,
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,13";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"uD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,18"
+	},
+/area/misc/hilbertshotel)
+"uJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,23"
+	},
+/area/misc/hilbertshotel)
+"uL" = (
+/obj/machinery/vending/dinnerware{
+	all_products_free = 1;
+	scan_id = 0;
+	pixel_y = 32;
+	pixel_x = 0
+	},
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"uM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	icon = 'icons/turf/decals.dmi';
+	dir = 3;
+	color = "#878787"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,20"
+	},
+/area/misc/hilbertshotel)
+"vm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "18,24"
+	},
+/area/misc/hilbertshotel)
+"vo" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "18,22"
+	},
+/area/misc/hilbertshotel)
+"vr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,25"
+	},
+/area/misc/hilbertshotel)
+"vs" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,7";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"vu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,25"
+	},
+/area/misc/hilbertshotel)
+"vv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,25"
+	},
+/area/misc/hilbertshotel)
+"vF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,17"
+	},
+/area/misc/hilbertshotel)
+"vI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "17,23"
+	},
+/area/misc/hilbertshotel)
+"vK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,6"
+	},
+/area/misc/hilbertshotel)
+"vR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,7"
+	},
+/area/misc/hilbertshotel)
+"vT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,21"
+	},
+/area/misc/hilbertshotel)
+"ws" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,10"
+	},
+/area/misc/hilbertshotel)
+"wu" = (
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/white/diagonal,
+/area/misc/hilbertshotel)
+"ww" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "19,21"
+	},
+/area/misc/hilbertshotel)
+"wH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,19"
+	},
+/area/misc/hilbertshotel)
+"wO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,17"
+	},
+/area/misc/hilbertshotel)
+"wQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,21"
+	},
+/area/misc/hilbertshotel)
+"wT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,23"
+	},
+/area/misc/hilbertshotel)
+"wX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,13";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"xb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,15"
+	},
+/area/misc/hilbertshotel)
+"xo" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,24"
+	},
+/area/misc/hilbertshotel)
+"xp" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,26"
+	},
+/area/misc/hilbertshotel)
+"xs" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,20"
+	},
+/area/misc/hilbertshotel)
+"xt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"xu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"xy" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,15"
+	},
+/area/misc/hilbertshotel)
+"xE" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,16"
+	},
+/area/misc/hilbertshotel)
+"xP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,8"
+	},
+/area/misc/hilbertshotel)
+"xW" = (
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/hilbertshotel)
+"ys" = (
+/turf/closed/indestructible/hotelwall{
+	color = "#000000"
+	},
+/area/misc/hilbertshotel)
+"yu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,25"
+	},
+/area/misc/hilbertshotel)
+"yx" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,6"
+	},
+/area/misc/hilbertshotel)
+"yD" = (
+/obj/structure/table/wood/fancy/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"yJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,16"
+	},
+/area/misc/hilbertshotel)
+"yK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,12";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"yV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,18"
+	},
+/area/misc/hilbertshotel)
+"yX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,27"
+	},
+/area/misc/hilbertshotel)
+"yZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,23"
+	},
+/area/misc/hilbertshotel)
+"zh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,24"
+	},
+/area/misc/hilbertshotel)
+"zr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,22"
+	},
+/area/misc/hilbertshotel)
+"zu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "3,12";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"zv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,27"
+	},
+/area/misc/hilbertshotel)
+"zy" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"zH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,13"
+	},
+/area/misc/hilbertshotel)
+"zN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,8"
+	},
+/area/misc/hilbertshotel)
+"zO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,24"
+	},
+/area/misc/hilbertshotel)
+"zT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,26"
+	},
+/area/misc/hilbertshotel)
+"zY" = (
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"Ad" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram,
+/area/misc/hilbertshotel)
+"Ag" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,27"
+	},
+/area/misc/hilbertshotel)
+"Ak" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"Aq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,21"
+	},
+/area/misc/hilbertshotel)
+"AC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,22"
+	},
+/area/misc/hilbertshotel)
+"AD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,17"
+	},
+/area/misc/hilbertshotel)
+"AH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,20"
+	},
+/area/misc/hilbertshotel)
+"AI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,6";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"AL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,21"
+	},
+/area/misc/hilbertshotel)
+"AU" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,10"
+	},
+/area/misc/hilbertshotel)
+"AZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/railing,
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,13";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Bz" = (
+/obj/structure/marker_beacon/indigo,
+/obj/structure/table/wood/fancy/blue,
+/obj/item/kirbyplants/organic/plant21{
+	pixel_y = 14
+	},
+/obj/item/serviette{
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"BW" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,20"
+	},
+/area/misc/hilbertshotel)
+"BX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,23"
+	},
+/area/misc/hilbertshotel)
+"Ca" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,21"
+	},
+/area/misc/hilbertshotel)
+"Cd" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,25"
+	},
+/area/misc/hilbertshotel)
+"Cp" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,26"
+	},
+/area/misc/hilbertshotel)
+"CB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,21"
+	},
+/area/misc/hilbertshotel)
+"CD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,23"
+	},
+/area/misc/hilbertshotel)
+"CI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/billboard/starway{
+	pixel_y = 0;
+	pixel_x = -34
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,5";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"CL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,20"
+	},
+/area/misc/hilbertshotel)
+"CM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,13"
+	},
+/area/misc/hilbertshotel)
+"CO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,24"
+	},
+/area/misc/hilbertshotel)
+"CP" = (
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/hilbertshotel)
+"Dd" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,6"
+	},
+/area/misc/hilbertshotel)
+"Dj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,27"
+	},
+/area/misc/hilbertshotel)
+"DC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,15"
+	},
+/area/misc/hilbertshotel)
+"DR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,5"
+	},
+/area/misc/hilbertshotel)
+"Eh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,22"
+	},
+/area/misc/hilbertshotel)
+"Ep" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,26"
+	},
+/area/misc/hilbertshotel)
+"Er" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,24"
+	},
+/area/misc/hilbertshotel)
+"EJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,9"
+	},
+/area/misc/hilbertshotel)
+"ER" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,13"
+	},
+/area/misc/hilbertshotel)
+"EY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,20"
+	},
+/area/misc/hilbertshotel)
+"Fi" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,16"
+	},
+/area/misc/hilbertshotel)
+"Fs" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "17,22"
+	},
+/area/misc/hilbertshotel)
+"FF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,18"
+	},
+/area/misc/hilbertshotel)
+"FU" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,7"
+	},
+/area/misc/hilbertshotel)
+"FX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,24"
+	},
+/area/misc/hilbertshotel)
+"FY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,20"
+	},
+/area/misc/hilbertshotel)
+"Gc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,21"
+	},
+/area/misc/hilbertshotel)
+"Gp" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,15"
+	},
+/area/misc/hilbertshotel)
+"GC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "21,22"
+	},
+/area/misc/hilbertshotel)
+"GN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,7"
+	},
+/area/misc/hilbertshotel)
+"GO" = (
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"GP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,27"
+	},
+/area/misc/hilbertshotel)
+"GT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,14"
+	},
+/area/misc/hilbertshotel)
+"GY" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 6;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"Hb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,26"
+	},
+/area/misc/hilbertshotel)
+"Hh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,11";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Ho" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "18,23"
+	},
+/area/misc/hilbertshotel)
+"Ht" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,24"
+	},
+/area/misc/hilbertshotel)
+"Hw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,17"
+	},
+/area/misc/hilbertshotel)
+"HA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,26"
+	},
+/area/misc/hilbertshotel)
+"HE" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,12"
+	},
+/area/misc/hilbertshotel)
+"HO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,26"
+	},
+/area/misc/hilbertshotel)
+"HW" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,9";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Ib" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "9,11";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Ie" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,10"
+	},
+/area/misc/hilbertshotel)
+"Is" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,5"
+	},
+/area/misc/hilbertshotel)
+"It" = (
+/obj/structure/closet/secure_closet/freezer/fridge/all_access,
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"Iz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,6"
+	},
+/area/misc/hilbertshotel)
+"IC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,16"
+	},
+/area/misc/hilbertshotel)
+"IF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,19"
+	},
+/area/misc/hilbertshotel)
+"IG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,25"
+	},
+/area/misc/hilbertshotel)
+"IL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,24"
+	},
+/area/misc/hilbertshotel)
+"IO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,18"
+	},
+/area/misc/hilbertshotel)
+"IP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,22"
+	},
+/area/misc/hilbertshotel)
+"IR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,23"
+	},
+/area/misc/hilbertshotel)
+"IS" = (
+/obj/structure/sign/clock/directional/north,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"Ja" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"Jc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,24"
+	},
+/area/misc/hilbertshotel)
+"Jh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,12"
+	},
+/area/misc/hilbertshotel)
+"Jy" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,7"
+	},
+/area/misc/hilbertshotel)
+"JF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,20"
+	},
+/area/misc/hilbertshotel)
+"JT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,24"
+	},
+/area/misc/hilbertshotel)
+"JV" = (
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/obj/structure/marker_beacon/violet,
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,6";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"JX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "19,24"
+	},
+/area/misc/hilbertshotel)
+"Kb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,21"
+	},
+/area/misc/hilbertshotel)
+"Ke" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "3,10";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Kj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,21"
+	},
+/area/misc/hilbertshotel)
+"Kl" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,5"
+	},
+/area/misc/hilbertshotel)
+"Km" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,26"
+	},
+/area/misc/hilbertshotel)
+"Kq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,21"
+	},
+/area/misc/hilbertshotel)
+"Ks" = (
+/obj/structure/fireplace,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"Kx" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,22"
+	},
+/area/misc/hilbertshotel)
+"KA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,22"
+	},
+/area/misc/hilbertshotel)
+"KF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,9"
+	},
+/area/misc/hilbertshotel)
+"KL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "8,11";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"KN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,25"
+	},
+/area/misc/hilbertshotel)
+"KQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,27"
+	},
+/area/misc/hilbertshotel)
+"KW" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 1
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,10";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Lb" = (
+/obj/machinery/light/directional/west,
+/obj/structure/closet/secure_closet/wall{
+	pixel_x = -31;
+	pixel_y = 0
+	},
+/obj/item/construction/rtd/loaded,
+/obj/item/construction/rtd/loaded{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/airlock_painter/decal,
+/obj/item/airlock_painter/decal,
+/obj/item/toner/large,
+/obj/item/toner/large,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 0;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/hilbertshotel)
+"Ld" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "18,20"
+	},
+/area/misc/hilbertshotel)
+"Lg" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,9"
+	},
+/area/misc/hilbertshotel)
+"Lh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,23"
+	},
+/area/misc/hilbertshotel)
+"Ll" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,25"
+	},
+/area/misc/hilbertshotel)
+"Ls" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,7"
+	},
+/area/misc/hilbertshotel)
+"Lu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,15"
+	},
+/area/misc/hilbertshotel)
+"Lx" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,8"
+	},
+/area/misc/hilbertshotel)
+"LA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,19"
+	},
+/area/misc/hilbertshotel)
+"LD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,14"
+	},
+/area/misc/hilbertshotel)
+"LF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "17,25"
+	},
+/area/misc/hilbertshotel)
+"LL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,7"
+	},
+/area/misc/hilbertshotel)
+"LM" = (
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/hilbertshotel)
+"Ml" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,27"
+	},
+/area/misc/hilbertshotel)
+"Mu" = (
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/coin/silver,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"Mz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,26"
+	},
+/area/misc/hilbertshotel)
+"MB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,24"
+	},
+/area/misc/hilbertshotel)
+"MC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,18"
+	},
+/area/misc/hilbertshotel)
+"MJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,12"
+	},
+/area/misc/hilbertshotel)
+"MW" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,27"
+	},
+/area/misc/hilbertshotel)
+"Ne" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "18,21"
+	},
+/area/misc/hilbertshotel)
+"Nk" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "20,22"
+	},
+/area/misc/hilbertshotel)
+"NB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "19,25"
+	},
+/area/misc/hilbertshotel)
+"NC" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/curtains_apartments.dmi';
+	icon_state = "curtain_apartments_top-open";
+	icon_type = "curtain_apartments_top";
+	id = "apartments_curtain_jerry"
+	},
+/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
+	icon_state = "1,12";
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"NF" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/machinery/door/airlock/survival_pod{
+	name = "Restroom"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"NQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,19"
+	},
+/area/misc/hilbertshotel)
+"NU" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,18"
+	},
+/area/misc/hilbertshotel)
+"NV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,11"
+	},
+/area/misc/hilbertshotel)
+"NY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,20"
+	},
+/area/misc/hilbertshotel)
+"NZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,20"
+	},
+/area/misc/hilbertshotel)
+"Oj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,18"
+	},
+/area/misc/hilbertshotel)
+"OP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,21"
+	},
+/area/misc/hilbertshotel)
+"OZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,25"
+	},
+/area/misc/hilbertshotel)
+"Pc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,23"
+	},
+/area/misc/hilbertshotel)
+"Pk" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/machinery/door/morgue{
+	name = "Bedroom"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"PB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,18"
+	},
+/area/misc/hilbertshotel)
+"PF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,25"
+	},
+/area/misc/hilbertshotel)
+"PH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "19,26"
+	},
+/area/misc/hilbertshotel)
+"PL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/marker_beacon/burgundy{
+	pixel_x = 17;
+	pixel_y = 16
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,11";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"PO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,5";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"PR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,16"
+	},
+/area/misc/hilbertshotel)
+"PY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,25"
+	},
+/area/misc/hilbertshotel)
+"Qb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,13";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Qd" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/three_course_meal{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/effect/spawner/random/food_or_drink/three_course_meal{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/obj/effect/spawner/random/food_or_drink/three_course_meal{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"Qh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,14"
+	},
+/area/misc/hilbertshotel)
+"Qi" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "7,14"
+	},
+/area/misc/hilbertshotel)
+"QI" = (
+/obj/machinery/door/airlock/survival_pod{
+	name = "Apartment"
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/hilbertshotel)
+"QJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,23"
+	},
+/area/misc/hilbertshotel)
+"QO" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"QQ" = (
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"QV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "17,21"
+	},
+/area/misc/hilbertshotel)
+"QW" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "18,25"
+	},
+/area/misc/hilbertshotel)
+"Rb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "20,27"
+	},
+/area/misc/hilbertshotel)
+"Ru" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,22"
+	},
+/area/misc/hilbertshotel)
+"RG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,27"
+	},
+/area/misc/hilbertshotel)
+"RO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,8"
+	},
+/area/misc/hilbertshotel)
+"RQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,26"
+	},
+/area/misc/hilbertshotel)
+"RV" = (
+/obj/machinery/door/airlock/survival_pod{
+	name = "Cosmo's Apartment";
+	locked = 1
+	},
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"RX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "8,10";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"RZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,15"
+	},
+/area/misc/hilbertshotel)
+"Si" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,14"
+	},
+/area/misc/hilbertshotel)
+"Sk" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,27"
+	},
+/area/misc/hilbertshotel)
+"Sn" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "17,26"
+	},
+/area/misc/hilbertshotel)
+"So" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,23"
+	},
+/area/misc/hilbertshotel)
+"Ss" = (
+/obj/structure/table/greyscale,
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/item/soap/deluxe,
+/obj/item/towel{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/towel{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/hilbertshotel)
+"Sy" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "20,25"
+	},
+/area/misc/hilbertshotel)
+"SA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,12"
+	},
+/area/misc/hilbertshotel)
+"SF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,8";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"SQ" = (
+/obj/machinery/room_controller/directional/south{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/hilbertshotel)
+"Tl" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,9"
+	},
+/area/misc/hilbertshotel)
+"Tm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,19"
+	},
+/area/misc/hilbertshotel)
+"Tz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,9"
+	},
+/area/misc/hilbertshotel)
+"TB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,27"
+	},
+/area/misc/hilbertshotel)
+"TD" = (
+/obj/item/paper{
+	pixel_x = -7;
+	pixel_y = 11;
+	default_raw_text = "Don't use this to get free shit, we're logging you - the sky wizards union."
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"TN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "3,22"
+	},
+/area/misc/hilbertshotel)
+"TQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "29,8"
+	},
+/area/misc/hilbertshotel)
+"TT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,22"
+	},
+/area/misc/hilbertshotel)
+"Ub" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "5,11";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Uw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,25"
+	},
+/area/misc/hilbertshotel)
+"UX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "22,23"
+	},
+/area/misc/hilbertshotel)
+"UY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,18"
+	},
+/area/misc/hilbertshotel)
+"Vi" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,19"
+	},
+/area/misc/hilbertshotel)
+"Vn" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,25"
+	},
+/area/misc/hilbertshotel)
+"Vv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,22"
+	},
+/area/misc/hilbertshotel)
+"Vy" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "8,23"
+	},
+/area/misc/hilbertshotel)
+"VA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,16"
+	},
+/area/misc/hilbertshotel)
+"VC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall,
+/area/misc/hilbertshotel)
+"VO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,19"
+	},
+/area/misc/hilbertshotel)
+"VX" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/misc/hilbertshotel)
+"VZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,17"
+	},
+/area/misc/hilbertshotel)
+"Wf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "25,24"
+	},
+/area/misc/hilbertshotel)
+"Wj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,7";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Wr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,15"
+	},
+/area/misc/hilbertshotel)
+"Ws" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,8"
+	},
+/area/misc/hilbertshotel)
+"Wu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "19,23"
+	},
+/area/misc/hilbertshotel)
+"Wy" = (
+/obj/machinery/vending/boozeomat{
+	all_products_free = 1;
+	onstation = 0;
+	scan_id = 0;
+	name = "built-in NiCola Apartmental Vending Machine";
+	desc = "It's almost as if those housing companies intentionally leave zero space for proper kitchens to force you to buy from those built-in vendors...";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/iron/cafeteria,
+/area/misc/hilbertshotel)
+"WI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "6,20"
+	},
+/area/misc/hilbertshotel)
+"WM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,25"
+	},
+/area/misc/hilbertshotel)
+"WN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,17"
+	},
+/area/misc/hilbertshotel)
+"WQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "7,5";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Xe" = (
+/obj/structure/table/wood,
+/obj/item/compact_remote{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/structure/marker_beacon/indigo,
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"Xg" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,20"
+	},
+/area/misc/hilbertshotel)
+"Xq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,7"
+	},
+/area/misc/hilbertshotel)
+"Xs" = (
+/obj/structure/drain,
+/obj/machinery/shower/directional/south,
+/obj/structure/curtain/cloth,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 6;
+	color = "#a3bfbc"
+	},
+/turf/open/floor/iron/freezer,
+/area/misc/hilbertshotel)
+"Xu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,12"
+	},
+/area/misc/hilbertshotel)
+"XE" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "5,22"
+	},
+/area/misc/hilbertshotel)
+"Yh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "6,7";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"Ym" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/table/bronze,
+/obj/structure/decorative{
+	icon_state = "iron_catwalk";
+	pixel_y = 5;
+	icon = 'icons/obj/tiles.dmi';
+	base_icon_state = "iron_catwalk";
+	dir = 8;
+	pixel_x = 4;
+	anchored = 1;
+	name = "speaker"
+	},
+/turf/open/floor/wood/tile,
+/area/misc/hilbertshotel)
+"Yy" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "24,24"
+	},
+/area/misc/hilbertshotel)
+"YB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,12"
+	},
+/area/misc/hilbertshotel)
+"YD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,6"
+	},
+/area/misc/hilbertshotel)
+"YL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,16"
+	},
+/area/misc/hilbertshotel)
+"YM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "27,20"
+	},
+/area/misc/hilbertshotel)
+"YN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,21"
+	},
+/area/misc/hilbertshotel)
+"YT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/fluff/metalpole{
+	dir = 4
+	},
+/obj/structure/fluff/metalpole{
+	dir = 8
+	},
+/obj/structure/fluff/metalpole/anchor{
+	dir = 1
+	},
+/turf/open/indestructible/tram{
+	base_icon_state = "0,34";
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	icon_state = "4,6";
+	name = "long way down"
+	},
+/area/misc/hilbertshotel)
+"YV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "4,27"
+	},
+/area/misc/hilbertshotel)
+"Zj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,6"
+	},
+/area/misc/hilbertshotel)
+"Zk" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "28,17"
+	},
+/area/misc/hilbertshotel)
+"ZB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "23,21"
+	},
+/area/misc/hilbertshotel)
+"ZC" = (
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/curtains_apartments.dmi';
+	icon_state = "curtain_apartments_top-open";
+	icon_type = "curtain_apartments_top";
+	id = "apartments_curtain_jerry"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
+	icon_state = "15,14";
+	dir = 8
+	},
+/area/misc/hilbertshotel)
+"ZH" = (
+/obj/structure/table/greyscale,
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/mirror/directional/east,
+/obj/structure/sink/kitchen/directional/west,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 8;
+	pixel_y = 15
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/hilbertshotel)
+"ZI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "30,13"
+	},
+/area/misc/hilbertshotel)
+"ZM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "17,27"
+	},
+/area/misc/hilbertshotel)
+"ZT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "26,8"
+	},
+/area/misc/hilbertshotel)
+
+(1,1,1) = {"
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+"}
+(2,1,1) = {"
+ys
+MW
+dv
+Cd
+ta
+IR
+TN
+qK
+CL
+Tm
+nm
+pX
+yJ
+Gp
+GT
+tT
+zu
+jw
+Ke
+EJ
+Lx
+Jy
+Dd
+sr
+ys
+"}
+(3,1,1) = {"
+ys
+YV
+iG
+PY
+qG
+lb
+oo
+hf
+kY
+NQ
+yV
+bu
+xE
+ij
+nO
+uu
+sx
+PL
+tI
+HW
+ts
+Wj
+YT
+PO
+ys
+"}
+(4,1,1) = {"
+ys
+Dj
+Hb
+Vn
+fA
+CD
+XE
+wQ
+gN
+Vi
+IO
+WN
+Fi
+xy
+eS
+AZ
+da
+Ub
+aC
+rP
+SF
+aY
+JV
+CI
+ys
+"}
+(5,1,1) = {"
+ys
+KQ
+ti
+PF
+hT
+lD
+jX
+Kb
+WI
+nf
+uD
+wO
+VA
+RZ
+nK
+wX
+yK
+mo
+KW
+nN
+bm
+Yh
+aG
+sq
+ys
+"}
+(6,1,1) = {"
+ys
+rR
+Cp
+jK
+zh
+ne
+AC
+OP
+ms
+wH
+bG
+AD
+hP
+mK
+Qi
+Qb
+tp
+Hh
+pM
+dV
+hK
+vs
+AI
+WQ
+ys
+"}
+(7,1,1) = {"
+ys
+kK
+hW
+yu
+Er
+Vy
+ai
+Gc
+uM
+ov
+PB
+Hw
+pT
+Lu
+Si
+oz
+cx
+KL
+RX
+KF
+zN
+vR
+yx
+rC
+ys
+"}
+(8,1,1) = {"
+ys
+oy
+Km
+pe
+MB
+aL
+Ru
+AL
+JF
+Ak
+Ak
+ZC
+ZC
+Ak
+Ak
+uc
+Jh
+Ib
+iD
+Tl
+hZ
+Ls
+YD
+sZ
+ys
+"}
+(9,1,1) = {"
+ys
+TB
+cZ
+vu
+IL
+ff
+dd
+gf
+Xg
+gF
+QQ
+tS
+ib
+yD
+gF
+gF
+su
+Ad
+qi
+qi
+qi
+pU
+Ak
+Ak
+ys
+"}
+(10,1,1) = {"
+ys
+Ml
+Mz
+KN
+FX
+QJ
+hu
+kN
+qE
+gF
+QO
+GO
+GO
+GO
+gF
+gF
+gF
+li
+li
+li
+GY
+gF
+gF
+gF
+ys
+"}
+(11,1,1) = {"
+ys
+Sk
+sc
+WM
+dX
+Lh
+dP
+ps
+kA
+NC
+GO
+GO
+GO
+GO
+Ja
+gF
+gF
+GO
+GO
+GO
+gF
+gF
+gF
+gF
+ys
+"}
+(12,1,1) = {"
+ys
+fD
+sj
+gs
+zO
+pI
+np
+YN
+km
+NC
+GO
+GO
+GO
+GO
+Mu
+gF
+gF
+Ks
+GO
+GO
+gF
+gF
+gF
+gF
+ys
+"}
+(13,1,1) = {"
+ys
+me
+nJ
+vv
+xo
+yZ
+sH
+CB
+NY
+gF
+fN
+eg
+qp
+GO
+gF
+gF
+gF
+GO
+GO
+GO
+gF
+gF
+gF
+gF
+ys
+"}
+(14,1,1) = {"
+ys
+rL
+ub
+jU
+JT
+BX
+Eh
+Kj
+FY
+gF
+xu
+lQ
+lQ
+Pk
+gF
+gF
+gF
+GO
+GO
+GO
+GO
+Xe
+gF
+gF
+ys
+"}
+(15,1,1) = {"
+ys
+zv
+ks
+vr
+CO
+ek
+zr
+Aq
+AH
+gF
+Xs
+rd
+lQ
+GO
+gF
+GO
+GO
+GO
+GO
+GO
+GO
+qN
+gF
+gF
+ys
+"}
+(16,1,1) = {"
+ys
+ZM
+Sn
+LF
+pB
+vI
+Fs
+QV
+kL
+qJ
+LM
+CP
+lQ
+QO
+GO
+GO
+GO
+GO
+GO
+GO
+GO
+Ym
+xu
+xu
+ys
+"}
+(17,1,1) = {"
+ys
+jv
+qk
+QW
+vm
+Ho
+vo
+Ne
+Ld
+gF
+rf
+wu
+NF
+GO
+GO
+GO
+GO
+GO
+GO
+GO
+GO
+Bz
+gF
+xu
+ys
+"}
+(18,1,1) = {"
+ys
+kx
+PH
+NB
+JX
+Wu
+nb
+ww
+ia
+gF
+ZH
+Ss
+lQ
+GO
+GO
+GO
+GO
+GO
+GO
+GO
+gF
+VC
+gF
+xu
+ys
+"}
+(19,1,1) = {"
+ys
+Rb
+dh
+Sy
+eA
+sA
+Nk
+mz
+kH
+gF
+lQ
+lQ
+lQ
+IS
+TD
+cG
+rT
+rT
+rT
+rT
+gF
+VC
+gF
+xu
+ys
+"}
+(20,1,1) = {"
+ys
+qU
+gm
+mM
+cv
+fT
+GC
+ck
+EY
+tR
+lQ
+gF
+gF
+gF
+QI
+gF
+Wy
+zY
+ld
+Qd
+VC
+VC
+gF
+xu
+ys
+"}
+(21,1,1) = {"
+ys
+yX
+HA
+IG
+cW
+UX
+qu
+vT
+hd
+oJ
+lQ
+iu
+Lb
+fK
+xW
+gF
+uL
+zY
+zY
+na
+gF
+VC
+lQ
+lQ
+ys
+"}
+(22,1,1) = {"
+ys
+aj
+HO
+up
+Jc
+qM
+TT
+ZB
+NZ
+oM
+lQ
+gF
+SQ
+xW
+tK
+gF
+It
+hQ
+sD
+kO
+gF
+zy
+pH
+lQ
+ys
+"}
+(23,1,1) = {"
+ys
+Ag
+um
+OZ
+Yy
+if
+gz
+Ca
+aK
+UY
+lQ
+gF
+gF
+RV
+xu
+gF
+gF
+xu
+gF
+gF
+gF
+VX
+hx
+lQ
+ys
+"}
+(24,1,1) = {"
+ys
+hR
+hk
+Uw
+Wf
+pc
+ah
+Kq
+hb
+jD
+lQ
+lQ
+lQ
+lQ
+xt
+lQ
+lQ
+lQ
+lQ
+lQ
+lQ
+lQ
+lQ
+lQ
+ys
+"}
+(25,1,1) = {"
+ys
+RG
+gh
+pu
+gb
+So
+Kx
+cQ
+xs
+lk
+MC
+eB
+PR
+DC
+av
+CM
+YB
+uf
+sh
+oX
+ZT
+FU
+cU
+jM
+ys
+"}
+(26,1,1) = {"
+ys
+fx
+Ep
+hi
+Ht
+uJ
+IP
+sa
+YM
+IF
+NU
+bz
+ph
+Wr
+LD
+cK
+MJ
+hv
+eL
+tz
+xP
+Xq
+Iz
+Kl
+ys
+"}
+(27,1,1) = {"
+ys
+pL
+xp
+cn
+iI
+wT
+Vv
+ir
+ec
+VO
+Oj
+Zk
+IC
+kl
+oL
+zH
+HE
+NV
+AU
+Lg
+RO
+GN
+Zj
+Is
+ys
+"}
+(28,1,1) = {"
+ys
+GP
+zT
+Ll
+eD
+Pc
+bV
+sK
+hw
+LA
+FF
+vF
+fh
+xb
+bJ
+ER
+SA
+qI
+Ie
+si
+TQ
+LL
+te
+DR
+ys
+"}
+(29,1,1) = {"
+ys
+hE
+RQ
+cO
+gw
+mF
+KA
+qm
+BW
+sW
+pZ
+VZ
+YL
+rN
+Qh
+ZI
+Xu
+py
+ws
+Tz
+Ws
+cq
+vK
+hr
+ys
+"}
+(30,1,1) = {"
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+ys
+"}

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -83,10 +83,6 @@
 	name = "long way down"
 	},
 /area/misc/hilbertshotel)
-"aK" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "aL" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -157,42 +153,6 @@
 	base_icon_state = "0,34";
 	icon_state = "7,18"
 	},
-/area/misc/hilbertshotel)
-"bJ" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,14"
-	},
-/area/misc/hilbertshotel)
-"bV" = (
-/obj/effect/light_emitter/interlink{
-	light_color = "#ffe7cf";
-	light_power = 1.5
-	},
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,22"
-	},
-/area/misc/hilbertshotel)
-"ck" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "cn" = (
 /obj/effect/abstract/marker{
@@ -462,6 +422,14 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 3
+	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -511,19 +479,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "10,23"
-	},
-/area/misc/hilbertshotel)
-"fh" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,16"
 	},
 /area/misc/hilbertshotel)
 "fp" = (
@@ -685,6 +640,15 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 8;
+	anchored = 1
+	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -719,16 +683,6 @@
 	base_icon_state = "0,34";
 	icon_state = "5,20"
 	},
-/area/misc/hilbertshotel)
-"hb" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
-"hd" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "hf" = (
 /obj/effect/abstract/marker{
@@ -793,19 +747,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "11,22"
-	},
-/area/misc/hilbertshotel)
-"hw" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,20"
 	},
 /area/misc/hilbertshotel)
 "hx" = (
@@ -919,8 +860,8 @@
 	all_products_free = 1;
 	scan_id = 0;
 	pixel_x = 0;
-	pixel_y = -5;
-	shut_up = 1
+	shut_up = 1;
+	density = 0
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
@@ -1142,12 +1083,6 @@
 	icon_state = "9,17"
 	},
 /area/misc/hilbertshotel)
-"kH" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "kK" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -1271,13 +1206,14 @@
 	},
 /area/misc/hilbertshotel)
 "mp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /obj/machinery/vending/games{
 	shut_up = 1;
-	pixel_x = -8;
 	pixel_y = 0
 	},
-/turf/closed/wall,
+/turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "ms" = (
 /obj/effect/abstract/marker{
@@ -1706,9 +1642,8 @@
 	},
 /area/misc/hilbertshotel)
 "pH" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 8;
-	volume_rate = 200
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 1
 	},
 /turf/open/space/basic,
 /area/misc/hilbertshotel)
@@ -1856,6 +1791,11 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/item/paper{
+	pixel_x = -7;
+	pixel_y = 11;
+	default_raw_text = "The details matters, even if the demograph is undesirable."
+	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1887,16 +1827,6 @@
 	icon_state = "22,22"
 	},
 /area/misc/hilbertshotel)
-"qD" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "qE" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -1921,19 +1851,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "4,24"
-	},
-/area/misc/hilbertshotel)
-"qI" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,11"
 	},
 /area/misc/hilbertshotel)
 "qJ" = (
@@ -1968,27 +1885,6 @@
 	base_icon_state = "0,34";
 	icon_state = "11,17"
 	},
-/area/misc/hilbertshotel)
-"qN" = (
-/obj/structure/table/bronze,
-/obj/machinery/status_display{
-	pixel_y = 6;
-	pixel_x = 16;
-	name = "TV screen";
-	desc = "An ancient, though still half-decent television screen, model M0-LDB."
-	},
-/obj/structure/decorative{
-	icon_state = "iron_catwalk";
-	pixel_y = 5;
-	icon = 'icons/obj/tiles.dmi';
-	base_icon_state = "iron_catwalk";
-	dir = 8;
-	pixel_x = -3;
-	anchored = 1;
-	name = "speaker"
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "qU" = (
 /obj/effect/abstract/marker{
@@ -2106,19 +2002,6 @@
 	icon_state = "12,26"
 	},
 /area/misc/hilbertshotel)
-"si" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,9"
-	},
-/area/misc/hilbertshotel)
 "sj" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -2167,8 +2050,8 @@
 	name = "built-in NiCola Apartmental Vending Machine";
 	desc = "It's almost as if those housing companies intentionally leave zero space for proper kitchens to force you to buy from those built-in vendors...";
 	pixel_x = 0;
-	pixel_y = -4;
-	shut_up = 1
+	shut_up = 1;
+	density = 0
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
@@ -2228,24 +2111,6 @@
 	icon_state = "14,22"
 	},
 /area/misc/hilbertshotel)
-"sK" = (
-/obj/item/paper{
-	pixel_x = -7;
-	pixel_y = 11;
-	default_raw_text = "The details matters, even if the demograph is undesirable."
-	},
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,21"
-	},
-/area/misc/hilbertshotel)
 "sW" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -2286,17 +2151,11 @@
 	},
 /area/misc/hilbertshotel)
 "te" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	volume_rate = 200;
+	dir = 4
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,6"
-	},
+/turf/open/space/basic,
 /area/misc/hilbertshotel)
 "ti" = (
 /obj/effect/abstract/marker{
@@ -2375,13 +2234,6 @@
 	name = "long way down"
 	},
 /area/misc/hilbertshotel)
-"tK" = (
-/obj/machinery/light_switch/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "tR" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
@@ -2435,12 +2287,6 @@
 	base_icon_state = "0,34";
 	icon_state = "15,26"
 	},
-/area/misc/hilbertshotel)
-"uc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "uf" = (
 /obj/effect/abstract/marker{
@@ -2637,19 +2483,6 @@
 	icon_state = "14,25"
 	},
 /area/misc/hilbertshotel)
-"vF" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,17"
-	},
-/area/misc/hilbertshotel)
 "vI" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -2688,12 +2521,6 @@
 	base_icon_state = "0,34";
 	icon_state = "8,7"
 	},
-/area/misc/hilbertshotel)
-"vT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "ws" = (
 /obj/effect/abstract/marker{
@@ -2797,19 +2624,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	icon_state = "6,13";
 	name = "long way down"
-	},
-/area/misc/hilbertshotel)
-"xb" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,15"
 	},
 /area/misc/hilbertshotel)
 "xo" = (
@@ -3052,9 +2866,7 @@
 	},
 /area/misc/hilbertshotel)
 "zy" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall,
 /area/misc/hilbertshotel)
 "zN" = (
@@ -3249,23 +3061,6 @@
 	name = "long way down"
 	},
 /area/misc/hilbertshotel)
-"Bz" = (
-/obj/structure/marker_beacon/indigo,
-/obj/structure/table/wood/fancy/blue,
-/obj/item/kirbyplants/organic/plant21{
-	pixel_y = 14
-	},
-/obj/item/serviette{
-	pixel_y = 7
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "BW" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -3291,12 +3086,6 @@
 	base_icon_state = "0,34";
 	icon_state = "15,23"
 	},
-/area/misc/hilbertshotel)
-"Ca" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Cd" = (
 /obj/effect/abstract/marker{
@@ -3437,19 +3226,6 @@
 	icon_state = "9,7"
 	},
 /area/misc/hilbertshotel)
-"DR" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,5"
-	},
-/area/misc/hilbertshotel)
 "Eh" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
@@ -3511,17 +3287,9 @@
 	},
 /area/misc/hilbertshotel)
 "ER" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,13"
-	},
+/obj/machinery/light/directional/east,
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "EY" = (
 /obj/effect/turf_decal/siding/white{
@@ -3561,19 +3329,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "17,22"
-	},
-/area/misc/hilbertshotel)
-"FF" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,18"
 	},
 /area/misc/hilbertshotel)
 "FX" = (
@@ -3829,19 +3584,6 @@
 	name = "long way down"
 	},
 /area/misc/hilbertshotel)
-"Ie" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,10"
-	},
-/area/misc/hilbertshotel)
 "It" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /obj/effect/turf_decal/siding/white{
@@ -3939,9 +3681,6 @@
 	pixel_x = -7;
 	pixel_y = 11;
 	default_raw_text = "Don't use this to get free shit, we're logging you - the sky wizards union."
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
 	},
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
@@ -4110,16 +3849,9 @@
 	icon_state = "9,26"
 	},
 /area/misc/hilbertshotel)
-"Kq" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "Ks" = (
-/obj/structure/fireplace,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/fireplace{
+	max_integrity = 100
 	},
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
@@ -4354,19 +4086,6 @@
 	icon_state = "3,8"
 	},
 /area/misc/hilbertshotel)
-"LA" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,19"
-	},
-/area/misc/hilbertshotel)
 "LF" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -4378,19 +4097,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "17,25"
-	},
-/area/misc/hilbertshotel)
-"LL" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,7"
 	},
 /area/misc/hilbertshotel)
 "LM" = (
@@ -4526,8 +4232,8 @@
 "NC" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/curtains_apartments.dmi';
-	icon_state = "curtain_apartments_top-open";
-	icon_type = "curtain_apartments_top";
+	icon_state = "curtain_apartments_bottom-open";
+	icon_type = "curtain_apartments_bottom";
 	id = "apartments_curtain_jerry"
 	},
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
@@ -4585,18 +4291,6 @@
 	icon_state = "11,11"
 	},
 /area/misc/hilbertshotel)
-"NZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
-"Og" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "Oj" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -4634,19 +4328,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "24,25"
-	},
-/area/misc/hilbertshotel)
-"Pc" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,23"
 	},
 /area/misc/hilbertshotel)
 "Pk" = (
@@ -5077,19 +4758,6 @@
 	icon_state = "20,25"
 	},
 /area/misc/hilbertshotel)
-"SA" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,12"
-	},
-/area/misc/hilbertshotel)
 "SF" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -5108,7 +4776,6 @@
 /obj/machinery/room_controller/directional/south{
 	pixel_y = 32
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "Tm" = (
@@ -5161,19 +4828,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "3,22"
-	},
-/area/misc/hilbertshotel)
-"TQ" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "29,8"
 	},
 /area/misc/hilbertshotel)
 "TT" = (
@@ -5325,12 +4979,6 @@
 	},
 /turf/open/indestructible/tram,
 /area/misc/hilbertshotel)
-"VX" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/misc/hilbertshotel)
 "VZ" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -5478,18 +5126,6 @@
 	name = "long way down"
 	},
 /area/misc/hilbertshotel)
-"Xe" = (
-/obj/structure/table/wood,
-/obj/item/compact_remote{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/structure/marker_beacon/indigo,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "Xg" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -5566,22 +5202,6 @@
 	name = "long way down"
 	},
 /area/misc/hilbertshotel)
-"Ym" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/table/bronze,
-/obj/structure/decorative{
-	icon_state = "iron_catwalk";
-	pixel_y = 5;
-	icon = 'icons/obj/tiles.dmi';
-	base_icon_state = "iron_catwalk";
-	dir = 8;
-	pixel_x = 4;
-	anchored = 1;
-	name = "speaker"
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "Yy" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
@@ -5627,11 +5247,10 @@
 /area/misc/hilbertshotel)
 "YD" = (
 /obj/machinery/vending/dorms{
-	pixel_x = -6;
 	pixel_y = 0;
 	shut_up = 1
 	},
-/turf/closed/wall,
+/turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "YL" = (
 /obj/effect/abstract/marker{
@@ -5706,17 +5325,11 @@
 	icon_state = "10,14"
 	},
 /area/misc/hilbertshotel)
-"ZB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
 "ZC" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/curtains_apartments.dmi';
-	icon_state = "curtain_apartments_top-open";
-	icon_type = "curtain_apartments_top";
+	icon_state = "curtain_apartments_bottom-open";
+	icon_type = "curtain_apartments_bottom";
 	id = "apartments_curtain_jerry"
 	},
 /obj/structure/decorative{
@@ -6143,9 +5756,9 @@ rT
 Ja
 gF
 gF
-ZB
-vT
-NZ
+rT
+rT
+rT
 gF
 gF
 gF
@@ -6172,7 +5785,7 @@ gF
 gF
 Ks
 rT
-aK
+rT
 gF
 gF
 gF
@@ -6197,9 +5810,9 @@ rT
 gF
 gF
 gF
-Ca
 rT
-aK
+rT
+rT
 gF
 gF
 gF
@@ -6224,11 +5837,11 @@ Pk
 gF
 gF
 gF
-Ca
 rT
-Og
-vT
-Xe
+rT
+rT
+rT
+rT
 gF
 gF
 gF
@@ -6247,15 +5860,15 @@ tR
 Xs
 rd
 lQ
-kH
+rT
 gF
-ZB
-vT
-ck
 rT
 rT
 rT
-qN
+rT
+rT
+rT
+rT
 gF
 gF
 gF
@@ -6274,19 +5887,19 @@ qJ
 LM
 CP
 lQ
-qD
-vT
-ck
+QO
 rT
 rT
 rT
 rT
 rT
-Ym
-xu
-xu
-xu
-xu
+rT
+rT
+rT
+gF
+gF
+gF
+gF
 ys
 "}
 (20,1,1) = {"
@@ -6301,19 +5914,19 @@ tR
 rf
 wu
 NF
-Ca
 rT
 rT
 rT
 rT
 rT
-hb
-hd
-Bz
+rT
+rT
+rT
+rT
 gF
 gF
 gF
-xu
+gF
 ys
 "}
 (21,1,1) = {"
@@ -6328,19 +5941,19 @@ tR
 ZH
 Ss
 lQ
-Ca
 rT
 rT
 rT
 rT
 rT
-aK
-gF
-VC
+rT
+rT
 gF
 gF
 gF
-xu
+gF
+gF
+gF
 ys
 "}
 (22,1,1) = {"
@@ -6356,18 +5969,18 @@ lQ
 lQ
 lQ
 IS
-hd
-tK
-hd
-hd
-hd
-Kq
-gF
-VC
+rT
+qp
+rT
+rT
+rT
+rT
 gF
 gF
 gF
-xu
+gF
+gF
+gF
 ys
 "}
 (23,1,1) = {"
@@ -6391,10 +6004,10 @@ ld
 Qd
 VC
 VC
+VC
 gF
 gF
 gF
-xu
 ys
 "}
 (24,1,1) = {"
@@ -6417,11 +6030,11 @@ zY
 zY
 na
 gF
+gF
 VC
-VC
-VC
-lQ
-lQ
+gF
+hx
+gF
 ys
 "}
 (25,1,1) = {"
@@ -6436,7 +6049,7 @@ lQ
 gF
 SQ
 xW
-uc
+xW
 gF
 su
 It
@@ -6445,10 +6058,10 @@ sD
 kO
 gF
 gF
-gF
+VC
 zy
 pH
-lQ
+gF
 ys
 "}
 (26,1,1) = {"
@@ -6461,7 +6074,7 @@ tR
 gF
 lQ
 gF
-gF
+ER
 YD
 mp
 gF
@@ -6472,10 +6085,10 @@ gF
 gF
 gF
 gF
+VC
 gF
-VX
-hx
-lQ
+te
+gF
 ys
 "}
 (27,1,1) = {"
@@ -6484,6 +6097,33 @@ pL
 xp
 cn
 iI
+tR
+gF
+gF
+gF
+gF
+gF
+xu
+gF
+gF
+gF
+xu
+gF
+gF
+gF
+gF
+VC
+gF
+xu
+gF
+ys
+"}
+(28,1,1) = {"
+ys
+GP
+zT
+Ll
+eD
 tR
 gF
 lQ
@@ -6500,36 +6140,9 @@ lQ
 lQ
 oM
 lQ
-lQ
-lQ
-lQ
-ys
-"}
-(28,1,1) = {"
-ys
-GP
-zT
-Ll
-eD
-Pc
-bV
-sK
-hw
-LA
-FF
-vF
-fh
-xb
-bJ
-ER
-SA
-qI
-Ie
-si
-TQ
-LL
-te
-DR
+xu
+xu
+gF
 ys
 "}
 (29,1,1) = {"

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -284,11 +284,6 @@
 	icon_state = "8,12"
 	},
 /area/misc/hilbertshotel)
-"cG" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/wood/tile,
-/area/misc/hilbertshotel)
 "cK" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -484,7 +479,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "ek" = (
 /obj/effect/abstract/marker{
@@ -648,7 +643,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "fT" = (
 /obj/effect/abstract/marker{
@@ -1025,7 +1020,7 @@
 	dir = 8;
 	anchored = 1
 	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "if" = (
 /obj/effect/abstract/marker{
@@ -1998,7 +1993,7 @@
 /area/misc/hilbertshotel)
 "qp" = (
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "qu" = (
 /obj/effect/abstract/marker{
@@ -2111,7 +2106,7 @@
 	anchored = 1;
 	name = "speaker"
 	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "qU" = (
 /obj/effect/abstract/marker{
@@ -2214,10 +2209,7 @@
 	},
 /area/misc/hilbertshotel)
 "rT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "sa" = (
 /obj/effect/abstract/marker{
@@ -2566,7 +2558,7 @@
 	alpha = 20;
 	color = "#FFFFFF"
 	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "tT" = (
 /obj/effect/abstract/marker{
@@ -3090,7 +3082,7 @@
 "yD" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "yJ" = (
 /obj/effect/abstract/marker{
@@ -3466,7 +3458,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "BW" = (
 /obj/effect/abstract/marker{
@@ -3900,9 +3892,6 @@
 	icon_state = "28,7"
 	},
 /area/misc/hilbertshotel)
-"GO" = (
-/turf/open/floor/wood/tile,
-/area/misc/hilbertshotel)
 "GP" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -4211,11 +4200,11 @@
 	pixel_y = 11;
 	default_raw_text = "Don't use this to get free shit, we're logging you - the sky wizards union."
 	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Ja" = (
 /obj/structure/dresser,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Jc" = (
 /obj/effect/abstract/marker{
@@ -4393,7 +4382,7 @@
 /area/misc/hilbertshotel)
 "Ks" = (
 /obj/structure/fireplace,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Kx" = (
 /obj/effect/abstract/marker{
@@ -4706,7 +4695,7 @@
 	anchored = 1
 	},
 /obj/item/coin/silver,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Mz" = (
 /obj/effect/abstract/marker{
@@ -5178,11 +5167,11 @@
 /area/misc/hilbertshotel)
 "QO" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "QQ" = (
 /obj/structure/table/wood/fancy/blue,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "QV" = (
 /obj/effect/abstract/marker{
@@ -5804,7 +5793,7 @@
 	pixel_y = 9
 	},
 /obj/structure/marker_beacon/indigo,
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Xg" = (
 /obj/effect/abstract/marker{
@@ -5903,7 +5892,7 @@
 	anchored = 1;
 	name = "speaker"
 	},
-/turf/open/floor/wood/tile,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
 "Yy" = (
 /obj/effect/abstract/marker{
@@ -6384,9 +6373,9 @@ kN
 qE
 tR
 QO
-GO
-GO
-GO
+rT
+rT
+rT
 jD
 GY
 GY
@@ -6410,16 +6399,16 @@ dP
 ps
 kA
 NC
-GO
-GO
-GO
-GO
+rT
+rT
+rT
+rT
 Ja
 gF
 gF
-GO
-GO
-GO
+rT
+rT
+rT
 gF
 gF
 gF
@@ -6437,16 +6426,16 @@ np
 YN
 km
 NC
-GO
-GO
-GO
-GO
+rT
+rT
+rT
+rT
 Mu
 gF
 gF
 Ks
-GO
-GO
+rT
+rT
 gF
 gF
 gF
@@ -6467,13 +6456,13 @@ tR
 fN
 eg
 qp
-GO
+rT
 gF
 gF
 gF
-GO
-GO
-GO
+rT
+rT
+rT
 gF
 gF
 gF
@@ -6498,10 +6487,10 @@ Pk
 gF
 gF
 gF
-GO
-GO
-GO
-GO
+rT
+rT
+rT
+rT
 Xe
 gF
 gF
@@ -6521,14 +6510,14 @@ tR
 Xs
 rd
 lQ
-GO
+rT
 gF
-GO
-GO
-GO
-GO
-GO
-GO
+rT
+rT
+rT
+rT
+rT
+rT
 qN
 gF
 gF
@@ -6549,13 +6538,13 @@ LM
 CP
 lQ
 QO
-GO
-GO
-GO
-GO
-GO
-GO
-GO
+rT
+rT
+rT
+rT
+rT
+rT
+rT
 Ym
 xu
 xu
@@ -6575,14 +6564,14 @@ tR
 rf
 wu
 NF
-GO
-GO
-GO
-GO
-GO
-GO
-GO
-GO
+rT
+rT
+rT
+rT
+rT
+rT
+rT
+rT
 Bz
 gF
 xu
@@ -6602,13 +6591,13 @@ tR
 ZH
 Ss
 lQ
-GO
-GO
-GO
-GO
-GO
-GO
-GO
+rT
+rT
+rT
+rT
+rT
+rT
+rT
 gF
 VC
 gF
@@ -6630,8 +6619,8 @@ lQ
 lQ
 lQ
 IS
-GO
-cG
+rT
+qp
 rT
 rT
 rT

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -1486,6 +1486,14 @@
 	color = "#878787";
 	pixel_x = -32
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	pixel_y = 32;
+	icon = 'icons/turf/decals.dmi';
+	dir = 2;
+	color = "#878787";
+	pixel_x = -32
+	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
 "mF" = (
@@ -1553,12 +1561,6 @@
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain_corner";
-	icon = 'icons/turf/decals.dmi';
-	dir = 3;
-	color = "#878787"
 	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2725,12 +2727,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain_corner";
-	icon = 'icons/turf/decals.dmi';
-	dir = 3;
-	color = "#878787"
-	},
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3350,6 +3346,14 @@
 	color = "#36373a";
 	dir = 9;
 	anchored = 1
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	pixel_y = 32;
+	icon = 'icons/turf/decals.dmi';
+	dir = 2;
+	color = "#878787";
+	pixel_x = -32
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -286,6 +286,7 @@
 /area/misc/hilbertshotel)
 "cG" = (
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood/tile,
 /area/misc/hilbertshotel)
 "cK" = (
@@ -990,17 +991,13 @@
 	},
 /area/misc/hilbertshotel)
 "hZ" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/machinery/vending/dinnerware{
+	all_products_free = 1;
+	scan_id = 0;
+	pixel_x = 0;
+	pixel_y = -5
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "9,8"
-	},
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "ia" = (
 /obj/effect/abstract/marker{
@@ -1081,20 +1078,6 @@
 	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi'
 	},
 /area/misc/hilbertshotel)
-"iD" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	base_icon_state = "0,34";
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	icon_state = "9,10";
-	name = "long way down"
-	},
-/area/misc/hilbertshotel)
 "iG" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -1149,17 +1132,16 @@
 	},
 /area/misc/hilbertshotel)
 "jD" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/structure/decorative{
+	icon_state = "siding_plain_corner";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	dir = 8;
+	anchored = 1
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "25,19"
-	},
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "jK" = (
 /obj/effect/abstract/marker{
@@ -1410,14 +1392,6 @@
 /area/misc/hilbertshotel)
 "li" = (
 /obj/structure/curtain/bounty,
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	dir = 4;
-	color = "#878787";
-	pixel_x = -32
-	},
 /turf/closed/wall/mineral/titanium/shuttle_wall/window/evac{
 	icon_state = "15,14";
 	dir = 8
@@ -1736,17 +1710,24 @@
 	},
 /area/misc/hilbertshotel)
 "oJ" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "22,18"
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	dir = 8;
+	anchored = 1
 	},
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "oL" = (
 /obj/effect/abstract/marker{
@@ -1762,17 +1743,9 @@
 	},
 /area/misc/hilbertshotel)
 "oM" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "23,18"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "oX" = (
 /obj/effect/abstract/marker{
@@ -1947,17 +1920,10 @@
 	icon_state = "siding_plain";
 	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 4;
-	color = "#878787";
-	pixel_x = -32
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain_corner";
-	pixel_y = 32;
-	icon = 'icons/turf/decals.dmi';
-	dir = 2;
-	color = "#878787";
-	pixel_x = -32
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	dir = 3;
+	anchored = 1
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
@@ -1993,6 +1959,14 @@
 	icon_state = "rain";
 	alpha = 100;
 	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 4
 	},
 /turf/open/indestructible/tram,
 /area/misc/hilbertshotel)
@@ -2342,28 +2316,16 @@
 	},
 /area/misc/hilbertshotel)
 "su" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/machinery/vending/boozeomat{
+	all_products_free = 1;
+	onstation = 0;
+	scan_id = 0;
+	name = "built-in NiCola Apartmental Vending Machine";
+	desc = "It's almost as if those housing companies intentionally leave zero space for proper kitchens to force you to buy from those built-in vendors...";
+	pixel_x = 0;
+	pixel_y = -4
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 5
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain_corner";
-	icon = 'icons/turf/decals.dmi';
-	dir = 4;
-	color = "#878787";
-	pixel_x = -32
-	},
-/turf/open/indestructible/tram,
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "sx" = (
 /obj/effect/abstract/marker{
@@ -2447,10 +2409,16 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
 /turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "9,5"
+	color = "#d6d6d6"
 	},
 /area/misc/hilbertshotel)
 "ta" = (
@@ -2566,27 +2534,23 @@
 	},
 /area/misc/hilbertshotel)
 "tK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/machinery/vending/dorms{
 	pixel_x = 0;
-	pixel_y = -32
+	pixel_y = 5
 	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "tR" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	dir = 1;
+	anchored = 1
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "21,18"
-	},
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "tS" = (
 /obj/structure/decorative{
@@ -2631,32 +2595,10 @@
 	},
 /area/misc/hilbertshotel)
 "uc" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/structure/decorative{
-	icon_state = "siding_plain";
-	pixel_y = 0;
-	icon = 'icons/turf/decals.dmi';
-	base_icon_state = "elevatorshaft";
-	color = "#878787";
-	dir = 5
-	},
-/obj/structure/decorative{
-	icon_state = "siding_plain_corner";
-	icon = 'icons/turf/decals.dmi';
-	dir = 4;
-	color = "#878787";
-	pixel_x = -32
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "9,13"
-	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "uf" = (
 /obj/effect/abstract/marker{
@@ -2741,15 +2683,6 @@
 	base_icon_state = "0,34";
 	icon_state = "27,23"
 	},
-/area/misc/hilbertshotel)
-"uL" = (
-/obj/machinery/vending/dinnerware{
-	all_products_free = 1;
-	scan_id = 0;
-	pixel_y = 32;
-	pixel_x = 0
-	},
-/turf/open/floor/iron/cafeteria,
 /area/misc/hilbertshotel)
 "uM" = (
 /obj/effect/abstract/marker{
@@ -3346,6 +3279,14 @@
 	alpha = 100;
 	name = "rain"
 	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#878787";
+	dir = 4
+	},
 /obj/effect/light_emitter/interlink{
 	light_color = "#ffe7cf";
 	light_power = 1.5
@@ -3373,6 +3314,15 @@
 	dir = 4;
 	color = "#878787";
 	pixel_x = -32
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	dir = 9;
+	anchored = 1
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
@@ -3984,9 +3934,10 @@
 	icon_state = "siding_plain";
 	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 6;
-	color = "#878787";
-	pixel_x = -32
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	dir = 8;
+	anchored = 1
 	},
 /turf/closed/wall,
 /area/misc/hilbertshotel)
@@ -4116,20 +4067,6 @@
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	icon_state = "4,9";
-	name = "long way down"
-	},
-/area/misc/hilbertshotel)
-"Ib" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	base_icon_state = "0,34";
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	icon_state = "9,11";
 	name = "long way down"
 	},
 /area/misc/hilbertshotel)
@@ -4269,7 +4206,11 @@
 /area/misc/hilbertshotel)
 "IS" = (
 /obj/structure/sign/clock/directional/north,
-/obj/machinery/light_switch/directional/east,
+/obj/item/paper{
+	pixel_x = -7;
+	pixel_y = 11;
+	default_raw_text = "Don't use this to get free shit, we're logging you - the sky wizards union."
+	},
 /turf/open/floor/wood/tile,
 /area/misc/hilbertshotel)
 "Ja" = (
@@ -4287,19 +4228,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "23,24"
-	},
-/area/misc/hilbertshotel)
-"Jh" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "9,12"
 	},
 /area/misc/hilbertshotel)
 "Jy" = (
@@ -4656,17 +4584,24 @@
 	},
 /area/misc/hilbertshotel)
 "Ls" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "9,7"
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	dir = 10;
+	anchored = 1
 	},
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "Lu" = (
 /obj/effect/abstract/marker{
@@ -5340,13 +5275,6 @@
 	icon_state = "30,26"
 	},
 /area/misc/hilbertshotel)
-"RV" = (
-/obj/machinery/door/airlock/survival_pod{
-	name = "Cosmo's Apartment";
-	locked = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
-/area/misc/hilbertshotel)
 "RX" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -5496,19 +5424,6 @@
 	},
 /turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
-"Tl" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "9,9"
-	},
-/area/misc/hilbertshotel)
 "Tm" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -5547,14 +5462,6 @@
 	base_icon_state = "0,34";
 	icon_state = "10,27"
 	},
-/area/misc/hilbertshotel)
-"TD" = (
-/obj/item/paper{
-	pixel_x = -7;
-	pixel_y = 11;
-	default_raw_text = "Don't use this to get free shit, we're logging you - the sky wizards union."
-	},
-/turf/open/floor/wood/tile,
 /area/misc/hilbertshotel)
 "TN" = (
 /obj/effect/abstract/marker{
@@ -5638,19 +5545,6 @@
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
 	icon_state = "22,23"
-	},
-/area/misc/hilbertshotel)
-"UY" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
-	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "24,18"
 	},
 /area/misc/hilbertshotel)
 "Vi" = (
@@ -5831,16 +5725,18 @@
 	},
 /area/misc/hilbertshotel)
 "Wy" = (
-/obj/machinery/vending/boozeomat{
-	all_products_free = 1;
-	onstation = 0;
-	scan_id = 0;
-	name = "built-in NiCola Apartmental Vending Machine";
-	desc = "It's almost as if those housing companies intentionally leave zero space for proper kitchens to force you to buy from those built-in vendors...";
-	pixel_x = 0;
-	pixel_y = 32
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	base_icon_state = "elevatorshaft";
+	color = "#36373a";
+	dir = 1;
+	anchored = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
 /area/misc/hilbertshotel)
 "WI" = (
 /obj/effect/abstract/marker{
@@ -6036,17 +5932,11 @@
 	},
 /area/misc/hilbertshotel)
 "YD" = (
-/obj/effect/abstract/marker{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
-	icon_state = "rain";
-	alpha = 100;
-	name = "rain"
+/obj/machinery/door/airlock/survival_pod{
+	name = "Cosmo's Apartment";
+	locked = 1
 	},
-/turf/open/indestructible/tram{
-	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
-	base_icon_state = "0,34";
-	icon_state = "9,6"
-	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/misc/hilbertshotel)
 "YL" = (
 /obj/effect/abstract/marker{
@@ -6439,19 +6329,19 @@ Ru
 AL
 JF
 Ak
-Ak
+oJ
 ZC
 ZC
-Ak
-Ak
-uc
-Jh
-Ib
-iD
-Tl
-hZ
+oJ
 Ls
-YD
+sZ
+sZ
+sZ
+sZ
+sZ
+sZ
+sZ
+sZ
 sZ
 ys
 "}
@@ -6465,21 +6355,21 @@ ff
 dd
 gf
 Xg
-gF
+tR
 QQ
 tS
 ib
 yD
-gF
-gF
-su
+pU
+qi
+qi
 Ad
 qi
 qi
 qi
-pU
-Ak
-Ak
+qi
+qi
+qi
 ys
 "}
 (10,1,1) = {"
@@ -6492,21 +6382,21 @@ QJ
 hu
 kN
 qE
-gF
+tR
 QO
 GO
 GO
 GO
-gF
-gF
-gF
+jD
+GY
+GY
 li
 li
 li
 GY
-gF
-gF
-gF
+GY
+GY
+GY
 ys
 "}
 (11,1,1) = {"
@@ -6573,7 +6463,7 @@ yZ
 sH
 CB
 NY
-gF
+tR
 fN
 eg
 qp
@@ -6600,7 +6490,7 @@ BX
 Eh
 Kj
 FY
-gF
+tR
 xu
 lQ
 lQ
@@ -6627,7 +6517,7 @@ ek
 zr
 Aq
 AH
-gF
+tR
 Xs
 rd
 lQ
@@ -6681,7 +6571,7 @@ Ho
 vo
 Ne
 Ld
-gF
+tR
 rf
 wu
 NF
@@ -6708,7 +6598,7 @@ Wu
 nb
 ww
 ia
-gF
+tR
 ZH
 Ss
 lQ
@@ -6735,12 +6625,12 @@ sA
 Nk
 mz
 kH
-gF
+Wy
 lQ
 lQ
 lQ
 IS
-TD
+GO
 cG
 rT
 rT
@@ -6762,14 +6652,14 @@ fT
 GC
 ck
 EY
-tR
 lQ
 gF
 gF
 gF
 QI
 gF
-Wy
+gF
+zY
 zY
 ld
 Qd
@@ -6789,14 +6679,14 @@ UX
 qu
 vT
 hd
-oJ
 lQ
 iu
 Lb
 fK
 xW
 gF
-uL
+hZ
+zY
 zY
 zY
 na
@@ -6816,13 +6706,13 @@ qM
 TT
 ZB
 NZ
-oM
 lQ
 gF
 SQ
 xW
+uc
 tK
-gF
+su
 It
 hQ
 sD
@@ -6843,12 +6733,12 @@ if
 gz
 Ca
 aK
-UY
 lQ
 gF
 gF
-RV
+YD
 xu
+gF
 gF
 gF
 xu
@@ -6870,13 +6760,13 @@ pc
 ah
 Kq
 hb
-jD
 lQ
 lQ
 lQ
 lQ
 lQ
 lQ
+oM
 lQ
 lQ
 lQ

--- a/_maps/splurt/templates/apartment_kiss.dmm
+++ b/_maps/splurt/templates/apartment_kiss.dmm
@@ -23,7 +23,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -63,7 +62,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -78,7 +76,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -110,7 +107,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -125,7 +121,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -140,7 +135,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -158,7 +152,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -250,7 +243,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -329,7 +321,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -344,7 +335,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -392,7 +382,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -412,7 +401,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -506,7 +494,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -646,7 +633,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -728,7 +714,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -752,7 +737,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -805,7 +789,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -858,7 +841,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -877,7 +859,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -979,7 +960,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1104,7 +1084,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1189,7 +1168,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1214,7 +1192,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1286,7 +1263,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -1310,7 +1286,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1373,7 +1348,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1428,7 +1402,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1455,7 +1428,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1490,7 +1462,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1517,7 +1488,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1531,7 +1501,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -1546,7 +1515,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1560,7 +1528,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1574,7 +1541,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1605,7 +1571,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1789,7 +1754,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -1809,7 +1773,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -1941,7 +1904,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2065,7 +2027,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2105,7 +2066,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2179,7 +2139,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2220,7 +2179,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2264,7 +2222,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2370,7 +2327,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2385,7 +2341,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2413,7 +2368,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2538,7 +2492,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2553,7 +2506,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2586,7 +2538,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2621,7 +2572,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2654,7 +2604,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2734,7 +2683,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2789,7 +2737,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2803,7 +2750,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2817,7 +2763,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2847,7 +2792,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -2918,7 +2862,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2932,7 +2875,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2967,7 +2909,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -2999,7 +2940,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3014,7 +2954,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3079,7 +3018,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3129,7 +3067,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3245,7 +3182,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3260,7 +3196,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3280,7 +3215,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3295,7 +3229,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3309,7 +3242,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3425,7 +3357,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3534,7 +3465,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3606,7 +3536,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3628,7 +3557,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3661,11 +3589,6 @@
 	icon_state = "11,24"
 	},
 /area/misc/hilbertshotel)
-"FY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
-/area/misc/hilbertshotel)
 "Gc" = (
 /obj/effect/abstract/marker{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
@@ -3673,7 +3596,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3791,7 +3713,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3841,7 +3762,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -3902,7 +3822,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -3976,7 +3895,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4072,7 +3990,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4099,7 +4016,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4127,7 +4043,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4245,7 +4160,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4263,7 +4177,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4304,7 +4217,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4423,7 +4335,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4655,7 +4566,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4707,7 +4617,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4767,7 +4676,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -4807,7 +4715,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4822,7 +4729,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4873,7 +4779,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -4930,7 +4835,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5010,7 +4914,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5071,7 +4974,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5086,7 +4988,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5110,7 +5011,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5197,7 +5097,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5297,7 +5196,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5338,7 +5236,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5401,7 +5298,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5476,7 +5372,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5531,7 +5426,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5558,7 +5452,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5578,7 +5471,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5605,7 +5497,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5655,7 +5546,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
 	base_icon_state = "0,34";
@@ -5669,7 +5559,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -5780,7 +5669,6 @@
 	alpha = 100;
 	name = "rain"
 	},
-/turf/open/space/basic,
 /turf/open/indestructible/tram{
 	base_icon_state = "0,34";
 	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
@@ -6531,7 +6419,7 @@ na
 gF
 VC
 VC
-FY
+VC
 lQ
 lQ
 ys

--- a/_maps/splurt/templates/apartment_morgue.dmm
+++ b/_maps/splurt/templates/apartment_morgue.dmm
@@ -2657,6 +2657,7 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/coin/silver,
 /turf/open/floor/iron/checker,
 /area/misc/hilbertshotel)
 "NG" = (

--- a/_maps/splurt/templates/apartment_morgue.dmm
+++ b/_maps/splurt/templates/apartment_morgue.dmm
@@ -1,0 +1,3943 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,11"
+	},
+/area/misc/hilbertshotel)
+"ac" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,8"
+	},
+/area/misc/hilbertshotel)
+"ae" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,21"
+	},
+/area/misc/hilbertshotel)
+"am" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,19"
+	},
+/area/misc/hilbertshotel)
+"ap" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,24"
+	},
+/area/misc/hilbertshotel)
+"av" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	alpha = 160;
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"aL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,12"
+	},
+/area/misc/hilbertshotel)
+"aS" = (
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"bo" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,24"
+	},
+/area/misc/hilbertshotel)
+"bw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,12"
+	},
+/area/misc/hilbertshotel)
+"bI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,20"
+	},
+/area/misc/hilbertshotel)
+"bJ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = -31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	pixel_x = -16;
+	anchored = 1;
+	name = "Waiting room radio";
+	desc = "The radio dial has been ripped off, and it's stuck on the 24/7 Herb Alpert all time hits station, how dreadful!"
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"bO" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/table/wood,
+/obj/item/lighter,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"bV" = (
+/obj/structure/bed/medical/emergency,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"co" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,14"
+	},
+/area/misc/hilbertshotel)
+"cs" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,5"
+	},
+/area/misc/hilbertshotel)
+"cC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,19"
+	},
+/area/misc/hilbertshotel)
+"cD" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,18"
+	},
+/area/misc/hilbertshotel)
+"cF" = (
+/obj/structure/table/optable,
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"cU" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"do" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,27"
+	},
+/area/misc/hilbertshotel)
+"dr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,22"
+	},
+/area/misc/hilbertshotel)
+"dQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,13"
+	},
+/area/misc/hilbertshotel)
+"dY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,27"
+	},
+/area/misc/hilbertshotel)
+"eb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,10"
+	},
+/area/misc/hilbertshotel)
+"ek" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram{
+	color = "#b8b8b8"
+	},
+/area/misc/hilbertshotel)
+"ep" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,16"
+	},
+/area/misc/hilbertshotel)
+"ew" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,10"
+	},
+/area/misc/hilbertshotel)
+"eP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,7"
+	},
+/area/misc/hilbertshotel)
+"eR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/punch{
+	alpha = 160;
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"fj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,12"
+	},
+/area/misc/hilbertshotel)
+"fu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,17"
+	},
+/area/misc/hilbertshotel)
+"fH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,13"
+	},
+/area/misc/hilbertshotel)
+"fJ" = (
+/obj/machinery/telecomms/relay/preset/auto,
+/turf/open/floor/catwalk_floor,
+/area/misc/hilbertshotel)
+"fP" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/sign/warning/no_smoking/directional/east,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"gv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,11"
+	},
+/area/misc/hilbertshotel)
+"gH" = (
+/obj/machinery/light/floor{
+	brightness = 3;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"gJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,12"
+	},
+/area/misc/hilbertshotel)
+"gP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,9"
+	},
+/area/misc/hilbertshotel)
+"gQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,21"
+	},
+/area/misc/hilbertshotel)
+"hj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"hq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,11"
+	},
+/area/misc/hilbertshotel)
+"ht" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,27"
+	},
+/area/misc/hilbertshotel)
+"hH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,10"
+	},
+/area/misc/hilbertshotel)
+"hQ" = (
+/obj/structure/table/reinforced,
+/obj/structure/noticeboard/directional/north,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"hV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,26"
+	},
+/area/misc/hilbertshotel)
+"ig" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,16"
+	},
+/area/misc/hilbertshotel)
+"iN" = (
+/obj/machinery/computer,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"iQ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,22"
+	},
+/area/misc/hilbertshotel)
+"iY" = (
+/obj/structure/falsewall,
+/turf/open/floor/iron/dark/side,
+/area/misc/hilbertshotel)
+"jc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,12"
+	},
+/area/misc/hilbertshotel)
+"jl" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,26"
+	},
+/area/misc/hilbertshotel)
+"jq" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"jw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,16"
+	},
+/area/misc/hilbertshotel)
+"jB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,9"
+	},
+/area/misc/hilbertshotel)
+"jI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,14"
+	},
+/area/misc/hilbertshotel)
+"jT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,17"
+	},
+/area/misc/hilbertshotel)
+"kf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,12"
+	},
+/area/misc/hilbertshotel)
+"kg" = (
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"ki" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,11"
+	},
+/area/misc/hilbertshotel)
+"kl" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,16"
+	},
+/area/misc/hilbertshotel)
+"ku" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,13"
+	},
+/area/misc/hilbertshotel)
+"kN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,18"
+	},
+/area/misc/hilbertshotel)
+"kT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram{
+	color = "#cfcfcf"
+	},
+/area/misc/hilbertshotel)
+"kV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,17"
+	},
+/area/misc/hilbertshotel)
+"kZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,15"
+	},
+/area/misc/hilbertshotel)
+"ld" = (
+/obj/structure/chair,
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"lx" = (
+/obj/machinery/vending/dorms{
+	shut_up = 1
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"lF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,6"
+	},
+/area/misc/hilbertshotel)
+"lG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,23"
+	},
+/area/misc/hilbertshotel)
+"lN" = (
+/obj/effect/turf_decal/trimline/purple/punch{
+	alpha = 160;
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"lO" = (
+/obj/structure/bodycontainer/morgue/beeper_off{
+	obj_flags = 3
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"ma" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	alpha = 160;
+	dir = 1
+	},
+/obj/structure/sign/calendar/directional/north,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"mg" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"ml" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,23"
+	},
+/area/misc/hilbertshotel)
+"mv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,8"
+	},
+/area/misc/hilbertshotel)
+"mB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,15"
+	},
+/area/misc/hilbertshotel)
+"mJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,26"
+	},
+/area/misc/hilbertshotel)
+"mS" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,24"
+	},
+/area/misc/hilbertshotel)
+"ne" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,8"
+	},
+/area/misc/hilbertshotel)
+"np" = (
+/obj/machinery/door/airlock/medical{
+	name = "Break Room"
+	},
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"nq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,17"
+	},
+/area/misc/hilbertshotel)
+"nv" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/obj/structure/noticeboard/directional/west,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"nF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,10"
+	},
+/area/misc/hilbertshotel)
+"nL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,16"
+	},
+/area/misc/hilbertshotel)
+"nT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,5"
+	},
+/area/misc/hilbertshotel)
+"om" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,26"
+	},
+/area/misc/hilbertshotel)
+"on" = (
+/obj/effect/turf_decal/trimline/purple/punch{
+	alpha = 160
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"ot" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/vending/imported/tiziran{
+	all_products_free = 1;
+	shut_up = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"oA" = (
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"pa" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,25"
+	},
+/area/misc/hilbertshotel)
+"pl" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,6"
+	},
+/area/misc/hilbertshotel)
+"pq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,20"
+	},
+/area/misc/hilbertshotel)
+"pu" = (
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"pE" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,18"
+	},
+/area/misc/hilbertshotel)
+"pM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,7"
+	},
+/area/misc/hilbertshotel)
+"pO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,14"
+	},
+/area/misc/hilbertshotel)
+"pY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,20"
+	},
+/area/misc/hilbertshotel)
+"qa" = (
+/obj/machinery/medical_kiosk,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"qd" = (
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"qf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,23"
+	},
+/area/misc/hilbertshotel)
+"qh" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "appartment_morgue_shutter";
+	name = "Pharmacy Shutters"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/north,
+/obj/structure/desk_bell{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"qr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,5"
+	},
+/area/misc/hilbertshotel)
+"rn" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/universal,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"rz" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"rG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,23"
+	},
+/area/misc/hilbertshotel)
+"rT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,19"
+	},
+/area/misc/hilbertshotel)
+"sf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,20"
+	},
+/area/misc/hilbertshotel)
+"sl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "appartment_morgue_shutter";
+	name = "Pharmacy Shutters"
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/structure/desk_bell{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/machinery/door/window/left/directional/west,
+/obj/item/pen,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"sr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,11"
+	},
+/area/misc/hilbertshotel)
+"su" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,18"
+	},
+/area/misc/hilbertshotel)
+"sC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,5"
+	},
+/area/misc/hilbertshotel)
+"sE" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,27"
+	},
+/area/misc/hilbertshotel)
+"sT" = (
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/closed/indestructible/steel,
+/area/misc/hilbertshotel)
+"sV" = (
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"tb" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"ti" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,22"
+	},
+/area/misc/hilbertshotel)
+"tm" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/purple/punch{
+	alpha = 160;
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"tx" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"tC" = (
+/obj/structure/sign/departments/medbay/alt/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	alpha = 160;
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"tD" = (
+/obj/structure/bodycontainer/morgue/beeper_off{
+	obj_flags = 3
+	},
+/obj/effect/turf_decal/trimline/white/warning,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"tF" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/corner{
+	alpha = 160
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"uf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,20"
+	},
+/area/misc/hilbertshotel)
+"up" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,14"
+	},
+/area/misc/hilbertshotel)
+"uv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,16"
+	},
+/area/misc/hilbertshotel)
+"uB" = (
+/obj/item/kirbyplants,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"uP" = (
+/obj/structure/table,
+/obj/item/storage/box/bandages{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/syringe,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"uV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,22"
+	},
+/area/misc/hilbertshotel)
+"vh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,7"
+	},
+/area/misc/hilbertshotel)
+"vi" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,10"
+	},
+/area/misc/hilbertshotel)
+"wi" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram{
+	color = "#d6d6d6"
+	},
+/area/misc/hilbertshotel)
+"wu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,5"
+	},
+/area/misc/hilbertshotel)
+"wC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,21"
+	},
+/area/misc/hilbertshotel)
+"wK" = (
+/obj/structure/table/reinforced,
+/obj/structure/sign/clock/directional/north,
+/obj/item/folder/white{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/paper/fluff/jobs/medical/blood_types{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"wO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,8"
+	},
+/area/misc/hilbertshotel)
+"wZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,21"
+	},
+/area/misc/hilbertshotel)
+"xd" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,21"
+	},
+/area/misc/hilbertshotel)
+"xo" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,20"
+	},
+/area/misc/hilbertshotel)
+"xw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,23"
+	},
+/area/misc/hilbertshotel)
+"xC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,26"
+	},
+/area/misc/hilbertshotel)
+"xH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,18"
+	},
+/area/misc/hilbertshotel)
+"xO" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,6"
+	},
+/area/misc/hilbertshotel)
+"yb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,7"
+	},
+/area/misc/hilbertshotel)
+"yn" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,9"
+	},
+/area/misc/hilbertshotel)
+"yw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,5"
+	},
+/area/misc/hilbertshotel)
+"yy" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"yH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,25"
+	},
+/area/misc/hilbertshotel)
+"yL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,8"
+	},
+/area/misc/hilbertshotel)
+"yZ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram,
+/area/misc/hilbertshotel)
+"zu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram{
+	color = "#c6c6c6"
+	},
+/area/misc/hilbertshotel)
+"zv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,15"
+	},
+/area/misc/hilbertshotel)
+"zH" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,9"
+	},
+/area/misc/hilbertshotel)
+"zI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,14"
+	},
+/area/misc/hilbertshotel)
+"zK" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"zO" = (
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"zP" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,21"
+	},
+/area/misc/hilbertshotel)
+"Ai" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/chair/sofa/corp/corner,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Ar" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,24"
+	},
+/area/misc/hilbertshotel)
+"At" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,24"
+	},
+/area/misc/hilbertshotel)
+"AO" = (
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"AV" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Bo" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 10
+	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"Bv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,9"
+	},
+/area/misc/hilbertshotel)
+"BF" = (
+/obj/structure/bodycontainer/morgue/beeper_off{
+	obj_flags = 3
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"BL" = (
+/obj/structure/curtain,
+/obj/machinery/door/airlock/medical{
+	name = "Operating Room"
+	},
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"BM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,23"
+	},
+/area/misc/hilbertshotel)
+"Cd" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,21"
+	},
+/area/misc/hilbertshotel)
+"Cg" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,20"
+	},
+/area/misc/hilbertshotel)
+"Ch" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,8"
+	},
+/area/misc/hilbertshotel)
+"Ci" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,13"
+	},
+/area/misc/hilbertshotel)
+"CR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,24"
+	},
+/area/misc/hilbertshotel)
+"CY" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"De" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,14"
+	},
+/area/misc/hilbertshotel)
+"Dj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,18"
+	},
+/area/misc/hilbertshotel)
+"Dk" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,12"
+	},
+/area/misc/hilbertshotel)
+"Dt" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,19"
+	},
+/area/misc/hilbertshotel)
+"DN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,17"
+	},
+/area/misc/hilbertshotel)
+"DR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"DW" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"Ep" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,7"
+	},
+/area/misc/hilbertshotel)
+"Er" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,27"
+	},
+/area/misc/hilbertshotel)
+"Ey" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,27"
+	},
+/area/misc/hilbertshotel)
+"Fj" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"FB" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"FM" = (
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"FR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/item/kirbyplants,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"Gh" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,23"
+	},
+/area/misc/hilbertshotel)
+"Hc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,25"
+	},
+/area/misc/hilbertshotel)
+"Hn" = (
+/turf/closed/indestructible/hotelwall{
+	color = "#000000"
+	},
+/area/misc/hilbertshotel)
+"Hs" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,19"
+	},
+/area/misc/hilbertshotel)
+"Hy" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram{
+	color = "#e8e8e8"
+	},
+/area/misc/hilbertshotel)
+"HF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram{
+	color = "#ababab"
+	},
+/area/misc/hilbertshotel)
+"HL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,22"
+	},
+/area/misc/hilbertshotel)
+"HV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,27"
+	},
+/area/misc/hilbertshotel)
+"Ie" = (
+/obj/structure/reagent_dispensers/water_cooler/punch_cooler/medical,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"Iy" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,17"
+	},
+/area/misc/hilbertshotel)
+"IA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,22"
+	},
+/area/misc/hilbertshotel)
+"IF" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,7"
+	},
+/area/misc/hilbertshotel)
+"IN" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,23"
+	},
+/area/misc/hilbertshotel)
+"Jp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"Jr" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,19"
+	},
+/area/misc/hilbertshotel)
+"Js" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,5"
+	},
+/area/misc/hilbertshotel)
+"Jv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,19"
+	},
+/area/misc/hilbertshotel)
+"JB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,27"
+	},
+/area/misc/hilbertshotel)
+"JL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,8"
+	},
+/area/misc/hilbertshotel)
+"JM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,11"
+	},
+/area/misc/hilbertshotel)
+"JP" = (
+/turf/closed/indestructible/hoteldoor{
+	icon_state = "fake_door";
+	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi'
+	},
+/area/misc/hilbertshotel)
+"JU" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"Ki" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,15"
+	},
+/area/misc/hilbertshotel)
+"Kn" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,13"
+	},
+/area/misc/hilbertshotel)
+"Kp" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "appartment_morgue_shutter";
+	name = "Privacy Shutter"
+	},
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"Kq" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,14"
+	},
+/area/misc/hilbertshotel)
+"KA" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"KB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,26"
+	},
+/area/misc/hilbertshotel)
+"KI" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,25"
+	},
+/area/misc/hilbertshotel)
+"Lc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,7"
+	},
+/area/misc/hilbertshotel)
+"Lv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,6"
+	},
+/area/misc/hilbertshotel)
+"LB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,15"
+	},
+/area/misc/hilbertshotel)
+"LJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,5"
+	},
+/area/misc/hilbertshotel)
+"LT" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"LZ" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"Md" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,15"
+	},
+/area/misc/hilbertshotel)
+"Ml" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,22"
+	},
+/area/misc/hilbertshotel)
+"Mr" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	alpha = 160
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"Mv" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/vending/cigarette{
+	all_products_free = 1;
+	shut_up = 1
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Mz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,25"
+	},
+/area/misc/hilbertshotel)
+"MK" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,6"
+	},
+/area/misc/hilbertshotel)
+"Nb" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,9"
+	},
+/area/misc/hilbertshotel)
+"Nc" = (
+/obj/structure/bodycontainer/morgue/beeper_off{
+	obj_flags = 3
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"Nj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,11"
+	},
+/area/misc/hilbertshotel)
+"Np" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,13"
+	},
+/area/misc/hilbertshotel)
+"NE" = (
+/obj/structure/table/reinforced,
+/obj/item/knife{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_uplift{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"NG" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,16"
+	},
+/area/misc/hilbertshotel)
+"NJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,18"
+	},
+/area/misc/hilbertshotel)
+"NM" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	color = "#d6d6d6"
+	},
+/area/misc/hilbertshotel)
+"Oj" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"OJ" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/surgery_tray/full/morgue,
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"OO" = (
+/obj/machinery/door/airlock/medical{
+	name = "Mortician's Office"
+	},
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/misc/hilbertshotel)
+"Pk" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,13"
+	},
+/area/misc/hilbertshotel)
+"PR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,22"
+	},
+/area/misc/hilbertshotel)
+"Qj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,6"
+	},
+/area/misc/hilbertshotel)
+"Qk" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"Qm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,24"
+	},
+/area/misc/hilbertshotel)
+"Qz" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,9"
+	},
+/area/misc/hilbertshotel)
+"QT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,9"
+	},
+/area/misc/hilbertshotel)
+"Rc" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "16,24"
+	},
+/area/misc/hilbertshotel)
+"Rp" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,11"
+	},
+/area/misc/hilbertshotel)
+"Rt" = (
+/obj/structure/sign/departments/medbay/alt/directional/north,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"RM" = (
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"RX" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,15"
+	},
+/area/misc/hilbertshotel)
+"So" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,21"
+	},
+/area/misc/hilbertshotel)
+"SA" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "15,25"
+	},
+/area/misc/hilbertshotel)
+"SB" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,15"
+	},
+/area/misc/hilbertshotel)
+"Tj" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,7"
+	},
+/area/misc/hilbertshotel)
+"Tm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,25"
+	},
+/area/misc/hilbertshotel)
+"TB" = (
+/obj/effect/turf_decal/trimline/purple/punch{
+	alpha = 160
+	},
+/obj/structure/sign/warning/no_smoking/directional/east,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"TJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/effect/light_emitter/interlink{
+	light_color = "#ffe7cf";
+	light_power = 1.5
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,26"
+	},
+/area/misc/hilbertshotel)
+"Uj" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/chair/office/light,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"Uk" = (
+/obj/structure/closet{
+	name = "janitorial supplies"
+	},
+/obj/item/storage/box/bodybags,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"Uw" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,10"
+	},
+/area/misc/hilbertshotel)
+"UI" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"UY" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,8"
+	},
+/area/misc/hilbertshotel)
+"Vt" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,17"
+	},
+/area/misc/hilbertshotel)
+"VD" = (
+/obj/machinery/button/polarizer{
+	id = "appartment_morgue_windows";
+	pixel_y = 24
+	},
+/turf/open/floor/iron/dark,
+/area/misc/hilbertshotel)
+"VN" = (
+/obj/structure/table/reinforced/rglass,
+/obj/machinery/button/door/directional/north{
+	id = "appartment_morgue_shutter"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north{
+	pixel_x = 16;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"VP" = (
+/obj/machinery/door/airlock/medical{
+	name = "Reception"
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"VV" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,6"
+	},
+/area/misc/hilbertshotel)
+"Wm" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/obj/structure/decorative{
+	icon_state = "siding_plain";
+	pixel_y = 0;
+	icon = 'icons/turf/decals.dmi';
+	dir = 4;
+	color = "#878787";
+	pixel_x = -32
+	},
+/turf/open/indestructible/tram{
+	color = "#f0f0f0"
+	},
+/area/misc/hilbertshotel)
+"Wu" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,20"
+	},
+/area/misc/hilbertshotel)
+"Wv" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "9,17"
+	},
+/area/misc/hilbertshotel)
+"WC" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "11,18"
+	},
+/area/misc/hilbertshotel)
+"WE" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,10"
+	},
+/area/misc/hilbertshotel)
+"WJ" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,14"
+	},
+/area/misc/hilbertshotel)
+"WS" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,12"
+	},
+/area/misc/hilbertshotel)
+"Xf" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,10"
+	},
+/area/misc/hilbertshotel)
+"XG" = (
+/obj/effect/spawner/structure/window{
+	polarizer_id = "appartment_morgue_windows"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+"XL" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,19"
+	},
+/area/misc/hilbertshotel)
+"XW" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/misc/hilbertshotel)
+"Ym" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,6"
+	},
+/area/misc/hilbertshotel)
+"YN" = (
+/turf/closed/indestructible/steel,
+/area/misc/hilbertshotel)
+"YR" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "12,26"
+	},
+/area/misc/hilbertshotel)
+"YT" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "10,13"
+	},
+/area/misc/hilbertshotel)
+"Zh" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Zs" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "13,25"
+	},
+/area/misc/hilbertshotel)
+"Zt" = (
+/obj/effect/abstract/marker{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/rain.dmi';
+	icon_state = "rain";
+	alpha = 100;
+	name = "rain"
+	},
+/turf/open/indestructible/tram{
+	icon = 'modular_zzplurt/icons/obj/skyscraper/background.dmi';
+	base_icon_state = "0,34";
+	icon_state = "14,16"
+	},
+/area/misc/hilbertshotel)
+"ZD" = (
+/obj/machinery/room_controller/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/hilbertshotel)
+
+(1,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(2,1,1) = {"
+Hn
+Ey
+hV
+Hc
+CR
+BM
+HL
+wZ
+Wu
+Hs
+xH
+Wv
+uv
+zv
+zI
+dQ
+gJ
+ki
+vi
+QT
+mv
+IF
+VV
+sC
+Hn
+"}
+(3,1,1) = {"
+Hn
+JB
+TJ
+Mz
+ap
+xw
+Ml
+ae
+uf
+Jv
+Dj
+jT
+jw
+LB
+up
+YT
+Dk
+sr
+WE
+Nb
+UY
+yb
+Ym
+nT
+Hn
+"}
+(4,1,1) = {"
+Hn
+ht
+mJ
+Tm
+At
+Gh
+IA
+xd
+bI
+Jr
+WC
+nq
+nL
+SB
+De
+fH
+aL
+hq
+Uw
+gP
+Ch
+eP
+Qj
+cs
+Hn
+"}
+(5,1,1) = {"
+Hn
+do
+YR
+yH
+Ar
+ml
+uV
+So
+xo
+am
+cD
+Vt
+ep
+Ki
+WJ
+Pk
+fj
+gv
+hH
+jB
+wO
+Tj
+pl
+Js
+Hn
+"}
+(6,1,1) = {"
+Hn
+HV
+KB
+Zs
+mS
+qf
+PR
+gQ
+sf
+Dt
+NJ
+DN
+ig
+kZ
+Kq
+Ci
+WS
+ab
+eb
+Bv
+yL
+vh
+MK
+qr
+Hn
+"}
+(7,1,1) = {"
+Hn
+dY
+xC
+KI
+Qm
+lG
+iQ
+Cd
+Cg
+XL
+kN
+kV
+Zt
+Md
+pO
+Np
+jc
+JM
+Xf
+Qz
+ac
+pM
+lF
+LJ
+Hn
+"}
+(8,1,1) = {"
+Hn
+sE
+om
+SA
+bo
+rG
+ti
+zP
+pq
+rT
+su
+Iy
+NG
+RX
+co
+Kn
+bw
+Rp
+nF
+zH
+JL
+Lc
+xO
+yw
+Hn
+"}
+(9,1,1) = {"
+Hn
+Er
+jl
+pa
+Rc
+IN
+dr
+wC
+pY
+cC
+pE
+fu
+kl
+mB
+jI
+ku
+kf
+Nj
+ew
+yn
+ne
+Ep
+Lv
+wu
+Hn
+"}
+(10,1,1) = {"
+Hn
+sT
+sT
+sT
+sT
+sT
+sT
+sT
+sT
+sT
+sT
+yZ
+Wm
+Hy
+NM
+kT
+zu
+yZ
+Hy
+wi
+kT
+zu
+ek
+HF
+Hn
+"}
+(11,1,1) = {"
+Hn
+YN
+LT
+KA
+YN
+lO
+Nc
+BF
+tD
+aS
+YN
+YN
+YN
+YN
+FB
+FB
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(12,1,1) = {"
+Hn
+YN
+ld
+zO
+iY
+oA
+sV
+sV
+kg
+AO
+yy
+nv
+Bo
+VP
+jq
+uB
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(13,1,1) = {"
+Hn
+YN
+NE
+lx
+YN
+iN
+tb
+Oj
+Oj
+Oj
+YN
+ma
+Uj
+qh
+jq
+cU
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(14,1,1) = {"
+Hn
+YN
+YN
+YN
+YN
+hQ
+LZ
+Uk
+DW
+Oj
+YN
+VN
+Mr
+Kp
+av
+bJ
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(15,1,1) = {"
+Hn
+Hn
+fJ
+YN
+YN
+XG
+XG
+YN
+YN
+yy
+YN
+qd
+XW
+Kp
+av
+bV
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(16,1,1) = {"
+Hn
+Hn
+Hn
+YN
+wK
+JU
+UI
+YN
+Jp
+mg
+YN
+Kp
+sl
+YN
+tC
+cU
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(17,1,1) = {"
+Hn
+Hn
+Hn
+YN
+VD
+Oj
+Oj
+BL
+jq
+RM
+YN
+FR
+tF
+eR
+lN
+tm
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(18,1,1) = {"
+Hn
+Hn
+Hn
+YN
+cF
+Oj
+Oj
+YN
+hj
+pu
+YN
+Rt
+on
+gH
+pu
+qa
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(19,1,1) = {"
+Hn
+Hn
+Hn
+YN
+Qk
+OJ
+rn
+YN
+DR
+CY
+YN
+Ie
+TB
+pu
+pu
+uP
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(20,1,1) = {"
+Hn
+Hn
+Hn
+YN
+YN
+YN
+YN
+YN
+YN
+np
+YN
+YN
+YN
+YN
+OO
+YN
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(21,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+YN
+Mv
+AV
+AV
+Zh
+YN
+Fj
+Fj
+Fj
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(22,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+YN
+ot
+AV
+tx
+bO
+YN
+FM
+Oj
+Oj
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(23,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+YN
+zK
+fP
+Ai
+rz
+YN
+ZD
+Oj
+Oj
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(24,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+YN
+YN
+YN
+YN
+YN
+YN
+YN
+JP
+YN
+YN
+YN
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(25,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}

--- a/_maps/splurt/templates/apartment_morgue.dmm
+++ b/_maps/splurt/templates/apartment_morgue.dmm
@@ -1153,7 +1153,7 @@
 "qh" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "appartment_morgue_shutter";
-	name = "Pharmacy Shutters"
+	name = "Reception Shutter"
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north,
@@ -1233,7 +1233,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "appartment_morgue_shutter";
-	name = "Pharmacy Shutters"
+	name = "Reception Shutter"
 	},
 /obj/item/folder/white{
 	pixel_x = 4;
@@ -2406,7 +2406,7 @@
 "Kp" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "appartment_morgue_shutter";
-	name = "Privacy Shutter"
+	name = "Reception Shutter"
 	},
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/flora/grass/jungle,
@@ -3011,14 +3011,16 @@
 "VD" = (
 /obj/machinery/button/polarizer{
 	id = "appartment_morgue_windows";
-	pixel_y = 24
+	pixel_y = 24;
+	name = "Privacy Windows"
 	},
 /turf/open/floor/iron/dark,
 /area/misc/hilbertshotel)
 "VN" = (
 /obj/structure/table/reinforced/rglass,
 /obj/machinery/button/door/directional/north{
-	id = "appartment_morgue_shutter"
+	id = "appartment_morgue_shutter";
+	name = "Reception Shutter"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1

--- a/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
+++ b/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
@@ -225,6 +225,12 @@
 	category = GHC_APARTMENT
 	landing_coords = list(23, 15)
 
+/datum/map_template/ghost_cafe_rooms/apartment_morgue
+	name = "Mortician's Office"
+	mappath = "_maps/splurt/templates/apartment_morgue.dmm"
+	category = GHC_SPECIAL
+	landing_coords = list(22, 10)
+
 #undef GHC_MISC
 #undef GHC_APARTMENT
 #undef GHC_BEACH

--- a/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
+++ b/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
@@ -223,7 +223,7 @@
 	name = "City Apartment (Empty)"
 	mappath = "_maps/splurt/templates/apartment_kiss.dmm"
 	category = GHC_APARTMENT
-	landing_coords = list(20, 12)
+	landing_coords = list(20, 13)
 
 #undef GHC_MISC
 #undef GHC_APARTMENT

--- a/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
+++ b/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
@@ -223,7 +223,7 @@
 	name = "City Apartment (Empty)"
 	mappath = "_maps/splurt/templates/apartment_kiss.dmm"
 	category = GHC_APARTMENT
-	landing_coords = list(20, 13)
+	landing_coords = list(22, 15)
 
 #undef GHC_MISC
 #undef GHC_APARTMENT

--- a/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
+++ b/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
@@ -219,6 +219,12 @@
 	mappath = "_maps/splurt/templates/apartment_spaceruin.dmm"
 	category = GHC_MISC
 
+/datum/map_template/ghost_cafe_rooms/apartment_kiss
+	name = "City Apartment (Empty)"
+	mappath = "_maps/splurt/templates/apartment_kiss.dmm"
+	category = GHC_APARTMENT
+	landing_coords = list(20, 12)
+
 #undef GHC_MISC
 #undef GHC_APARTMENT
 #undef GHC_BEACH

--- a/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
+++ b/modular_zzplurt/code/modules/hilbertshotel/hotel_room_templates.dm
@@ -223,7 +223,7 @@
 	name = "City Apartment (Empty)"
 	mappath = "_maps/splurt/templates/apartment_kiss.dmm"
 	category = GHC_APARTMENT
-	landing_coords = list(22, 15)
+	landing_coords = list(23, 15)
 
 #undef GHC_MISC
 #undef GHC_APARTMENT


### PR DESCRIPTION
## About The Pull Request

This PR adds a new apartment that is geared towards the inner interior decorator of spacemen, and a mortician's office.

This apartment comes barely finished, and includes utilities such as wood, iron, etc to finish up the rest of it.

The Mortician office comes with all the usual tools.

## Why It's Good For The Game

Adds variety to the hilbert's hotel selection.

## Proof Of Testing

### DIY Apartment

<img width="512" height="432" alt="test" src="https://github.com/user-attachments/assets/9791b318-4b5c-4e1f-91e1-d435c02650fb" />

### Mortician's Office

<img width="432" height="432" alt="office" src="https://github.com/user-attachments/assets/2d1ddaf0-c909-4e1c-8145-155a22014405" />

## Changelog

:cl:
add: Added empty city apartment to Hilbert's Hotel
add: Added mortician's office to Hilbert's Hotel
/:cl: