### PR TITLE
Extra Plasmaman Envirosuits and Envirosuit Kits

### DIFF
--- a/modular_zzplurt/code/game/objects/items/storage/boxes/clothes_boxes.dm
+++ b/modular_zzplurt/code/game/objects/items/storage/boxes/clothes_boxes.dm
@@ -1,3 +1,73 @@
+/// Lewd Toys box
 /obj/item/storage/box/lewd_toys/PopulateContents()
 	. = ..()
 	new /obj/item/storage/box/portal_fleshlight(src)
+
+/// Start Plasmaman Envirosuit Boxes
+/// Orange
+
+/obj/item/storage/box/envirosuit
+	name = "orange envirosuit kit"
+	desc = "A box containing a complete plasmaman envirosuit in a garish orange. For the most average of bones."
+
+/obj/item/storage/box/envirosuit/PopulateContents()
+	new /obj/item/clothing/under/plasmaman(src)
+	new /obj/item/clothing/head/helmet/space/plasmaman(src)
+	new /obj/item/clothing/gloves/color/plasmaman(src)
+
+/// Slacks
+
+/obj/item/storage/box/envirosuit/slacks
+	name = "enviroslacks kit"
+	desc = "A box containing a complete set of plasmaman's formals. For the fanciest of bones."
+
+/obj/item/storage/box/envirosuit/slacks/PopulateContents()
+	new /obj/item/clothing/under/plasmaman/enviroslacks(src)
+	new /obj/item/clothing/head/helmet/space/plasmaman/white(src)
+	new /obj/item/clothing/gloves/color/plasmaman/white(src)
+
+/// White
+
+/obj/item/storage/box/envirosuit/white
+	name = "white envirosuit kit"
+	desc = "A box containing a complete plasmaman envirosuit in white. For the brightest of bones."
+
+/obj/item/storage/box/envirosuit/white/PopulateContents()
+	new /obj/item/clothing/under/plasmaman/white(src)
+	new /obj/item/clothing/head/helmet/space/plasmaman/white(src)
+	new /obj/item/clothing/gloves/color/plasmaman/white(src)
+
+/// Black
+
+/obj/item/storage/box/envirosuit/black
+	name = "black envirosuit kit"
+	desc = "A box containing a complete plasmaman envirosuit in black. For the edgiest of bones."
+
+/obj/item/storage/box/envirosuit/black/PopulateContents()
+	new /obj/item/clothing/under/plasmaman/black(src)
+	new /obj/item/clothing/head/helmet/space/plasmaman/black(src)
+	new /obj/item/clothing/gloves/color/plasmaman/black(src)
+
+/// Khaki
+
+/obj/item/storage/box/envirosuit/khaki
+	name = "khaki envirosuit kit"
+	desc = "A box containing a complete plasmaman envirosuit in a drab khaki. For the most adventurous of bones."
+
+/obj/item/storage/box/envirosuit/khaki/PopulateContents()
+	new /obj/item/clothing/under/plasmaman/khaki(src)
+	new /obj/item/clothing/head/helmet/space/plasmaman/khaki(src)
+	new /obj/item/clothing/gloves/color/plasmaman/explorer(src)
+
+/// Prototype
+
+/obj/item/storage/box/envirosuit/prototype
+	name = "prototype envirosuit kit"
+	desc = "A box containing a complete prototype plasmaman envirosuit. For the most nostalgic of bones."
+
+/obj/item/storage/box/envirosuit/prototype/PopulateContents()
+	new /obj/item/clothing/under/plasmaman/prototype(src)
+	new /obj/item/clothing/head/helmet/space/plasmaman/prototype(src)
+	new /obj/item/clothing/gloves/color/plasmaman/prototype(src)
+
+/// End Plasmaman Envirosuit Boxes

--- a/modular_zzplurt/code/modules/clothing/head/plasmaman.dm
+++ b/modular_zzplurt/code/modules/clothing/head/plasmaman.dm
@@ -1,0 +1,25 @@
+/// Cosmetic Envirohelmets
+/// Black Envirohelm, renamed Chaplain suit
+
+/obj/item/clothing/head/helmet/space/plasmaman/black
+	name = "black plasma envirosuit helmet"
+	desc = "A special black containment helmet that allows plasma-based lifeforms to exist safely in an oxygenated environment. It is space-worthy, and may be worn in tandem with other EVA gear."
+	icon = 'icons/obj/clothing/head/plasmaman_hats.dmi'
+	icon_state = "chap_envirohelm"
+
+/// Khaki Envirohelm, renamed Miner suit
+
+/obj/item/clothing/head/helmet/space/plasmaman/khaki
+	name = "khaki plasma envirosuit helmet"
+	desc = "A special khaki containment helmet that allows plasma-based lifeforms to exist safely in an oxygenated environment. It is space-worthy, and may be worn in tandem with other EVA gear."
+	icon = 'icons/obj/clothing/head/plasmaman_hats.dmi'
+	icon_state = "explorer_envirohelm"
+
+/// Prototype Envirohelm, renamed Curator suit
+
+/obj/item/clothing/head/helmet/space/plasmaman/prototype
+	name = "prototype plasma envirosuit helmet"
+	desc = "A slight modification on a traditional voidsuit helmet, this helmet was Nanotrasen's first solution to the *logistical problems* that come with employing plasmamen. Despite their limitations, these helmets still see use by historians and old-skool plasmamen alike."
+	icon = 'icons/obj/clothing/head/plasmaman_hats.dmi'
+	icon_state = "prototype_envirohelm"
+	actions_types = list(/datum/action/item_action/toggle_welding_screen) // removes flashlight functionality, as curator suit lacks one

--- a/modular_zzplurt/code/modules/clothing/under/plasmaman.dm
+++ b/modular_zzplurt/code/modules/clothing/under/plasmaman.dm
@@ -1,0 +1,31 @@
+/// Black Envirosuit, renamed Chaplain suit
+
+/obj/item/clothing/under/plasmaman/black
+	name = "black plasma envirosuit"
+	desc = "A special black containment suit that allows plasma-based lifeforms to exist safely in an oxygenated environment, and automatically extinguishes them in a crisis. Despite being airtight, it's not spaceworthy."
+	icon = 'icons/obj/clothing/under/plasmaman.dmi'
+	icon_state = "chap_envirosuit"
+
+/// White Envirosuit, renamed Chef suit
+
+/obj/item/clothing/under/plasmaman/white
+	name = "white plasma envirosuit"
+	desc = "A special white containment suit that allows plasma-based lifeforms to exist safely in an oxygenated environment, and automatically extinguishes them in a crisis. Despite being airtight, it's not spaceworthy."
+	icon = 'icons/obj/clothing/under/plasmaman.dmi'
+	icon_state = "chef_envirosuit"
+
+/// Khaki Envirosuit, renamed Miner suit
+
+/obj/item/clothing/under/plasmaman/khaki
+	name = "khaki plasma envirosuit"
+	desc = "A special khaki containment suit that allows plasma-based lifeforms to exist safely in an oxygenated environment, and automatically extinguishes them in a crisis. Despite being airtight, it's not spaceworthy."
+	icon = 'icons/obj/clothing/under/plasmaman.dmi'
+	icon_state = "explorer_envirosuit"
+
+/// Prototype Envirosuit, renamed Curator suit
+
+/obj/item/clothing/under/plasmaman/prototype
+	name = "protoype envirosuit"
+	desc = "Made out of a modified voidsuit, this suit was Nanotrasen's first solution to the *logistical problems* that come with employing plasmamen. Due to the modifications, the suit is no longer space-worthy. Despite their limitations, these suits are still in use by historians and old-skool plasmamen alike."
+	icon = 'icons/obj/clothing/under/plasmaman.dmi'
+	icon_state = "prototype_envirosuit"

--- a/modular_zzplurt/code/modules/loadout/categories/inhands.dm
+++ b/modular_zzplurt/code/modules/loadout/categories/inhands.dm
@@ -1,3 +1,38 @@
 /datum/loadout_item/inhand/toolbox/New(category)
 	LAZYADD(blacklisted_roles, ROLE_PERSISTENCE)
 	. = ..()
+
+/*
+PLASMAMAN ENVIROSUIT KITS
+SPECIES RESTRICTED
+*/
+
+/datum/loadout_item/inhand/envirokit_orange
+	name = "Envirosuit Kit: Orange"
+	item_path = /obj/item/storage/box/envirosuit
+	restricted_species = list(SPECIES_PLASMAMAN)
+
+/datum/loadout_item/inhand/envirokit_black
+	name = "Envirosuit Kit: Black"
+	item_path = /obj/item/storage/box/envirosuit/black
+	restricted_species = list(SPECIES_PLASMAMAN)
+
+/datum/loadout_item/inhand/envirokit_white
+	name = "Envirosuit Kit: White"
+	item_path = /obj/item/storage/box/envirosuit/white
+	restricted_species = list(SPECIES_PLASMAMAN)
+
+/datum/loadout_item/inhand/envirokit_khaki
+	name = "Envirosuit Kit: Khaki"
+	item_path = /obj/item/storage/box/envirosuit/khaki
+	restricted_species = list(SPECIES_PLASMAMAN)
+
+/datum/loadout_item/inhand/envirokit_slacks
+	name = "Envirosuit Kit: Formal Enviroslacks"
+	item_path = /obj/item/storage/box/envirosuit/slacks
+	restricted_species = list(SPECIES_PLASMAMAN)
+
+/datum/loadout_item/inhand/envirokit_prototype
+	name = "Envirosuit Kit: Protoype"
+	item_path = /obj/item/storage/box/envirosuit/prototype
+	restricted_species = list(SPECIES_PLASMAMAN)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10251,6 +10251,7 @@
 #include "modular_zzplurt\code\modules\clothing\head\hats.dm"
 #include "modular_zzplurt\code\modules\clothing\head\helmets.dm"
 #include "modular_zzplurt\code\modules\clothing\head\nanotrasen.dm"
+#include "modular_zzplurt\code\modules\clothing\head\plasmaman.dm"
 #include "modular_zzplurt\code\modules\clothing\masks\costume.dm"
 #include "modular_zzplurt\code\modules\clothing\masks\gasmask.dm"
 #include "modular_zzplurt\code\modules\clothing\masks\masks.dm"
@@ -10269,6 +10270,7 @@
 #include "modular_zzplurt\code\modules\clothing\suits\wintercoats.dm"
 #include "modular_zzplurt\code\modules\clothing\under\misc.dm"
 #include "modular_zzplurt\code\modules\clothing\under\nanotrasen.dm"
+#include "modular_zzplurt\code\modules\clothing\under\plasmaman.dm"
 #include "modular_zzplurt\code\modules\clothing\under\uniform.dm"
 #include "modular_zzplurt\code\modules\clothing\under\jobs\medical.dm"
 #include "modular_zzplurt\code\modules\clothing\under\jobs\rnd.dm"
@@ -10673,6 +10675,4 @@
 #include "modular_zzplurt\modules\primitive_production\code\primitive.dm"
 #include "modular_zzplurt\modules\storyteller\event_defines\crewset\obsessed.dm"
 #include "modular_zzplurt\modules\synthx\code\bodyparts\internal_computer\internal_computer.dm"
-#include "modular_zzplurt\code\modules\clothing\head\plasmaman.dm"
-#include "modular_zzplurt\code\modules\clothing\under\plasmaman.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10673,4 +10673,6 @@
 #include "modular_zzplurt\modules\primitive_production\code\primitive.dm"
 #include "modular_zzplurt\modules\storyteller\event_defines\crewset\obsessed.dm"
 #include "modular_zzplurt\modules\synthx\code\bodyparts\internal_computer\internal_computer.dm"
+#include "modular_zzplurt\code\modules\clothing\head\plasmaman.dm"
+#include "modular_zzplurt\code\modules\clothing\under\plasmaman.dm"
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request

First PR for this codebase, apologies for any modularity issues.

'Adds' four 'new' envirosuits, all renamed versions of job-specific envirosuits. Black, white, khaki, prototype which use the chaplain, chef, miner and curator envirosuit sprites respectively.

Adds a few species restricted boxes containing complete plasmaman envirosuits for cosmetic purposes (including the aforementioned new four) to the inhand loadout menu.

## Why It's Good For The Game

Adds more customisation to what is, probably, the most underloved species.

## Proof Of Testing
<img width="807" height="253" alt="image" src="https://github.com/user-attachments/assets/2863f1c0-7602-4dac-9372-a047c2722c97" />

Last four suits are the "new" ones.

<img width="711" height="336" alt="image" src="https://github.com/user-attachments/assets/215714e7-e434-43d6-b8c9-6d0f55e56f6d" />

As seen in the Inhand section of the Loadout menu.  All kits are species restricted and clumped together in the UI.
_Species restriction stops ne'erdowell tiders from getting a free welding/space/flashlight capable helmet off of spawn._

<img width="736" height="238" alt="image" src="https://github.com/user-attachments/assets/3541bb6a-7375-491e-b514-75e3d10046f5" />

All the necesseties, in a box.

## Changelog
:cl:
add: Added four cosmetic versions of job-exclusive plasmaman envirosuits.
add: Added six plasmaman-exclusive envirosuit kits to the inhand loadout menu. Dripless skeletons rejoice!
/:cl:
