### PR TITLE
[codex] Fix taur testicle sprite icon routing

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -175,6 +175,7 @@
 #include "food_edibility_check.dm"
 #include "full_heal.dm"
 #include "gas_transfer.dm"
+#include "genital_taur_icons.dm"
 #include "get_turf_pixel.dm"
 #include "geyser.dm"
 #include "gloves_and_shoes_armor.dm"

--- a/code/modules/unit_tests/genital_taur_icons.dm
+++ b/code/modules/unit_tests/genital_taur_icons.dm
@@ -1,0 +1,9 @@
+/datum/unit_test/genital_taur_icons
+
+/datum/unit_test/genital_taur_icons/Run()
+	var/mob/living/carbon/human/consistent/test_subject = allocate(/mob/living/carbon/human/consistent)
+	test_subject.dna.species.mutant_bodyparts[FEATURE_TAUR] = list(MUTANT_INDEX_NAME = "Cow", MUTANT_INDEX_COLOR_LIST = list("#FFFFFF", "#FFFFFF", "#FFFFFF"))
+	test_subject.dna.features["penis_taur_mode"] = TRUE
+
+	var/datum/sprite_accessory/genital/testicles/testicles = allocate(/datum/sprite_accessory/genital/testicles/pair)
+	TEST_ASSERT_EQUAL(testicles.get_special_icon(test_subject), 'modular_skyrat/master_files/icons/mob/sprite_accessory/genitals/taur_testicles_onmob.dmi', "Taur testicles used the wrong on-mob icon file.")

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/genitals.dm
@@ -176,7 +176,7 @@
 	if(!taur_mode || !target_mob.dna.features["penis_taur_mode"] || taur_mode & STYLE_TAUR_SNAKE)
 		return icon
 
-	return 'modular_skyrat/master_files/icons/mob/sprite_accessory/genitals/taur_penis_onmob.dmi'
+	return 'modular_skyrat/master_files/icons/mob/sprite_accessory/genitals/taur_testicles_onmob.dmi'
 
 /datum/sprite_accessory/genital/testicles/get_special_x_dimension(mob/living/carbon/human/target_mob)
 	var/taur_mode = target_mob?.get_taur_mode()


### PR DESCRIPTION
## Summary
- Fixes taur testicles resolving to the taur penis on-mob DMI instead of the existing taur testicles DMI.
- Adds a focused unit test covering the taur testicle special icon path.

## Root cause
`/datum/sprite_accessory/genital/testicles/get_special_icon()` returned `taur_penis_onmob.dmi`, so testicle taur alts could not use `taur_testicles_onmob.dmi`.

## Validation
- `git diff --check` passed.
- Focused source assertion passed for penis and testicles taur icon routing.
- `bin\test.cmd` could not run because BYOND `dm.exe` is not installed in this workspace.
- `python tools\ticked_file_enforcement\ticked_file_enforcement.py < unit_tests schema` reports pre-existing missing includes: `automapper.dm`, `digitigrade_sprites.dm`, `opposing_force.dm`, `underwear_items.dm`.

Closes #109