### PR TITLE
fix(announcer): prevent mutating shared sound_override in player loop

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -236,23 +236,24 @@
 		else
 			preferred_announcer = SSstation.announcer
 
-		if(!sound_override)
-			sound_override = preferred_announcer.get_rand_alert_sound()
-		else if(preferred_announcer.event_sounds[sound_override])
-			var/list/announcer_key = preferred_announcer.event_sounds[sound_override]
-			sound_override = pick(announcer_key)
-		else if(sound_override == ANNOUNCER_COMMAND_REPORT)
-			sound_override = preferred_announcer.get_rand_report_sound()
-		else if(sound_override == ANNOUNCER_RANDOM_WELCOME)
-			sound_override = preferred_announcer.get_rand_welcome_sound()
+		var/temp_sound_override = sound_override
+		if(!temp_sound_override)
+			temp_sound_override = preferred_announcer.get_rand_alert_sound()
+		else if(preferred_announcer.event_sounds[temp_sound_override])
+			var/list/announcer_key = preferred_announcer.event_sounds[temp_sound_override]
+			temp_sound_override = pick(announcer_key)
+		else if(temp_sound_override == ANNOUNCER_COMMAND_REPORT)
+			temp_sound_override = preferred_announcer.get_rand_report_sound()
+		else if(temp_sound_override == ANNOUNCER_RANDOM_WELCOME)
+			temp_sound_override = preferred_announcer.get_rand_welcome_sound()
 		// couldnt find ANYTHING fallback please FALLBACK!!!
-		else if(GLOB.announcer_keys.Find(sound_override) || sound_override == ANNOUNCER_RANDOM_ALERT)
-			sound_override = preferred_announcer.get_rand_alert_sound()
+		else if(GLOB.announcer_keys.Find(temp_sound_override) || temp_sound_override == ANNOUNCER_RANDOM_ALERT)
+			temp_sound_override = preferred_announcer.get_rand_alert_sound()
 
-		if(!isnull(sound_override))
-			sound_override = sound(sound_override)
+		if(!isnull(temp_sound_override))
+			temp_sound_override = sound(temp_sound_override)
 
-		var/sound_to_play = !isnull(sound_override) ? sound_override : 'sound/announcer/notice/notice2.ogg'
+		var/sound_to_play = !isnull(temp_sound_override) ? temp_sound_override : 'sound/announcer/notice/notice2.ogg'
 
 		if(target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))
 			var/area/A = get_area(target)


### PR DESCRIPTION
Closes #1032

## Problem
The announcer preference setting in Sound preferences is broken during a round. While the welcome sound plays correctly, all subsequent announcements played throughout the round use the announcer preference of the first player in the players list.

## Cause
In `/proc/dispatch_announcement_to_players`, the sound override logic mutates the shared `sound_override` parameter in-place inside the player loop. After the first iteration, `sound_override` is cast into a `/sound` object, failing all event string matching checks for subsequent players.

## Solution
Introduced a local `temp_sound_override` variable inside the player loop, ensuring the shared parameter is never mutated.