### PR TITLE
Fix Bounty #954: Make Dominance traits neutral and fix chugging

### DIFF
--- a/modular_zubbers/code/datums/quirks/negative_quirks/well_trained.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/well_trained.dm
@@ -4,7 +4,7 @@
 	icon = "fa-sort-down"
 	medical_record_text = "Patient can be easily swayed by a sufficiently assertive individual"
 	// Yes, it should be neutral. Yes, this is a bad idea. This is funny and multiple people are saying it's time to be funny.
-	value = -1
+	value = 0
 	gain_text = "<span class='notice'>You feel like being someone's pet</span>"
 	lose_text = "<span class='notice'>You no longer feel like being a pet...</span>"
 	quirk_flags = QUIRK_HIDE_FROM_SCAN | QUIRK_PROCESSES

--- a/modular_zubbers/code/datums/quirks/positive_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/positive_quirks/dominant_aura.dm
@@ -3,7 +3,7 @@
 	desc = "Your personality is assertive enough to appear as powerful to other people, so much in fact that the weaker kind can't help but throw themselves at your feet on command."
 	icon = "fa-sort-up"
 	medical_record_text = "Patient displays a high level of assertiveness within their personality."
-	value = 1
+	value = 0
 	gain_text = span_notice("You feel like making someone your pet.")
 	lose_text = span_notice("You feel less assertive than before")
 	quirk_flags = QUIRK_HIDE_FROM_SCAN
@@ -78,7 +78,7 @@
 
 		. = TRUE
 
-//Gotta check for borg module
+#Gotta check for borg module
 	for(var/mob/living/silicon/robot/borg_sub in hearers(world.view / 2, quirk_holder))
 		if(!borg_sub.has_quirk(/datum/quirk/well_trained) || (borg_sub == quirk_holder))
 			continue
@@ -116,4 +116,3 @@
 
 	if(.)
 		TIMER_COOLDOWN_START(quirk_holder, DOMINANT_COOLDOWN_SNAP, 10 SECONDS) // 1/10th of a second knockdown with a 10 seconds cooldown on a neutral quirk.
-

--- a/modular_zzplurt/code/modules/food_and_drinks/chugging.dm
+++ b/modular_zzplurt/code/modules/food_and_drinks/chugging.dm
@@ -26,7 +26,7 @@
 		if(!reagents || !reagents.total_volume)
 			beingChugged = FALSE
 			return
-		gulp_size = 50
+		gulp_size = reagents.total_volume
 		user.visible_message(span_notice("[user] chugs [src]."), \
 			span_notice("You chug [src]."))
 		beingChugged = FALSE


### PR DESCRIPTION
This PR addresses Bounty #954:\n1. Makes 'Well-Trained' and 'Dominant Aura' neutral quirks (0 points).\n2. Fixes chugging logic to consume the entire reagent volume in one go.\n\nCloses #954