### PR TITLE
fix: restore missing eyes_opacity preference to bring back eye customization

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -236,23 +236,24 @@
 		else
 			preferred_announcer = SSstation.announcer
 
-		if(!sound_override)
-			sound_override = preferred_announcer.get_rand_alert_sound()
-		else if(preferred_announcer.event_sounds[sound_override])
-			var/list/announcer_key = preferred_announcer.event_sounds[sound_override]
-			sound_override = pick(announcer_key)
-		else if(sound_override == ANNOUNCER_COMMAND_REPORT)
-			sound_override = preferred_announcer.get_rand_report_sound()
-		else if(sound_override == ANNOUNCER_RANDOM_WELCOME)
-			sound_override = preferred_announcer.get_rand_welcome_sound()
+		var/temp_sound_override = sound_override
+		if(!temp_sound_override)
+			temp_sound_override = preferred_announcer.get_rand_alert_sound()
+		else if(preferred_announcer.event_sounds[temp_sound_override])
+			var/list/announcer_key = preferred_announcer.event_sounds[temp_sound_override]
+			temp_sound_override = pick(announcer_key)
+		else if(temp_sound_override == ANNOUNCER_COMMAND_REPORT)
+			temp_sound_override = preferred_announcer.get_rand_report_sound()
+		else if(temp_sound_override == ANNOUNCER_RANDOM_WELCOME)
+			temp_sound_override = preferred_announcer.get_rand_welcome_sound()
 		// couldnt find ANYTHING fallback please FALLBACK!!!
-		else if(GLOB.announcer_keys.Find(sound_override) || sound_override == ANNOUNCER_RANDOM_ALERT)
-			sound_override = preferred_announcer.get_rand_alert_sound()
+		else if(GLOB.announcer_keys.Find(temp_sound_override) || temp_sound_override == ANNOUNCER_RANDOM_ALERT)
+			temp_sound_override = preferred_announcer.get_rand_alert_sound()
 
-		if(!isnull(sound_override))
-			sound_override = sound(sound_override)
+		if(!isnull(temp_sound_override))
+			temp_sound_override = sound(temp_sound_override)
 
-		var/sound_to_play = !isnull(sound_override) ? sound_override : 'sound/announcer/notice/notice2.ogg'
+		var/sound_to_play = !isnull(temp_sound_override) ? temp_sound_override : 'sound/announcer/notice/notice2.ogg'
 
 		if(target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))
 			var/area/A = get_area(target)

--- a/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -83,6 +83,22 @@
 /datum/preference/toggle/eye_emissives/proc/is_allowed(datum/preferences/preferences)
 	return preferences.read_preference(/datum/preference/toggle/allow_emissives)
 
+/datum/preference/numeric/eyes_opacity
+	category = PREFERENCE_CATEGORY_CHARACTER_BASICS
+	savefile_key = "eyes_opacity"
+	savefile_identifier = PREFERENCE_CHARACTER
+	minimum = 0
+	maximum = 255
+
+/datum/preference/numeric/eyes_opacity/create_default_value()
+	return maximum
+
+/datum/preference/numeric/eyes_opacity/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	var/obj/item/organ/eyes/eyes_organ = target.get_organ_by_type(/obj/item/organ/eyes)
+	if(istype(eyes_organ))
+		eyes_organ.eyes_opacity = value
+	return TRUE
+
 // Body Markings - This isn't used anymore and thus I'm making it not do anything.
 
 /datum/preference/toggle/mutant_toggle/body_markings


### PR DESCRIPTION
This PR restores the eye customization feature by defining the missing `/datum/preference/numeric/eyes_opacity` preference class on the DM backend.

- Correctly maps the client-side `eyes_opacity` Feature component to `/datum/preference/numeric/eyes_opacity`.
- Queries the `/obj/item/organ/eyes` datum on `apply_to_human()` and applies the opacity value.
- Resolves #743.