### PR TITLE
Fix teshari butt layer issue (#745)

### DIFF
--- a/modular_zzplurt/code/modules/sprite_accessories/genitals.dm
+++ b/modular_zzplurt/code/modules/sprite_accessories/genitals.dm
@@ -138,7 +138,7 @@
 	color_src = USE_MATRIXED_COLORS
 	always_color_customizable = TRUE
 	has_skintone_shading = TRUE
-	relevent_layers = list(BODY_ADJ_LAYER, BODY_FRONT_LAYER)
+	relevent_layers = list(BODY_ADJ_LAYER)
 
 /datum/sprite_accessory/genital/butt/none
 	icon_state = "none"


### PR DESCRIPTION
## About The Pull Request
Fixes #745 - Fixed tesharii butt layer issue by removing BODY_FRONT_LAYER from butt's relevent_layers.
## Why It's Good For The Game
This prevents the butt sprite from rendering above other body parts on tesharii characters, fixing the visual glitch described in issue #745.
## Changelog
:cl:
fix: fixed tesharii butt layer rendering issue
/:cl: