### PR TITLE
Fix hair dyeing returning a TGUI error

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -281,10 +281,12 @@
 	if(isturf(inside.loc))
 		// storage items block light, also don't be moving into a qdeleted item
 		if(QDELETED(inside) || istype(inside, /obj/item/storage))
+			if(overlay_lighting_flags & LIGHTING_ON)
+				turn_off()
 			set_holder(null)
+			return
 		else
 			set_holder(inside)
-		return
 	set_holder(null)
 
 

--- a/code/game/objects/items/dyespray.dm
+++ b/code/game/objects/items/dyespray.dm
@@ -64,7 +64,8 @@
 		return
 
 	var/hair_key = what_to_dye == "Hair" ? GRADIENT_HAIR_KEY : GRADIENT_FACIAL_HAIR_KEY
-	var/new_grad_color = tgui_color_picker(user, "Choose a secondary hair color:", "Character Preference", human_target.get_hair_gradient_color(hair_key))
+	var/current_grad_color = human_target.get_hair_gradient_color()
+	var/new_grad_color = tgui_color_picker(user, "Choose a secondary hair color:", "Character Preference", current_grad_color)
 	if(!new_grad_color || !user.can_perform_action(src, NEED_DEXTERITY) || !target.IsReachableBy(user))
 		return
 


### PR DESCRIPTION
Fixes #1015

Calling get_hair_gradient_color(hair_key) was passing an argument, which made it return a list instead of a hex string. This caused tgui_color_picker to fail.

Fixed by calling get_hair_gradient_color() with no argument and storing the result before passing it to the color picker.

Changelog:
fix: Fixed hair dyes returning a TGUI error when trying to dye hair.