### PR TITLE
[TM ONLY]Balances xenos for 100HP and lack of skyrat guns

### DIFF
--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/defender.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/defender.dm
@@ -4,11 +4,11 @@
 	name = "alien defender"
 	desc = "A heavy looking alien with a wrecking ball-like tail that'd probably hurt to get hit by."
 	caste = "defender"
-	maxHealth = 300
-	health = 300
+	maxHealth = 250 //Splurt Edit
+	health = 250 //Splurt Edit
 	icon_state = "aliendefender"
-	melee_damage_lower = 25
-	melee_damage_upper = 30
+	melee_damage_lower = 20 //Splurt Edit
+	melee_damage_upper = 25 //Splurt Edit
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/warrior
 	default_organ_types_by_slot = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/drone.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/drone.dm
@@ -4,11 +4,11 @@
 	name = "alien drone"
 	desc = "As plain looking as you could call an alien with armored black chitin and large claws."
 	caste = "drone"
-	maxHealth = 200
-	health = 200
+	maxHealth = 125 //Splurt Edit
+	health = 125 //Splurt Edit
 	icon_state = "aliendrone"
-	melee_damage_lower = 15
-	melee_damage_upper = 20
+	melee_damage_lower = 10 //Splurt Edit
+	melee_damage_upper = 15 //Splurt Edit
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/praetorian
 	default_organ_types_by_slot = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/praetorian.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/praetorian.dm
@@ -4,11 +4,11 @@
 	name = "alien praetorian"
 	desc = "An alien that looks like the awkward half-way point between a queen and a drone, in fact that's likely what it is."
 	caste = "praetorian"
-	maxHealth = 400
-	health = 400
+	maxHealth = 250 //Splurt Edit
+	health = 250 //Splurt Edit
 	icon_state = "alienpraetorian"
-	melee_damage_lower = 25
-	melee_damage_upper = 30
+	melee_damage_lower = 20 //Splurt Edit
+	melee_damage_upper = 25 //Splurt Edit
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/queen
 	default_organ_types_by_slot = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/queen.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/queen.dm
@@ -4,9 +4,9 @@
 	name = "alien queen"
 	desc = "A hulking beast of an alien, for some reason this one seems more important than the others, you should probably quit staring at it and do something."
 	caste = "queen"
-	maxHealth = 500
+	maxHealth = 300 //Splurt Edit
 	status_flags = NONE //can't shove or KO the queen, kiddo.
-	health = 500
+	health = 300 //Splurt Edit
 	icon_state = "alienqueen"
 	melee_damage_lower = 30
 	melee_damage_upper = 35

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/ravager.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/ravager.dm
@@ -6,11 +6,11 @@
 	name = "alien ravager"
 	desc = "An alien with angry red chitin, with equally intimidating looking blade-like claws in place of normal hands. That sharp tail looks like it'd probably hurt."
 	caste = "ravager"
-	maxHealth = 350
-	health = 350
+	maxHealth = 200 //Splurt Edit
+	health = 200 //Splurt Edit
 	icon_state = "alienravager"
-	melee_damage_lower = 30
-	melee_damage_upper = 35
+	melee_damage_lower = 20 //Splurt Edit
+	melee_damage_upper = 25 //Splurt Edit
 	default_organ_types_by_slot = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
 		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/ravager.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/ravager.dm
@@ -9,8 +9,8 @@
 	maxHealth = 200 //Splurt Edit
 	health = 200 //Splurt Edit
 	icon_state = "alienravager"
-	melee_damage_lower = 20 //Splurt Edit
-	melee_damage_upper = 25 //Splurt Edit
+	melee_damage_lower = 25 //Splurt Edit
+	melee_damage_upper = 30 //Splurt Edit
 	default_organ_types_by_slot = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
 		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
@@ -7,13 +7,13 @@
 	name = "alien runner"
 	desc = "A short alien with sleek red chitin, clearly abiding by the 'red ones go faster' theorem and almost always running on all fours."
 	caste = "runner"
-	maxHealth = 150
-	health = 150
+	maxHealth = 100 //Splurt Edit
+	health = 100 //Splurt Edit
 	icon_state = "alienrunner"
 	/// Holds the evade ability to be granted to the runner later
 	var/datum/action/cooldown/alien/skyrat/evade/evade_ability
