### PR TITLE
Armadyne Sechuds

### DIFF
--- a/modular_zzplurt/code/modules/client/loadout/glasses.dm
+++ b/modular_zzplurt/code/modules/client/loadout/glasses.dm
@@ -1,3 +1,8 @@
 /datum/loadout_item/glasses/contact
 	name = "Contact Lenses"
 	item_path = /obj/item/clothing/glasses/contact
+
+/datum/loadout_item/glasses/hud/Armadyne_HUD
+	name = "Armadyne Security HUD"
+	item_path = /obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper/armadyne
+	restricted_roles = list(ALL_JOBS_SEC)

--- a/modular_zzplurt/code/modules/vending/security.dm
+++ b/modular_zzplurt/code/modules/vending/security.dm
@@ -30,3 +30,8 @@
 		/obj/item/watertank/pepperspray = 2,
 		/obj/item/storage/belt/holster/energy = 4,
 	)
+
+/obj/machinery/vending/security
+	zzplurt_contraband = list(
+		/obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper/armadyne = 2,
+	)


### PR DESCRIPTION
## About The Pull Request

Readds the Armadyne sechuds to the security equipment vendor and loadout. They're just sec sunglasses but... They're goggles. Basically, they look cooler and better in my opinion.

## Why It's Good For The Game

Drip = Cool = Good 

## Proof Of Testing
<img width="1073" height="135" alt="image" src="https://github.com/user-attachments/assets/c8d1026e-3743-42c5-917b-c0e68a351e7f" />


## Changelog

:cl:
add: Added Armadyne Sechuds to equipment vendor and loadouts.
/:cl: