### PR TITLE
Fix Minor Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ As of our recent split from Skyrat, a lot of codedocs/modularization guides need
 
 **1. Do Not Be A Dick**
 
-- The S.P.L.U.R.T. main repository is run by and contributed by volunteers and hobbiests. Please be considerate with the people who help maintain our codebase. We reserve the right to permanently remove anyone who does not show both our contributors and maintainers common decency.
+- The S.P.L.U.R.T. main repository is run by and contributed by volunteers and hobbyists. Please be considerate with the people who help maintain our codebase. We reserve the right to permanently remove anyone who does not show both our contributors and maintainers common decency.
 - S.P.L.U.R.T. does not operate a strict "goodboy" points system or have defined goals, and anyone is welcome to contribute to this project. That being said, the maintainers of this project are free to curate comments as seen fit to uphold a respectful environment.
 
 **2. Modularization Standards Will be Upheld**


### PR DESCRIPTION
Fixed a minor typo in the Readme
_____________________________
Hobbiests to Hobbyists
## About The Pull Request
Just fixed a minor typo that has no real bearing on the rest of the game code,
## Why It's Good For The Game
No longer will people testing code be foiled by a tiny typo in a readme most don't even notice
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
