### PR TITLE
Readds the Spectre IPC parts

### DIFF
--- a/modular_zubbers/code/modules/customization/datums/robotic_styles/robotic_styles.dm
+++ b/modular_zubbers/code/modules/customization/datums/robotic_styles/robotic_styles.dm
@@ -154,6 +154,10 @@ GLOBAL_LIST_EMPTY(robotic_styles_list)
 	name = "Excelsior"
 	icon = 'modular_zubbers/icons/mob/augmentation/excelsior.dmi'
 
+/datum/robotic_style/spectre //SPLURT ADDITION
+	name = "Spectre Dynamics"
+	icon = 'modular_zzplurt/icons/mob/augmentation/spectre.dmi'
+
 /datum/robotic_style/dimorphic // subtype so we don't have to define dimorphic head+chest every single time
 	abstract_type = /datum/robotic_style/dimorphic
 	dimorphic_overrides = list(


### PR DESCRIPTION
## About The Pull Request

3 line fix. Got removed during the upstream pull and there is literally no history as to what part of it removed it.

## Why It's Good For The Game

My favorite IPC shell :)

## Proof Of Testing

<img width="345" height="633" alt="image" src="https://github.com/user-attachments/assets/7ee1e20e-ac24-43c3-9ac4-c7cfda3e333e" />
<img width="235" height="324" alt="image" src="https://github.com/user-attachments/assets/b09ba84e-29ee-4958-b797-130ec1c81223" />


## Changelog

:cl:
fix: Spectre IPC parts are now pickable again
/:cl: