### PR TITLE
Added detectives camera to the detective drobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -718,6 +718,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	premium = list(
 		/obj/item/clothing/head/flatcap = 1,
 		/obj/item/clothing/glasses/sunglasses/noir = 1,
+		obj/item/camera/detective = 1,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/det_wardrobe
 	extra_price = PAYCHECK_COMMAND * 1.75

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -718,7 +718,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	premium = list(
 		/obj/item/clothing/head/flatcap = 1,
 		/obj/item/clothing/glasses/sunglasses/noir = 1,
-		obj/item/camera/detective = 1,
+		/obj/item/camera/detective = 1,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/det_wardrobe
 	extra_price = PAYCHECK_COMMAND * 1.75


### PR DESCRIPTION

## About The Pull Request

Added the detectives camera to the items sold in the detectives drobe
## Why It's Good For The Game

Currently the availability of the detectives camera is unreliable. Typically it is simply placed in the detectives office but not every map has one + if it is somehow lost there is never a spare. This ensures at least 1 will always be available on every map.

## Proof Of Testing

Untested

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
qol: Added the detectives camera to their office vendor.
/:cl:
