### PR TITLE
Update Messy and Productive quirks

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/climax.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_arousal/climax.dm
@@ -272,7 +272,7 @@
 				if(create_cum_decal)
 					if(HAS_TRAIT(src, TRAIT_MESSY))
 						// Transfer reagents to the turf uisng liquids system
-						var/datum/reagents/R = new(testicles.internal_fluid_maximum)
+						var/datum/reagents/R = new(testicles.cumshot_size)
 						testicles.reagents.trans_to(R, testicles.cumshot_size, transferred_by = src)
 						if(partner && partner != src)
 							// Get turf between src and partner for directional splatter
@@ -289,7 +289,7 @@
 					// Transfer reagents directly to partner
 					var/mob/living/target_mob = partner || interactable_inrange_mobs[target_choice]
 
-					var/datum/reagents/R = new(testicles.internal_fluid_maximum)
+					var/datum/reagents/R = new(testicles.cumshot_size)
 
 					//Check if the target has custom genital fluids enabled
 					if(!(target_mob.client?.prefs?.read_preference(/datum/preference/toggle/erp/custom_genital_fluids) || nonhuman_bypass_partner))

--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/cum_plus.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/cum_plus.dm
@@ -29,16 +29,19 @@
 	var/obj/item/organ/genital/testicles/mob_testi = quirk_mob.get_organ_slot(ORGAN_SLOT_TESTICLES)
 	if(mob_testi)
 		mob_testi.internal_fluid_maximum *= CUMPLUS_MULT_TESTI
+		mob_testi.reagents.maximum_volume *= CUMPLUS_MULT_TESTI
 
 	// Vagina
 	var/obj/item/organ/genital/vagina/mob_vagi = quirk_mob.get_organ_slot(ORGAN_SLOT_VAGINA)
 	if(mob_vagi)
 		mob_vagi.internal_fluid_maximum *= CUMPLUS_MULT_VAGI
+		mob_vagi.reagents.maximum_volume *= CUMPLUS_MULT_VAGI
 
 	// Breasts
 	var/obj/item/organ/genital/testicles/mob_boobi = quirk_mob.get_organ_slot(ORGAN_SLOT_BREASTS)
 	if(mob_boobi)
 		mob_boobi.internal_fluid_maximum *= CUMPLUS_MULT_BOOBI
+		mob_boobi.reagents.maximum_volume *= CUMPLUS_MULT_BOOBI
 
 // Reduce fluids
 /datum/quirk/cum_plus/remove()
@@ -51,16 +54,19 @@
 	var/obj/item/organ/genital/testicles/mob_testi = quirk_mob.get_organ_slot(ORGAN_SLOT_TESTICLES)
 	if(mob_testi)
 		mob_testi.internal_fluid_maximum /= CUMPLUS_MULT_TESTI
+		mob_testi.reagents.maximum_volume /= CUMPLUS_MULT_TESTI
 
 	// Vagina
 	var/obj/item/organ/genital/vagina/mob_vagi = quirk_mob.get_organ_slot(ORGAN_SLOT_VAGINA)
 	if(mob_vagi)
 		mob_vagi.internal_fluid_maximum /= CUMPLUS_MULT_VAGI
+		mob_vagi.reagents.maximum_volume /= CUMPLUS_MULT_VAGI
 
 	// Breasts
 	var/obj/item/organ/genital/testicles/mob_boobi = quirk_mob.get_organ_slot(ORGAN_SLOT_BREASTS)
 	if(mob_boobi)
 		mob_boobi.internal_fluid_maximum /= CUMPLUS_MULT_BOOBI
+		mob_boobi.reagents.maximum_volume /= CUMPLUS_MULT_BOOBI
 
 #undef CUMPLUS_MULT_GLOBAL
 #undef CUMPLUS_MULT_TESTI


### PR DESCRIPTION

## About The Pull Request
Messy + Productive quirks were never updated after the reagent system update for fluids in Bubberstation PR 3398. This fixes that.

## Why It's Good For The Game
Fluid fixes fun.

## Proof Of Testing
<img width="426" height="30" alt="2026-05-12 17-42-29" src="https://github.com/user-attachments/assets/c315c541-6cf5-49e1-a12b-50ce60fb4b15" />
(with _mult changed to 1.0)

</details>

## Changelog
:cl:

fix: update Messy and Extra-Productive quirks for reagent system

/:cl:
