### PR TITLE
make hypersensitive and depression no longer mutually exclude one another

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -8,7 +8,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/scarred_eye),
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/fluoride_stare),
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/touchy),
-	list(/datum/quirk/jolly, /datum/quirk/depression, /datum/quirk/hypersensitive),
+	list(/datum/quirk/jolly, /datum/quirk/hypersensitive), // SPLURT EDIT CHANGE - no reason you can't be sensitive and depressed. to reimplement, (/datum/quirk/jolly, /datum/quirk/depression,(...)
 	list(/datum/quirk/no_taste, /datum/quirk/vegetarian, /datum/quirk/deviant_tastes, /datum/quirk/gamer),
 	list(/datum/quirk/pineapple_liker, /datum/quirk/pineapple_hater, /datum/quirk/gamer),
 	list(/datum/quirk/alcohol_tolerance, /datum/quirk/light_drinker),

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -8,7 +8,8 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/scarred_eye),
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/fluoride_stare),
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/touchy),
-	list(/datum/quirk/jolly, /datum/quirk/hypersensitive), // SPLURT EDIT CHANGE - no reason you can't be sensitive and depressed. to reimplement, (/datum/quirk/jolly, /datum/quirk/depression,(...)
+	list(/datum/quirk/jolly, /datum/quirk/depression), // SPLURT EDIT CHANGE - no reason you can't be sensitive and depressed. to reimplement, ", /datum/quirk/hypersensitive"
+	list(/datum/quirk/jolly, /datum/quirk/hypersensitive), // SPLURT EDIT ADD - we don't want players to be happy
 	list(/datum/quirk/no_taste, /datum/quirk/vegetarian, /datum/quirk/deviant_tastes, /datum/quirk/gamer),
 	list(/datum/quirk/pineapple_liker, /datum/quirk/pineapple_hater, /datum/quirk/gamer),
 	list(/datum/quirk/alcohol_tolerance, /datum/quirk/light_drinker),


### PR DESCRIPTION

## About The Pull Request

Makes Hypersensitive and Depression no longer conflict. Jolly is not removed from the blacklist simply because having your mood randomly spike instead of plummet is a tangible positive for your gameplay that could result in real mechanical advantage.

## Why It's Good For The Game

These are two negative quirks which combined make each other much more of a problem, and there's no real reason not to enable that for people who opt into it. There are also items explicitly meant to make your mood go up, and having extremely sad characters who have to counteract their mood drops with it would be good flavor for people who like managing stuff like that (me).

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="471" height="117" alt="image" src="https://github.com/user-attachments/assets/0933e1ee-c811-4ea7-a4d7-2388215cd2ec" />
<img width="486" height="39" alt="image" src="https://github.com/user-attachments/assets/86131842-0181-4ea1-b999-b460eafb48fe" />

</details>

## Changelog
:cl:
balance: Hypersensitive and Depression can be taken together.
/:cl:
