### PR TITLE
Fixes superglued supply manifests when player with no access to the crate tries to tear them off

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1163,7 +1163,10 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 		if(error_msg)
 			if(!silent)
 				balloon_alert(user, error_msg)
-			return TRUE
+			//SPLURT EDIT CHANGE BEGIN - Fixes not able to tear manifests from locked crate
+			//return TRUE - SPLURT EDIT - ORIGINAL
+			return FALSE
+			//SPLURT EDIT CHANGE END
 
 	if(iscarbon(user))
 		add_fingerprint(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1164,8 +1164,8 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 			if(!silent)
 				balloon_alert(user, error_msg)
 			//SPLURT EDIT CHANGE BEGIN - Fixes not able to tear manifests from locked crate
-			//return TRUE - SPLURT EDIT - ORIGINAL
-			return FALSE
+			return FALSE //SPLURT EDIT - ORIGINAL: return TRUE
+			
 			//SPLURT EDIT CHANGE END
 
 	if(iscarbon(user))


### PR DESCRIPTION

## About The Pull Request

Basically, if you tried to tear the supply manifest off a crate that you have no access to, you were unable to. This should fix it.

## Why It's Good For The Game

Squashing bugs 🐛

## Proof Of Testing

It compiles and works.

</details>

## Changelog

:cl:
fix: the supply manifests are no longer superglued to some locked crates
/:cl:


