### PR TITLE
Makes loneop unable to spawn below 50 players

### DIFF
--- a/code/modules/events/ghost_role/operative.dm
+++ b/code/modules/events/ghost_role/operative.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/ghost_role/operative
 	weight = 0 //its weight is relative to how much stationary and neglected the nuke disk is. See nuclearbomb.dm. Shouldn't be dynamic hijackable.
 	max_occurrences = 1
+	min_players = 50 //SPLURT EDIT - Doesn't spawn below 50 active crew
 	category = EVENT_CATEGORY_INVASION
 	description = "A single nuclear operative assaults the station."
 


### PR DESCRIPTION

## About The Pull Request
Yes 50

## Why It's Good For The Game
Lone Op Nuke Station Ka Boom. (Also kate asked me to do this)

## Proof Of Testing
No but I know it works

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Loneop can't spawn below 50 crew.
/:cl:

