### PR TITLE
Bounty suggestion #659 Bubber-Fix but better this time.

### DIFF
--- a/_maps/splurt/automapper/automapper_config.toml
+++ b/_maps/splurt/automapper/automapper_config.toml
@@ -133,6 +133,22 @@ required_map = "MetaStation.dmm"
 coordinates = [89, 135, 1]
 trait_name = "Station"
 
+# Biodome Security Medical Expansion
+[templates.biodome_security_medic_medbay]
+map_files = ["biodome_security_medic_medbay.dmm"]
+directory = "_maps/splurt/automapper/templates/biodome/"
+required_map = "biodome.dmm"
+coordinates = [149, 88, 2]
+trait_name = "Station"
+
+# Biodome Security Secret Alternate Punishment Area
+[templates.biodome_security_alternate_punishment]
+map_files = ["biodome_security_alternate_punishment.dmm"]
+directory = "_maps/splurt/automapper/templates/biodome/"
+required_map = "biodome.dmm"
+coordinates = [149, 81, 1]
+trait_name = "Station"
+
 # Metastation Security Medical Expansion
 [templates.metastation_security_medic_medbay]
 map_files = ["metastation_security_medic_medbay.dmm"]
@@ -253,7 +269,7 @@ required_map = "tramstation.dmm"
 coordinates = [55, 149, 2]
 trait_name = "Station"
 
-# Nebulastation Sauna
+# Nebulastation Security Medical Expansion
 [templates.nebulastation_security_medic_medbay]
 map_files = ["nebulastation_security_medic_medbay.dmm"]
 directory = "_maps/splurt/automapper/templates/nebulastation/"

--- a/_maps/splurt/automapper/templates/biodome/biodome_security_alternate_punishment.dmm
+++ b/_maps/splurt/automapper/templates/biodome/biodome_security_alternate_punishment.dmm
@@ -14,7 +14,8 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/item/paper{
 	pixel_x = 6;
-	pixel_y = -3
+	pixel_y = -3;
+	default_raw_text = "<p>C,</p><hr><p>Look, I got the room done but CC is not happy. It was bad enough getting in the station for the remodel but they seem to know I was not just 'cleaning up maintenance'. I was able to get the furniture and items but Cargo too was suspicious. They were not buying the Sex Ed classes excuse, cost me a paycheck to get them to stop. But look, its done. If you are reading this than you found the false wall, could not get the ladder in for you but this will have to work. I hope this is worth it for you.</p><hr><p>S.</p>"
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/execution/transfer)

--- a/_maps/splurt/automapper/templates/biodome/biodome_security_alternate_punishment.dmm
+++ b/_maps/splurt/automapper/templates/biodome/biodome_security_alternate_punishment.dmm
@@ -1,87 +1,231 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aq" = (
-/turf/closed/wall,
-/area/station/maintenance/department/security)
+/obj/structure/bed/bdsm_bed,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/marker_beacon/violet,
+/obj/item/clothing/suit/straight_jacket/latex_straight_jacket/reinforced{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/ball_mittens_reinforced{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
 "at" = (
+/obj/effect/turf_decal/siding/purple/inner_corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"aL" = (
+/obj/effect/turf_decal/siding/purple/inner_corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/marker_beacon/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"dh" = (
+/obj/structure/holosign/sexsign,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/station/security/execution/transfer)
+"gH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/milking_machine,
+/obj/item/clothing/sextoy/vibroring{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"pH" = (
 /obj/structure/chair/pillow_small,
 /obj/item/clothing/sextoy/dildo{
 	pixel_x = 3;
 	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/reagent_containers/cup/glass/bottle/femcum_whiskey{
 	pixel_x = 11;
 	pixel_y = -2
 	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"qy" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"qN" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/double_rainbow/directional/south,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"xN" = (
+/obj/effect/turf_decal/siding/purple/inner_corner,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/ultra/directional/east,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"yb" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"yo" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph/directional/east,
+/obj/item/lustwish_discount{
+	pixel_x = 2;
+	pixel_y = 3
 	},
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"aL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/area/station/security/execution/transfer)
+"Am" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
 /obj/effect/turf_decal/siding/purple,
-/obj/effect/turf_decal/siding/dark_red/corner{
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"Ba" = (
+/turf/closed/wall/r_wall,
+/area/station/security/execution/transfer)
+"Be" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/marker_beacon/purple,
+/obj/structure/chair/pillow_small,
+/obj/item/clothing/sextoy/fleshlight{
+	pixel_x = 6;
+	pixel_y = -7
+	},
+/obj/item/reagent_containers/cup/glass/bottle/cum_rum{
+	pixel_x = -14;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"Bw" = (
+/obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"Cn" = (
+/obj/structure/chair/x_stand,
+/obj/item/clothing/sextoy/magic_wand{
+	pixel_x = -16;
+	pixel_y = -5
+	},
+/obj/item/clothing/sextoy/nipple_clamps{
+	pixel_x = -9;
+	pixel_y = -11
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"dh" = (
-/obj/effect/turf_decal/siding/purple/inner_corner,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/area/station/security/execution/transfer)
+"Du" = (
+/obj/item/flashlight/glowstick/pink{
+	pixel_x = 7;
+	pixel_y = 0
 	},
+/obj/structure/marker_beacon/purple,
+/obj/structure/sign/poster/contraband/fun_police/directional/east,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"gH" = (
-/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
-/obj/effect/spawner/random/trash/graffiti,
+/area/station/security/execution/transfer)
+"Ge" = (
+/obj/structure/ladder,
+/obj/structure/sign/poster/contraband/heart/directional/west,
+/obj/effect/turf_decal/stripes/blue/full,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/station/maintenance/department/security)
-"pH" = (
+/area/station/security/execution/transfer)
+"Li" = (
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/purple/inner_corner{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"Lx" = (
 /obj/item/flashlight/glowstick/pink{
 	pixel_x = -7;
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/tile/purple/diagonal_centre,
 /turf/open/floor/glass/reinforced,
-/area/station/maintenance/department/security)
-"qy" = (
-/obj/effect/spawner/random/decoration/glowstick/on{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 8
-	},
-/obj/machinery/light_switch/default_on/directional/west,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"qN" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
-/obj/structure/sign/poster/contraband/missing_gloves/directional/east,
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/item/toy/plush/rouny{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"yb" = (
+/area/station/security/execution/transfer)
+"Nf" = (
+/turf/template_noop,
+/area/template_noop)
+"Pt" = (
 /obj/machinery/vending/dorms,
 /obj/item/toy/plush/toaste_plushy{
 	pixel_x = 3;
@@ -105,73 +249,14 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Am" = (
+/area/station/security/execution/transfer)
+"PR" = (
+/obj/structure/falsewall/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/milking_machine,
-/obj/item/clothing/sextoy/vibroring{
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Ba" = (
-/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
-/obj/structure/railing,
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
-	},
-/area/station/maintenance/department/security)
-"Be" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/double_rainbow/directional/south,
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Bw" = (
-/obj/structure/chair/pillow_small,
-/obj/item/clothing/sextoy/fleshlight{
-	pixel_x = 6;
-	pixel_y = -7
-	},
-/obj/item/reagent_containers/cup/glass/bottle/cum_rum{
-	pixel_x = -14;
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark_red,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Cn" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/end,
-/obj/structure/sign/poster/contraband/ultra/directional/east,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Du" = (
-/obj/effect/spawner/random/decoration/glowstick/on{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/purple/diagonal_centre,
-/turf/open/floor/glass/reinforced,
-/area/station/maintenance/department/security)
-"Ge" = (
+/turf/open/floor/plating,
+/area/station/security/execution/transfer)
+"Qf" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -183,197 +268,156 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Li" = (
-/obj/structure/chair/x_stand,
-/obj/item/clothing/sextoy/magic_wand{
-	pixel_x = -16;
-	pixel_y = -5
-	},
-/obj/item/clothing/sextoy/nipple_clamps{
-	pixel_x = -9;
-	pixel_y = -11
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Lx" = (
-/obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
+/area/station/security/execution/transfer)
+"Rh" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
-/area/station/maintenance/department/security)
-"Nf" = (
-/turf/template_noop,
-/area/template_noop)
-"Pt" = (
-/obj/structure/holosign/sexsign,
+/area/station/security/execution/transfer)
+"Ri" = (
 /obj/effect/turf_decal/siding/dark_red{
-	dir = 9
+	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_half{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"Tt" = (
+/obj/effect/spawner/random/decoration/glowstick/on{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/obj/structure/marker_beacon/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/area/station/maintenance/department/security)
-"PR" = (
-/obj/structure/bed/bdsm_bed,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/marker_beacon/violet,
-/obj/item/clothing/suit/straight_jacket/latex_straight_jacket/reinforced{
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"Vo" = (
+/obj/effect/turf_decal/tile/purple/diagonal_centre,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/glass/reinforced,
+/area/station/security/execution/transfer)
+"Yl" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/security/execution/transfer)
+"ZJ" = (
+/obj/effect/spawner/random/decoration/glowstick/on{
 	pixel_x = -8;
-	pixel_y = 5
+	pixel_y = -2
 	},
-/obj/item/clothing/gloves/ball_mittens_reinforced{
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/siding/purple/inner_corner{
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Qf" = (
-/obj/structure/ladder,
-/obj/structure/sign/poster/contraband/heart/directional/west,
-/obj/effect/turf_decal/stripes/blue/full,
-/obj/structure/window/reinforced/tinted/frosted/spawner/directional/north,
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
-	},
-/area/station/maintenance/department/security)
-"Rh" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark_red,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Ri" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/poster/contraband/lusty_xenomorph/directional/east,
-/obj/item/lustwish_discount{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Vo" = (
-/obj/item/flashlight/glowstick/pink{
-	pixel_x = 7;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/marker_beacon/purple,
-/obj/structure/sign/poster/contraband/fun_police/directional/east,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"Yl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/maintenance/department/security)
-"ZJ" = (
-/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
-/turf/closed/wall,
-/area/station/maintenance/department/security)
+/area/station/security/execution/transfer)
 
 (1,1,1) = {"
+Ba
+Ba
+Ba
+Ba
+Ba
+Ba
+Ba
 Nf
 Nf
 Nf
-aq
-aq
-ZJ
-aq
-aq
-aq
 "}
 (2,1,1) = {"
-Nf
-Nf
-Nf
+Ba
+Ge
+dh
+Tt
 Qf
 Pt
-qy
-Ge
-yb
-aq
+Ba
+Nf
+Nf
+Nf
 "}
 (3,1,1) = {"
-Nf
-Nf
-Nf
+Ba
+Rh
+yb
+xN
 Lx
 Yl
-dh
-pH
-Bw
-aq
+Ba
+Nf
+Nf
+Nf
 "}
 (4,1,1) = {"
-aq
-gH
+Ba
+Ba
+Ba
 Ba
 Li
 aL
-Du
+Ba
 PR
-Rh
-aq
+Ba
+Ba
 "}
 (5,1,1) = {"
-aq
-qN
-Cn
+Nf
+Nf
+Nf
+Ba
 Am
 Vo
 at
 Ri
 Be
-aq
+Ba
 "}
 (6,1,1) = {"
+Nf
+Nf
+Nf
+Ba
+Cn
+qy
+ZJ
 aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
+Bw
+Ba
+"}
+(7,1,1) = {"
+Nf
+Nf
+Nf
+Ba
+gH
+Du
+pH
+yo
+qN
+Ba
+"}
+(8,1,1) = {"
+Nf
+Nf
+Nf
+Ba
+Ba
+Ba
+Ba
+Ba
+Ba
+Ba
 "}

--- a/_maps/splurt/automapper/templates/biodome/biodome_security_alternate_punishment.dmm
+++ b/_maps/splurt/automapper/templates/biodome/biodome_security_alternate_punishment.dmm
@@ -12,6 +12,10 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/item/paper{
+	pixel_x = 6;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/execution/transfer)
 "at" = (
@@ -196,9 +200,24 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/execution/transfer)
 "Ge" = (
-/obj/structure/ladder,
 /obj/structure/sign/poster/contraband/heart/directional/west,
-/obj/effect/turf_decal/stripes/blue/full,
+/obj/structure/table/glass/plasmaglass,
+/obj/effect/spawner/random/food_or_drink/island_booze{
+	pixel_x = 9;
+	pixel_y = 12
+	},
+/obj/effect/spawner/random/food_or_drink/booze{
+	pixel_x = -4;
+	pixel_y = 16
+	},
+/obj/effect/spawner/random/food_or_drink/booze{
+	pixel_x = -10;
+	pixel_y = 6
+	},
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},

--- a/_maps/splurt/automapper/templates/biodome/biodome_security_medic_medbay.dmm
+++ b/_maps/splurt/automapper/templates/biodome/biodome_security_medic_medbay.dmm
@@ -3,341 +3,302 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "bW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/table/optable,
-/obj/item/wallframe/defib_mount,
-/obj/machinery/light/small/directional/north{
-	dir = 8
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "ho" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "hZ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/item/folder/white{
-	pixel_x = -10;
-	pixel_y = 7
-	},
-/obj/item/folder/red{
-	pixel_x = 9;
-	pixel_y = 7
-	},
-/obj/machinery/computer/records/medical/laptop,
-/turf/open/floor/iron/white,
-/area/station/security/medical)
-"ik" = (
-/turf/closed/wall,
-/area/station/security/medical)
-"iE" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
-"kb" = (
-/obj/structure/window/spawner/directional/south,
-/obj/structure/bed/medical/emergency,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/item/toy/plush/beeplushie{
-	name = "Dr. Bees";
-	desc = "When in doubt, just ask yourself: What would Dr. Bees do?."
+/obj/effect/landmark/start/security_medic,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"iE" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
 	},
-/obj/structure/sign/poster/contraband/beekind/directional/west,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"kb" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "mF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/medkit/surgery{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/healthanalyzer,
+/obj/item/clothing/gloves/latex,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/structure/ladder{
+	layer = 2.8
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "tc" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/computer/operating{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/white,
-/area/station/security/medical)
-"uG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
-"uJ" = (
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/obj/item/storage/medkit/surgery{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/healthanalyzer,
-/obj/item/clothing/gloves/latex,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"uJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "vT" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/structure/ladder,
-/obj/structure/sign/poster/contraband/andromeda_bitters/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
-"wN" = (
-/turf/closed/wall/r_wall,
-/area/station/security/medical)
-"xC" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/item/tank/internals/oxygen,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
-"zm" = (
-/obj/effect/landmark/start/security_medic,
-/turf/open/floor/iron/white,
-/area/station/security/medical)
-"BW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/cup/bottle/multiver,
+/obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/item/storage/medkit/regular,
+/obj/structure/table,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/o2,
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/brute,
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 3;
-	pixel_y = 5
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
 	},
-/obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/storage/medkit/regular,
-/obj/item/reagent_containers/syringe,
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/medkit/brute,
-/obj/item/storage/medkit/fire,
-/obj/item/storage/medkit/o2,
-/obj/item/storage/medkit/toxin,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"Dt" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+"xC" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/security_medic,
-/obj/item/wallframe/frontier_medstation,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"Em" = (
+"zm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/security_medic,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"BW" = (
+/turf/closed/wall,
+/area/station/security/medical)
+"Dt" = (
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/item/folder/white{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/healthanalyzer,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"Em" = (
+/obj/structure/table/optable,
+/obj/item/wallframe/defib_mount,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Fl" = (
-/obj/machinery/iv_drip,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/structure/closet/secure_closet/security_medic,
+/obj/item/wallframe/frontier_medstation,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Ie" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/turf/closed/wall/r_wall,
 /area/station/security/medical)
 "IJ" = (
 /obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"Jo" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Brig Infirmary Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/security/medical)
 "Nf" = (
-/turf/template_noop,
-/area/template_noop)
-"Nq" = (
-/obj/structure/window/spawner/directional/south,
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"OC" = (
-/turf/closed/wall/r_wall/fakewood,
+"Nq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/security/medical)
 "PJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_medic,
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/wall_healer/directional/east,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "RV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
-"RZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
-"Tf" = (
-/obj/machinery/door/window/left/directional/south{
-	name = "Brig Infirmary"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/security/medical)
-"Tl" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"RZ" = (
+/obj/machinery/computer/records/medical/laptop{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"Tf" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
+"Tl" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Wf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/structure/bed/medical/emergency,
+/obj/item/toy/plush/beeplushie{
+	name = "Dr. Bees";
+	desc = "When in doubt, just ask yourself: What would Dr. Bees do?."
+	},
+/obj/structure/sign/poster/contraband/beekind/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Ye" = (
-/obj/machinery/door/window/right/directional/south{
-	name = "Brig Infirmary"
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Infirmiary"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"YF" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
 
 (1,1,1) = {"
-Nf
-Nf
-Nf
-OC
-OC
-OC
-OC
-wN
-wN
-wN
+Ie
+Ie
+Ie
+Ie
+BW
+BW
 "}
 (2,1,1) = {"
-Nf
-Nf
-vT
-wN
+Ie
 IJ
 tc
-bW
-uJ
-BW
-kb
-"}
-(3,1,1) = {"
-Nf
-Nf
-Nf
-wN
-Tl
-Em
-Em
 Em
 mF
-Tf
+Nq
 "}
-(4,1,1) = {"
-Nf
-Nf
-Nf
-wN
+(3,1,1) = {"
 Ie
 RV
-bb
+uJ
 zm
 ho
 Ye
 "}
-(5,1,1) = {"
-iE
-RZ
-uG
-Jo
-Wf
+(4,1,1) = {"
+Ie
 Dt
 hZ
 PJ
 Fl
 Nq
 "}
-(6,1,1) = {"
-YF
+(5,1,1) = {"
+Ie
+vT
+Nf
 xC
-uG
-wN
-ik
-ik
-ik
-ik
-ik
-ik
+RZ
+Nq
+"}
+(6,1,1) = {"
+Ie
+bb
+Tl
+bW
+bb
+Nq
 "}
 (7,1,1) = {"
-Nf
-Nf
-uG
-Nf
-Nf
-Nf
-Nf
-Nf
-Nf
-Nf
+Ie
+Wf
+Tf
+iE
+kb
+Nq
+"}
+(8,1,1) = {"
+Ie
+BW
+BW
+BW
+BW
+BW
 "}

--- a/_maps/splurt/automapper/templates/biodome/biodome_security_medic_medbay.dmm
+++ b/_maps/splurt/automapper/templates/biodome/biodome_security_medic_medbay.dmm
@@ -37,22 +37,13 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "mF" = (
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/medkit/surgery{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/healthanalyzer,
-/obj/item/clothing/gloves/latex,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/structure/ladder{
-	layer = 2.8
-	},
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/medkit/surgery{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -88,9 +79,6 @@
 /obj/item/storage/medkit/o2,
 /obj/item/storage/medkit/fire,
 /obj/item/storage/medkit/brute,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
@@ -129,15 +117,24 @@
 	pixel_x = 3
 	},
 /obj/item/healthanalyzer,
-/obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
+/obj/item/clothing/gloves/latex,
+/obj/item/healthanalyzer,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/surgical,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Em" = (
 /obj/structure/table/optable,
-/obj/item/wallframe/defib_mount,
+/obj/item/wallframe/defib_mount{
+	pixel_x = 6;
+	pixel_y = 0
+	},
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8

--- a/_maps/splurt/automapper/templates/iceboxstation/iceboxstation_security_medic_medbay_zlevel_2.dmm
+++ b/_maps/splurt/automapper/templates/iceboxstation/iceboxstation_security_medic_medbay_zlevel_2.dmm
@@ -47,14 +47,12 @@
 /area/station/security/prison/safe)
 "tc" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/tile/red/real_red/half{
-	dir = 3
-	},
 /obj/structure/chair/pillow_small,
 /obj/item/toy/plush/snakeplushie{
 	name = "snek med plushie";
 	desc = "An adorable stuffed toy that resembles a snake. This one comes with 3 years of med school debt and a tiny plastic badge."
 	},
+/obj/effect/turf_decal/tile/red/real_red/half,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/medical)
 "uG" = (
@@ -142,9 +140,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/medical)
 "Vo" = (
-/obj/effect/turf_decal/tile/red/real_red/half{
-	dir = 3
-	},
+/obj/effect/turf_decal/tile/red/real_red/half,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/medical)
 "Wf" = (

--- a/_maps/splurt/automapper/templates/iceboxstation/iceboxstation_security_medic_medbay_zlevel_3.dmm
+++ b/_maps/splurt/automapper/templates/iceboxstation/iceboxstation_security_medic_medbay_zlevel_3.dmm
@@ -30,7 +30,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/security/execution/education)
+/area/station/security/medical)
 "hZ" = (
 /turf/closed/wall,
 /area/station/security/medical)
@@ -58,7 +58,7 @@
 	},
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/white/textured,
-/area/station/security/execution/education)
+/area/station/security/medical)
 "qN" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -71,7 +71,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/security/execution/education)
+/area/station/security/medical)
 "tc" = (
 /obj/item/storage/medkit/regular{
 	pixel_x = 3;
@@ -87,13 +87,10 @@
 /obj/effect/turf_decal/tile/red/anticorner,
 /obj/effect/turf_decal/tile/red/anticorner,
 /turf/open/floor/iron/white/textured,
-/area/station/security/execution/education)
+/area/station/security/medical)
 "uJ" = (
 /turf/closed/wall/r_wall,
 /area/station/security/medical)
-"uW" = (
-/turf/closed/wall/r_wall,
-/area/station/security/execution/education)
 "Am" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -115,7 +112,7 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/white/textured,
-/area/station/security/execution/education)
+/area/station/security/medical)
 "Eb" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Infirmary"
@@ -174,15 +171,12 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
-"Ye" = (
-/turf/closed/wall,
-/area/station/security/execution/education)
 
 (1,1,1) = {"
 uJ
 hZ
 hZ
-Ye
+hZ
 "}
 (2,1,1) = {"
 uJ
@@ -218,5 +212,5 @@ tc
 uJ
 uJ
 uJ
-uW
+uJ
 "}

--- a/_maps/splurt/automapper/templates/metastation/metastation_security_medic_medbay.dmm
+++ b/_maps/splurt/automapper/templates/metastation/metastation_security_medic_medbay.dmm
@@ -60,10 +60,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "hZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/window/spawner/directional/east,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 5
 	},
-/obj/structure/window/spawner/directional/east,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 5
 	},
@@ -74,12 +74,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/south,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 10
 	},
@@ -106,10 +106,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "mF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/bed/medical/emergency,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 8
 	},
-/obj/structure/bed/medical/emergency,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 8
 	},
@@ -127,8 +127,8 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -144,9 +144,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/dark_red/line,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "tc" = (
@@ -157,8 +155,8 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -184,9 +182,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -196,6 +191,9 @@
 /obj/item/reagent_containers/cup/tube,
 /obj/item/storage/portable_chem_mixer,
 /obj/item/wallframe/frontier_medstation,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 6
+	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 6
 	},
@@ -223,8 +221,8 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -238,8 +236,10 @@
 	dir = 9
 	},
 /obj/structure/sign/poster/official/moth_epi/directional/west,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner,
 /obj/item/healthanalyzer,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Bw" = (
@@ -260,17 +260,15 @@
 /area/station/security/brig)
 "Cn" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/dark_red/line,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Du" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/door/window/right/directional/east{
 	name = "Infirmary"
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 4
@@ -278,19 +276,19 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Em" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
 /obj/machinery/wall_healer/directional/west,
 /obj/structure/table/optable,
 /obj/item/wallframe/defib_mount,
 /obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 9
-	},
 /obj/item/storage/medkit/surgery{
 	pixel_x = -2;
 	pixel_y = 0
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -299,10 +297,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -328,10 +326,10 @@
 /obj/machinery/door/window/left/directional/east{
 	name = "Infirmary"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 4
 	},
@@ -342,11 +340,11 @@
 /area/station/security/medical)
 "Ra" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/machinery/computer/operating{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 8
@@ -359,7 +357,6 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/item/folder/red{
 	pixel_x = 3
 	},
@@ -367,10 +364,13 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "RV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
@@ -382,13 +382,13 @@
 /turf/closed/wall/r_wall,
 /area/station/security/prison/visit)
 "Tf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/landmark/start/security_medic,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
 	},
-/obj/effect/landmark/start/security_medic,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Vo" = (
@@ -396,7 +396,6 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/item/storage/medkit/brute{
 	pixel_x = -5;
 	pixel_y = 0
@@ -413,6 +412,9 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "Wf" = (
@@ -428,7 +430,6 @@
 	},
 /obj/machinery/iv_drip,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -436,6 +437,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /turf/open/floor/iron/white,
 /area/station/security/medical)

--- a/_maps/splurt/automapper/templates/moonstation/moonstation_security_medic_medbay.dmm
+++ b/_maps/splurt/automapper/templates/moonstation/moonstation_security_medic_medbay.dmm
@@ -131,7 +131,7 @@
 /area/station/security/medical)
 "Be" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Security Equipment Room"
+	name = "Infirmary"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,

--- a/_maps/splurt/automapper/templates/tramstation/tramstation_security_medic_medbay.dmm
+++ b/_maps/splurt/automapper/templates/tramstation/tramstation_security_medic_medbay.dmm
@@ -51,6 +51,7 @@
 	dir = 5
 	},
 /obj/machinery/computer/records/medical/laptop,
+/obj/structure/sign/poster/official/help_others/directional/north,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "kb" = (
@@ -72,7 +73,6 @@
 	pixel_x = -8;
 	pixel_y = 3
 	},
-/obj/structure/sign/poster/official/help_others/directional/north,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "qN" = (

--- a/_maps/splurt/automapper/templates/voidraptor/voidraptor_security_medic_medbay.dmm
+++ b/_maps/splurt/automapper/templates/voidraptor/voidraptor_security_medic_medbay.dmm
@@ -62,6 +62,7 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/directional/east,
+/obj/structure/sign/poster/official/space_cops/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -306,7 +307,6 @@
 	},
 /area/station/security/holding_cell)
 "ZJ" = (
-/obj/structure/sign/poster/official/space_cops/directional/west,
 /obj/structure/table/optable,
 /obj/item/wallframe/defib_mount,
 /obj/item/storage/medkit/surgery,


### PR DESCRIPTION

## About The Pull Request
This is to re-do the Biodome automaps after the Bubber Remodel of Biodome. It also just does some cosmetic touch ups on some of the automaps + fixes some decals that were messed up.
## Why It's Good For The Game

This just fixes some of the errors from the first PR push and handles the merge conflict of the Biodome rework.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="978" height="510" alt="image" src="https://github.com/user-attachments/assets/60c42b76-d54b-4536-89ce-2da6cad6ce41" />
</details>

## Changelog

-Biodome Alternate - Changed floor decals.
-Biodome Medic - Changed floor tiles.
-Icebox level 2 - Fixed decal direction.
-Meta - Simplified decals and fixed for new red sec decals.
-Moon - Fixed the name of the door from "Security Equipment Room" to "Infirmary" (spotted by Dr. Arielpro).
-Tram - Moved poster over one tile.
-Void Raptor - Moved poster to opposite wall.
-Fixed Automap cords for Biodome.
:cl:
fix: fixed Decals in some of the Security Medical Expansions that were broken / busy.
map: Re-added / Re-worked Biodome Security Medical Expansion that was merge conflicted with Bubber's Biodome update.
/:cl:
