### PR TITLE
Makes the space law book redirect to our wiki instead of bubber's

### DIFF
--- a/modular_zubbers/code/modules/security/space_law_book.dm
+++ b/modular_zubbers/code/modules/security/space_law_book.dm
@@ -30,7 +30,8 @@
 	name = "Corporate Regulations"
 	desc = "A set of Nanotrasen regulations for keeping law, order, and procedure followed within their space stations."
 	starting_title = "Corporate Regulations"
-	page_link = "index.php?title=Space_Law"
+	page_link = "?title=Space_Law" //SPLURT EDIT - So it sends us to the space law page we have
+
 
 /obj/item/book/manual/wiki/security_space_law/attack_self(mob/user) // Was in /tg/ folder, moved it here, made it 100% chance to learn language since you can spam it inhand anyhow. Saves us all from carpal tunnel.
 	if(user.can_read(src) && !user.has_language(/datum/language/legalese, SPOKEN_LANGUAGE))
@@ -40,7 +41,7 @@
 		.=..()
 
 /obj/item/book/manual/wiki/security_space_law/display_content(mob/living/user)
-	var/wiki_url = "http://wiki.bubberstation.org"
+	var/wiki_url = "http://wiki.splurt.space" // SPLURT EDIT - it was bubber's first, we are not bubber.
 	if(!wiki_url)
 		user.balloon_alert(user, "this book is empty!")
 		return


### PR DESCRIPTION

## About The Pull Request
Title

## Why It's Good For The Game

We are Splurt Not Bubber.

## Proof Of Testing
2 links changed. It werks.

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: The space law books now redirect to our wiki
/:cl:

