### PR TITLE
Fix Bounty #954: Move Dominant Aura and Well-Trained quirks to neutral

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
@@ -3,7 +3,7 @@
 	desc = "Your personality is assertive enough to appear as powerful to other people, so much in fact that the weaker kind can't help but throw themselves at your feet on command."
 	icon = "fa-sort-up"
 	medical_record_text = "Patient displays a high level of assertiveness within their personality."
-	value = 1
+	value = 0
 	gain_text = span_notice("You feel like making someone your pet.")
 	lose_text = span_notice("You feel less assertive than before")
 	quirk_flags = QUIRK_HIDE_FROM_SCAN

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
@@ -4,7 +4,7 @@
 	icon = "fa-sort-down"
 	medical_record_text = "Patient can be easily swayed by a sufficiently assertive individual"
 	// Yes, it should be neutral. Yes, this is a bad idea. This is funny and multiple people are saying it's time to be funny.
-	value = -1
+	value = 0
 	gain_text = "<span class='notice'>You feel like being someone's pet</span>"
 	lose_text = "<span class='notice'>You no longer feel like being a pet...</span>"
 	quirk_flags = QUIRK_HIDE_FROM_SCAN | QUIRK_PROCESSES


### PR DESCRIPTION
## About The Pull Request

Fixes #954

Both `Dominant Aura` and `Well-Trained` quirks were incorrectly categorized:

- **Well-Trained** was in `negative_quirks/` with `value = -1` but should be neutral
- **Dominant Aura** was in `positive_quirks/` with `value = 1` but should be neutral

Code comment even confirms: 'Yes, it should be neutral.' 😄

## Changes

- Moved `well_trained.dm` from `negative_quirks/` → `neutral_quirks/`
- Changed `value = -1` → `value = 0` for Well-Trained
- Moved `dominant_aura.dm` from `positive_quirks/` → `neutral_quirks/`
- Changed `value = 1` → `value = 0` for Dominant Aura

## Why It's Good For The Game

These quirks are roleplaying features with no real gameplay advantage/disadvantage, so they should not count towards the player's quirk balance.

## Changelog

🆑 balance
- fix: Dominant Aura and Well-Trained quirks are now neutral (value = 0)
/🆑