### PR TITLE
fix: prevent cyborg chameleon projector from fizzling in ghost cafe (#968)

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -66,7 +66,7 @@
 		to_chat(user, span_notice("You activate \the [src]."))
 		playsound(src, 'sound/effects/seedling_chargeup.ogg', 100, TRUE, -6)
 		apply_wibbly_filters(user)
-		if (do_after(user, 5 SECONDS, target = user, hidden = TRUE) && user.cell.use(ACTIVATION_COST))
+		if (do_after(user, 5 SECONDS, target = user, timed_action_flags = IGNORE_USER_LOC_CHANGE | IGNORE_HELD_ITEM | IGNORE_INCAPACITATED, hidden = TRUE) && user.cell.use(ACTIVATION_COST))
 			playsound(src, 'sound/effects/bamf.ogg', 100, TRUE, -6)
 			to_chat(user, span_notice("You are now disguised as the Nanotrasen engineering borg \"[friendlyName]\"."))
 			activate(user)

--- a/modular_skyrat/modules/borgs/code/robot_items.dm
+++ b/modular_skyrat/modules/borgs/code/robot_items.dm
@@ -665,7 +665,7 @@
 			f = user.filters[start+i]
 			animate(f, offset=f:offset, time=0, loop=3, flags=ANIMATION_PARALLEL)
 			animate(offset=f:offset-1, time=rand()*20+10)
-		if (do_after(user, 5 SECONDS, target=user) && use_power(user, activationCost))
+		if (do_after(user, 5 SECONDS, target=user, timed_action_flags = IGNORE_USER_LOC_CHANGE | IGNORE_HELD_ITEM | IGNORE_INCAPACITATED) && use_power(user, activationCost))
 			playsound(src, 'sound/effects/bamf.ogg', 100, TRUE, -6)
 			to_chat(user, span_notice("You are now disguised."))
 			activate(user)


### PR DESCRIPTION
### 📝 Description
This PR resolves issue #968. 

The Cyborg's chameleon projector/shapeshifter module utilizes a 5-second `do_after` delay to activate its disguise. However, when playing as a Cyborg ghost role inside the Ghost Cafe area, the disguise activation would instantly "fizzles" (deactivates). 

This happens because ghost roles in the cafe often possess specific states (such as `TRAIT_INCAPACITATED`) or experience slight location drift, which immediately triggers the standard, strict `do_after` interruption checks.

### 🛠️ Proposed Changes
By adding the `timed_action_flags = IGNORE_USER_LOC_CHANGE | IGNORE_HELD_ITEM | IGNORE_INCAPACITATED` flags to the disguise `do_after` activation delay in both `/obj/item/borg_shapeshifter` and `/obj/item/borg_chameleon`, we successfully prevent these false-positive checks from instantly interrupting the disguise sequence. The projector now successfully activates inside the Ghost Cafe.

- **Files modified:**
  - `modular_skyrat/modules/borgs/code/robot_items.dm`
  - `code/modules/antagonists/nukeop/equipment/borgchameleon.dm`

### 🔑 Linking
Fixes #968