### PR TITLE
QoL WT-458 Tweaks

### DIFF
--- a/modular_zubbers/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/modular_zubbers/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -13,3 +13,17 @@
 	fire_delay = 3
 	//18 damage per 0.3 seconds = 60 DPS
 	//Reference: Laser Gun 22 damage per 0.4 seconds = 55DPS
+
+//SPLURT ADDITION EDIT BEGIN - WT-458 Tweaks
+/obj/item/gun/ballistic/automatic/wt550/security/Initialize(mapload)
+	. = ..()
+
+	if(type != /obj/item/gun/ballistic/automatic/wt550/security)
+		return
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/wt458)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+	)
+//SPLURT ADDITION EDIT END

--- a/modular_zzplurt/code/modules/modular_weapons/code/smg.dm
+++ b/modular_zzplurt/code/modules/modular_weapons/code/smg.dm
@@ -82,7 +82,7 @@
 	AddElement(/datum/element/manufacturer_examine, COMPANY_NANOTRASEN)
 
 /obj/item/gun/ballistic/automatic/wt458/add_bayonet_point()
-	AddComponent(/datum/component/bayonet_attachable, offset_x = 25, offset_y = 2)
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 25, offset_y = 14)
 
 /obj/item/gun/ballistic/automatic/wt458/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
@@ -90,3 +90,6 @@
 		light_overlay = "flight", \
 		overlay_x = 10, \
 		overlay_y = 19)
+
+/obj/item/gun/ballistic/automatic/wt458/nomag
+	spawnwithmagazine = FALSE

--- a/modular_zzplurt/code/modules/sec_haul/code/guncrafting.dm
+++ b/modular_zzplurt/code/modules/sec_haul/code/guncrafting.dm
@@ -4,10 +4,20 @@
 
 /datum/crafting_recipe/wt458
 	name = "WT-458 Conversion Kit"
-	result = /obj/item/gun/ballistic/automatic/wt458
+	result = /obj/item/gun/ballistic/automatic/wt458/nomag
 	reqs = list(
 		/obj/item/weaponcrafting/gunkit/wt458_kit = 1,
 		/obj/item/gun/ballistic/automatic/wt550/security = 1,
 	)
+	steps = list(
+		"Take out the magazine",
+		"Leave the rifle unchambered"
+	)
 	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
+
+/datum/crafting_recipe/wt458/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/gun/ballistic/automatic/wt550/security/the_gun = collected_requirements[/obj/item/gun/ballistic/automatic/wt550/security][1]
+	if(the_gun.magazine || the_gun.chambered)
+		return FALSE
+	return ..()


### PR DESCRIPTION

## About The Pull Request
Tweaks WT-458 to make more sense. That includes:
- Reposition of knife overlay to actually be on gun
- Crafting recipe no longer spawns WT with full mag
- Crafting recipe now requires WT to be completely empty
## Why It's Good For The Game
Makes more sense. Also bug killing. :3

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="925" height="643" alt="image" src="https://github.com/user-attachments/assets/8dfbce8f-88ea-4ff4-b85b-53b2dc4a9942" />


</details>

## Changelog
:cl:
qol: crafting recipe for WT-458 now requires empty WT-551
fix: WT-458 crafting recipe no longer gives you free mag
fix: bayonet no longer flies below WT-458

/:cl:
