### PR TITLE
Fix: Make Dominant Aura and Well-Trained neutral traits (#954)

### DIFF
--- a/modular_zubbers/code/datums/quirks/negative_quirks/well_trained.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/well_trained.dm
@@ -4,7 +4,7 @@
 	icon = "fa-sort-down"
 	medical_record_text = "Patient can be easily swayed by a sufficiently assertive individual"
 	// Yes, it should be neutral. Yes, this is a bad idea. This is funny and multiple people are saying it's time to be funny.
-	value = -1
+	value = 0
 	gain_text = "<span class='notice'>You feel like being someone's pet</span>"
 	lose_text = "<span class='notice'>You no longer feel like being a pet...</span>"
 	quirk_flags = QUIRK_HIDE_FROM_SCAN | QUIRK_PROCESSES

--- a/modular_zubbers/code/datums/quirks/positive_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/positive_quirks/dominant_aura.dm
@@ -3,7 +3,7 @@
 	desc = "Your personality is assertive enough to appear as powerful to other people, so much in fact that the weaker kind can't help but throw themselves at your feet on command."
 	icon = "fa-sort-up"
 	medical_record_text = "Patient displays a high level of assertiveness within their personality."
-	value = 1
+	value = 0
 	gain_text = span_notice("You feel like making someone your pet.")
 	lose_text = span_notice("You feel less assertive than before")
 	quirk_flags = QUIRK_HIDE_FROM_SCAN


### PR DESCRIPTION
This PR fixes issue #954 by making both traits neutral instead of positive/negative.

## Changes
- **Dominant Aura**: Changed `value` from `1` (positive) to `0` (neutral)
- **Well-Trained**: Changed `value` from `-1` (negative) to `0` (neutral)

## Reasoning
These traits are ERP-only quirks that don't provide any gameplay advantage or disadvantage. They should be neutral like `bodymorph`.

## Remaining Work
The Chugging functionality fix requires more investigation into the drink system.

Fixes #954 (partial)