-	melee_damage_lower = 15
-	melee_damage_upper = 20
+	melee_damage_lower = 10 //Splurt Edit
+	melee_damage_upper = 15 //Splurt Edit
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/ravager
 	on_fire_pixel_y = 0
 	default_organ_types_by_slot = list(

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/sentinel.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/sentinel.dm
@@ -4,8 +4,8 @@
 	name = "alien sentinel"
 	desc = "An alien that'd be unremarkable if not for the bright coloring and visible acid glands that cover it."
 	caste = "sentinel"
-	maxHealth = 200
-	health = 200
+	maxHealth = 150 //Splurt Edit
+	health = 150 //Splurt Edit
 	icon_state = "aliensentinel"
 	melee_damage_lower = 10
 	melee_damage_upper = 15

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/spitter.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/spitter.dm
@@ -4,8 +4,8 @@
 	name = "alien spitter"
 	desc = "A fairly heavy looking alien with prominent acid glands, it's mouth dripping with... some kind of toxin or acid."
 	caste = "spitter"
-	maxHealth = 150 //Splurt Edit
-	health = 150 //Splurt Edit
+	maxHealth = 200 //Splurt Edit
+	health = 200 //Splurt Edit
 	icon_state = "alienspitter"
 	melee_damage_lower = 15
 	melee_damage_upper = 20

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/spitter.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/spitter.dm
@@ -4,8 +4,8 @@
 	name = "alien spitter"
 	desc = "A fairly heavy looking alien with prominent acid glands, it's mouth dripping with... some kind of toxin or acid."
 	caste = "spitter"
-	maxHealth = 300
-	health = 300
+	maxHealth = 150 //Splurt Edit
+	health = 150 //Splurt Edit
 	icon_state = "alienspitter"
 	melee_damage_lower = 15
 	melee_damage_upper = 20

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
@@ -4,11 +4,11 @@
 	name = "alien warrior"
 	desc = "If there are aliens to call walking tanks, this would be one of them, with both the heavy armor and strong arms to back that claim up."
 	caste = "warrior"
-	maxHealth = 400
-	health = 400
+	maxHealth = 200 //Splurt Edit
+	health = 200 //Splurt Edit
 	icon_state = "alienwarrior"
-	melee_damage_lower = 30
-	melee_damage_upper = 35
+	melee_damage_lower = 20 //Splurt Edit
+	melee_damage_upper = 25 //Splurt Edit
 	default_organ_types_by_slot = list(
 		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
 		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
@@ -4,8 +4,8 @@
 	name = "alien warrior"
 	desc = "If there are aliens to call walking tanks, this would be one of them, with both the heavy armor and strong arms to back that claim up."
 	caste = "warrior"
-	maxHealth = 200 //Splurt Edit
-	health = 200 //Splurt Edit
+	maxHealth = 250 //Splurt Edit
+	health = 250 //Splurt Edit
 	icon_state = "alienwarrior"
 	melee_damage_lower = 20 //Splurt Edit
 	melee_damage_upper = 25 //Splurt Edit


### PR DESCRIPTION
## About The Pull Request

This PR aims to rebalance the xenos for 100HP and the lack of skyrat gun's, when the HP was brough back down to 100HP instead of 135HP, the xeno balance was completly glanced over and forgotten by someone who shall not be named upstream so they remained "balanced" for 135HP and skyrat guns, this is a early PR from upstream for balancing purposes

Queen HP is 300 from 500
Defender HP is 250 from 300
Drone HP is 125 from 200
Preatorian HP is 250 from 400
Ravager HP is 200 from 350
Rouny is HP 100 from 150
Sentinel HP is 150 from 200
Spitter HP is 200 from 300
Warrior HP is 250 from 400

Queen Dmg untouched
Defender Dmg is 20-25 was 25-30
Drone Dmg is 10-15 was 15-20
Preatorian Dmg is 20-25 was 25-30
Ravager Dmg is 25-30 was 30-35
Rouny is Dmg is 10-15 was 15-20
Sentinel Dmg untouched
Spitter Dmg is untouched
Warrior Dmg is 20-25 was 30-25

## Why It's Good For The Game

Xenos being able to steamroll the station with even only 7 xenos with an strong HP pool of 200-500HP isnt fair to anyone involved but the xenos

## Proof Of Testing

works on my machine

## Changelog

:cl:
balance: rebalances skyrat xenos for 100hp and no skyrat guns
/:cl: