### PR TITLE
Fix ringgag not letting you use emotes

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
@@ -71,6 +71,20 @@
 	inhand_icon_state = "balaclava"
 
 // SPLURT EDIT - Delete unused muzzle/ball and muzzle/ring
+// /obj/item/clothing/mask/muzzle/ball
+// 	name = "ballgag"
+// 	desc = "I'm pretty fuckin far from okay."
+// 	icon = 'modular_skyrat/master_files/icons/obj/clothing/masks.dmi'
+// 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/mask.dmi'
+// 	icon_state = "ballgag"
+//
+// /obj/item/clothing/mask/muzzle/ring
+// 	name = "ring gag"
+// 	desc = "A mouth wrap seemingly designed to hold the mouth open."
+// 	icon = 'modular_skyrat/master_files/icons/obj/clothing/masks.dmi'
+// 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/mask.dmi'
+// 	icon_state = "ringgag"
+// SPLURT EDIT END
 
 /obj/item/clothing/mask/surgical/greyscale
 	icon = 'icons/map_icons/clothing/mask.dmi'

--- a/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
@@ -70,22 +70,7 @@
 	icon_state = "swatclavam"
 	inhand_icon_state = "balaclava"
 
-/obj/item/clothing/mask/muzzle/ball
-	name = "ballgag"
-	desc = "I'm pretty fuckin far from okay."
-	icon = 'modular_skyrat/master_files/icons/obj/clothing/masks.dmi'
-	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/mask.dmi'
-	icon_state = "ballgag"
-
-/obj/item/clothing/mask/muzzle/ring
-	name = "ring gag"
-	desc = "A mouth wrap seemingly designed to hold the mouth open."
-	icon = 'modular_skyrat/master_files/icons/obj/clothing/masks.dmi'
-	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/mask.dmi'
-	icon_state = "ringgag"
-	// SPLURT EDIT - Make ring gag not block mouth
-	flags_cover = NONE
-	// SPLURT EDIT END
+// SPLURT EDIT - Delete unused muzzle/ball and muzzle/ring
 
 /obj/item/clothing/mask/surgical/greyscale
 	icon = 'icons/map_icons/clothing/mask.dmi'

--- a/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/masks/breath.dm
@@ -70,7 +70,7 @@
 	icon_state = "swatclavam"
 	inhand_icon_state = "balaclava"
 
-// SPLURT EDIT - Delete unused muzzle/ball and muzzle/ring
+// SPLURT EDIT - Delete unused muzzle/ball and muzzle/ring moved to /obj/item/clothing/mask/ballgag/ring
 // /obj/item/clothing/mask/muzzle/ball
 // 	name = "ballgag"
 // 	desc = "I'm pretty fuckin far from okay."

--- a/modular_skyrat/modules/modular_implants/code/nifsofts/dorms.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts/dorms.dm
@@ -33,7 +33,7 @@
 					// Head / Mask /Neck Items
 					/obj/item/clothing/mask/ballgag,
 					/obj/item/clothing/mask/ballgag/choking,
-					/obj/item/clothing/mask/muzzle/ring,
+					/obj/item/clothing/mask/ballgag/ring, // SPLURT EDIT - Use new ring class
 					/obj/item/clothing/head/deprivation_helmet,
 					/obj/item/clothing/glasses/blindfold/kinky,
 					/obj/item/clothing/ears/kinky_headphones,

--- a/modular_skyrat/modules/modular_items/lewd_items/code/clothing_pref_check.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/clothing_pref_check.dm
@@ -1,6 +1,7 @@
 /// Global list containing all the clothing we'd want to check prefs for before we put on someone.
 GLOBAL_LIST_INIT(pref_checked_clothes, list(
 	/obj/item/clothing/mask/ballgag,
+	/obj/item/clothing/mask/ballgag/ring, // SPLURT EDIT - Add missing gag
 	/obj/item/clothing/mask/ballgag/choking,
 	/obj/item/clothing/mask/gas/bdsm_mask,
 	/obj/item/clothing/suit/corset,

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
@@ -87,6 +87,28 @@
 	gag_size = possible_gag_sizes[size_list_position]
 	balloon_alert(user, "size set to [gag_size]")
 
+// SPLURT ADDITION - Moved ring-gag here
+// A ringgag to allow constant oral
+/obj/item/clothing/mask/ballgag/ring
+	name = "ring gag"
+	desc = "A mouth wrap seemingly designed to hold the mouth open."
+	icon = 'modular_skyrat/master_files/icons/obj/clothing/masks.dmi'
+	icon_state = "/obj/item/clothing/mask/ballgag/ring"
+	post_init_icon_state = "ringgag"
+	inhand_icon_state = "blindfold"
+	lefthand_file = 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/clothing/glasses_righthand.dmi'
+	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/mask.dmi'
+	worn_icon_muzzled = null
+	worn_icon_state = "ringgag"
+	greyscale_config = null
+	greyscale_config_worn = null
+	greyscale_config_inhand_left = null
+	greyscale_config_inhand_right = null
+	greyscale_colors = "#AD66BE"
+	flags_cover = NONE
+// END SPLURT ADDITION
+
 // A ballgag that can choke the wearer
 /obj/item/clothing/mask/ballgag/choking
 	name = "phallic ball gag"

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
@@ -87,13 +87,13 @@
 	gag_size = possible_gag_sizes[size_list_position]
 	balloon_alert(user, "size set to [gag_size]")
 
-// SPLURT ADDITION - Moved ring-gag here
+// SPLURT ADDITION - Moved ringgag here
 // A ringgag to allow constant oral
 /obj/item/clothing/mask/ballgag/ring
 	name = "ring gag"
 	desc = "A mouth wrap seemingly designed to hold the mouth open."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/masks.dmi'
-	icon_state = "/obj/item/clothing/mask/ballgag/ring"
+	icon_state = "ringgag"
 	post_init_icon_state = "ringgag"
 	inhand_icon_state = "blindfold"
 	lefthand_file = 'icons/mob/inhands/clothing/glasses_lefthand.dmi'
@@ -105,7 +105,7 @@
 	greyscale_config_worn = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
-	greyscale_colors = "#AD66BE"
+	greyscale_colors = null
 	flags_cover = NONE
 // END SPLURT ADDITION
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/erp_belt.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/erp_belt.dm
@@ -42,6 +42,7 @@
 
 						//clothing
 						/obj/item/clothing/mask/ballgag,
+						/obj/item/clothing/mask/ballgag/ring, // SPLURT EDIT - Add ringgag
 						/obj/item/clothing/mask/ballgag/choking,
 						/obj/item/clothing/head/domina_cap,
 						/obj/item/clothing/head/costume/skyrat/maid,

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
@@ -98,7 +98,7 @@
 				//clothing facial/head
 				/obj/item/clothing/mask/ballgag = 8,
 				/obj/item/clothing/mask/ballgag/choking = 8,
-				/obj/item/clothing/mask/muzzle/ring = 4,
+				/obj/item/clothing/mask/ballgag/ring = 8, // SPLURT EDIT - Use new ring class
 				/obj/item/clothing/head/deprivation_helmet = 5,
 				/obj/item/clothing/glasses/blindfold/kinky = 5,
 				/obj/item/clothing/ears/kinky_headphones = 5,


### PR DESCRIPTION

## About The Pull Request
Updates the ring-gag to be a subtype of the better implemented ballgag type.
## Why It's Good For The Game
Unable to emote while using ringgag sucks
## Proof Of Testing
Currently working on fixing the vendor icon, but everything else seems to be working

Edit: Fixed the vendor icon

## Changelog
:cl:
fix: Can now emote while wearing ring-gag
/:cl:
