### PR TITLE
Items no longer dissappear when failing to pack the crate with packing peanuts + items no longer put on crate when failing to pack them

### DIFF
--- a/modular_zzplurt/code/game/objects/structures/crates_lockers/closets.dm
+++ b/modular_zzplurt/code/game/objects/structures/crates_lockers/closets.dm
@@ -59,15 +59,15 @@
 
 /obj/structure/closet/attackby(obj/item/W, mob/user, list/modifiers, list/attack_modifiers)
 	if(istype(W, /obj/item/stack/packing_peanuts) && opened && packable && !packing_overlay)
-		try_packing(W, user)
-		take_contents()
+		if(try_packing(W, user))
+			take_contents()
 		return TRUE //no afterattack
 	else if(opened && packing_overlay && !iscyborg(user)) //Don't let cyborgs pack things, they lose their modules like that
 		balloon_alert(user, "packing item...")
 		if(do_after(user, 1 SECONDS, target = src))
 			insert(W)
 			balloon_alert(user, "packed!")
-			return TRUE
+		return TRUE
 	return ..()
 
 /obj/structure/closet/dump_contents()


### PR DESCRIPTION

## About The Pull Request

Fixes items disappearing when failing to pack the crate with packing peanuts. Also fixes putting of items in crate when failing to pack the said item into the crate with packing peanuts.
## Why It's Good For The Game

Bugs bad (except for moths)
## Proof Of Testing

Ran locally, tested the intended changes and found no errors/runtimes related to fixed issue.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Removed an ability of items in crate to be made invisible when failing to pack the crate with packing peanuts.
fix: Item will no longer be put on top of crate with packing peanuts when failing to pack the item in the crate
/:cl:
