### PR TITLE
Fix announcer preference bug

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -236,23 +236,25 @@
 		else
 			preferred_announcer = SSstation.announcer
 
-		if(!sound_override)
-			sound_override = preferred_announcer.get_rand_alert_sound()
-		else if(preferred_announcer.event_sounds[sound_override])
-			var/list/announcer_key = preferred_announcer.event_sounds[sound_override]
-			sound_override = pick(announcer_key)
-		else if(sound_override == ANNOUNCER_COMMAND_REPORT)
-			sound_override = preferred_announcer.get_rand_report_sound()
-		else if(sound_override == ANNOUNCER_RANDOM_WELCOME)
-			sound_override = preferred_announcer.get_rand_welcome_sound()
+		var/target_sound = sound_override
+
+		if(!target_sound)
+			target_sound = preferred_announcer.get_rand_alert_sound()
+		else if(preferred_announcer.event_sounds[target_sound])
+			var/list/announcer_key = preferred_announcer.event_sounds[target_sound]
+			target_sound = pick(announcer_key)
+		else if(target_sound == ANNOUNCER_COMMAND_REPORT)
+			target_sound = preferred_announcer.get_rand_report_sound()
+		else if(target_sound == ANNOUNCER_RANDOM_WELCOME)
+			target_sound = preferred_announcer.get_rand_welcome_sound()
 		// couldnt find ANYTHING fallback please FALLBACK!!!
-		else if(GLOB.announcer_keys.Find(sound_override) || sound_override == ANNOUNCER_RANDOM_ALERT)
-			sound_override = preferred_announcer.get_rand_alert_sound()
+		else if(GLOB.announcer_keys.Find(target_sound) || target_sound == ANNOUNCER_RANDOM_ALERT)
+			target_sound = preferred_announcer.get_rand_alert_sound()
 
-		if(!isnull(sound_override))
-			sound_override = sound(sound_override)
+		if(!isnull(target_sound))
+			target_sound = sound(target_sound)
 
-		var/sound_to_play = !isnull(sound_override) ? sound_override : 'sound/announcer/notice/notice2.ogg'
+		var/sound_to_play = !isnull(target_sound) ? target_sound : 'sound/announcer/notice/notice2.ogg'
 
 		if(target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))
 			var/area/A = get_area(target)


### PR DESCRIPTION
Fixes #1032. This PR prevents the priority_announce code from mutating the sound_override argument inside the player loop, ensuring that everyone receives their preferred announcer sound rather than just the first player's.