### PR TITLE
Fixes and minor addition to text output for mob_holder interactions

### DIFF
--- a/modular_zzplurt/code/datums/elements/holder_micro.dm
+++ b/modular_zzplurt/code/datums/elements/holder_micro.dm
@@ -175,15 +175,25 @@
 	if(istype(M))
 		switch(resolve_intent_name(user))
 			if("harm") //TO:DO, rework all of these interactions to be a lot more in depth
-				visible_message(span_danger("[user] slams their fist down on [M]!"))
+				user.visible_message(span_danger("[user] slams their fist down on [M]!"),
+								span_danger("You slam your fist down on [M]!")) // Have to use a seperate call for "user" since "M" is invisible to bystanders
+				M.visible_message(span_danger("[user] slams their fist down on [M]!"),
+								span_userdanger("[user] slams their fist down on you!"))
 				playsound(loc, 'sound/items/weapons/punch1.ogg', 50, 1)
 				M.adjust_brute_loss(5)
 			if("disarm")
-				visible_message(span_danger("[user] pins [M] down with a finger!"))
+
+				user.visible_message(span_danger("[user] pins [M] down with a finger!"),
+								span_danger("You pin [M] down with a finger!"))
+				M.visible_message(span_danger("[user] pins [M] down with a finger!"),
+								span_userdanger("[user] pins you down with a finger!"))
 				playsound(loc, 'sound/effects/bodyfall/bodyfall1.ogg', 50, 1)
 				M.adjust_stamina_loss(10)
 			if("grab")
-				visible_message(span_danger("[user] squeezes their fist around [M]!"))
+				user.visible_message(span_danger("[user] squeezes their fist around [M]!"),
+								span_danger("You squeeze your fist around [M]!"))
+				M.visible_message(span_danger("[user] squeezes their fist around [M]!"),
+								span_userdanger("[user] squeezes their fist around you!"))
 				playsound(loc, 'sound/items/weapons/thudswoosh.ogg', 50, 1)
 				M.adjust_oxy_loss(5)
 			else

--- a/modular_zzplurt/code/datums/elements/holder_micro.dm
+++ b/modular_zzplurt/code/datums/elements/holder_micro.dm
@@ -176,24 +176,33 @@
 		switch(resolve_intent_name(user))
 			if("harm") //TO:DO, rework all of these interactions to be a lot more in depth
 				user.visible_message(span_danger("[user] slams their fist down on [M]!"),
-								span_danger("You slam your fist down on [M]!")) // Have to use a seperate call for "user" since "M" is invisible to bystanders
-				M.visible_message(span_danger("[user] slams their fist down on [M]!"),
-								span_userdanger("[user] slams their fist down on you!"))
+								span_danger("You slam your fist down on [M]!"),
+								null,
+								null,
+								list(M)
+				)
+				to_chat(M, span_userdanger("[user] slams their fist down on you!")) // Seems I was wrong, I can do better
 				playsound(loc, 'sound/items/weapons/punch1.ogg', 50, 1)
 				M.adjust_brute_loss(5)
 			if("disarm")
 
 				user.visible_message(span_danger("[user] pins [M] down with a finger!"),
-								span_danger("You pin [M] down with a finger!"))
-				M.visible_message(span_danger("[user] pins [M] down with a finger!"),
-								span_userdanger("[user] pins you down with a finger!"))
+								span_danger("You pin [M] down with a finger!"),
+								null,
+								null,
+								list(M)
+				)
+				to_chat(M, span_userdanger("[user] pins you down with a finger!"))
 				playsound(loc, 'sound/effects/bodyfall/bodyfall1.ogg', 50, 1)
 				M.adjust_stamina_loss(10)
 			if("grab")
 				user.visible_message(span_danger("[user] squeezes their fist around [M]!"),
-								span_danger("You squeeze your fist around [M]!"))
-				M.visible_message(span_danger("[user] squeezes their fist around [M]!"),
-								span_userdanger("[user] squeezes their fist around you!"))
+								span_danger("You squeeze your fist around [M]!"),
+								null,
+								null,
+								list(M)
+				)
+				to_chat(M, span_userdanger("[user] squeezes their fist around you!"))
 				playsound(loc, 'sound/items/weapons/thudswoosh.ogg', 50, 1)
 				M.adjust_oxy_loss(5)
 			else


### PR DESCRIPTION

## About The Pull Request
A fix to the text output for mob_holder interactions of different intents (Except for "help" as that uses different code). Additionally made some minor improvements to the way. Those include Disarm-, Grab, and Harm intent interactions with a picked up character.
## Why It's Good For The Game
Smaller characters being in a mob_holder now get information for what is happening to them should an interaction like that take place. Improves immersion.
## Proof Of Testing
It gives three different outputs depending on if the person is performing the action, has the action performed on them or is witnessing it. Important are the three last messages per screenshot.
<details>
<summary>Screenshots/Videos</summary>
<img width="519" height="116" alt="mobholderview" src="https://github.com/user-attachments/assets/9f9dd6a8-b9d4-44d8-a718-9434e29a2486" />

<img width="518" height="259" alt="microview" src="https://github.com/user-attachments/assets/b3c3ca09-7b61-4ad9-94d3-541af0bd39fa" />

<img width="517" height="110" alt="bystanderview" src="https://github.com/user-attachments/assets/9553a138-4ab4-4d3d-9b6d-adebcd72ec5c" />

</details>

## Changelog
🆑 
Adds missing text for certain size based interactions. 
/🆑 
