### PR TITLE
[TM Only/Early Pull] Fixes Security Officers with departments not having alternate titles

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -135,13 +135,22 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	if(dep_trim)
 		var/obj/item/card/id/worn_id = spawning.get_idcard(hand_first = FALSE)
 		SSid_access.apply_trim_to_card(worn_id, dep_trim)
+
+		// SPLURT EDIT: get their preferred job title
+		var/chosen_title = player_client?.prefs?.alt_job_titles?[title] || title
+		var/display_assignment = chosen_title
+
+		// ... and gives the preferred title + assigned department
+		if(department)
+			display_assignment = "[chosen_title] ([department])"
+
+		worn_id.assignment = display_assignment
+		worn_id.update_label()
 		spawning.update_ID_card()
 
-		// Update PDA to match new trim.
 		var/obj/item/modular_computer/pda/pda = spawning.get_item_by_slot(ITEM_SLOT_BELT)
-		var/assignment = worn_id.get_trim_assignment()
-		if(istype(pda) && !isnull(assignment))
-			pda.imprint_id(spawning.real_name, assignment)
+		if(istype(pda))
+			pda.imprint_id(spawning.real_name, display_assignment)
 
 	var/spawn_point = pick(LAZYACCESS(GLOB.department_security_spawns, department))
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -136,21 +136,33 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		var/obj/item/card/id/worn_id = spawning.get_idcard(hand_first = FALSE)
 		SSid_access.apply_trim_to_card(worn_id, dep_trim)
 
-		// SPLURT EDIT: get their preferred job title
+		// SPLURT EDIT ADDITION BEGIN - ALTERNATE JOB TITLES
+
+		// gets their preferred alt title
 		var/chosen_title = player_client?.prefs?.alt_job_titles?[title] || title
 		var/display_assignment = chosen_title
 
-		// ... and gives the preferred title + assigned department
+		// and adds the department
 		if(department)
 			display_assignment = "[chosen_title] ([department])"
 
 		worn_id.assignment = display_assignment
 		worn_id.update_label()
-		spawning.update_ID_card()
 
+		spawning.update_ID_card()
+	
+		// Update PDA to match new trim.
 		var/obj/item/modular_computer/pda/pda = spawning.get_item_by_slot(ITEM_SLOT_BELT)
+		/*
+			var/assignment = worn_id.get_trim_assignment()
+		if(istype(pda) && !isnull(assignment))
+			pda.imprint_id(spawning.real_name, assignment)
+		*/
+		// splurt edit - the above is changed as we assigned display_assignment earlier with their custom title, otherwise assignment is just 'security officer (department)'
 		if(istype(pda))
 			pda.imprint_id(spawning.real_name, display_assignment)
+
+		// SPLURT EDIT CHANGE END - ALTERNATE JOB TITLES
 
 	var/spawn_point = pick(LAZYACCESS(GLOB.department_security_spawns, department))
 


### PR DESCRIPTION
## About The Pull Request

## Why It's Good For The Game

This code fixes a bug that makes it so security officers who are assigned a department do not have alternate titles. This works by adding on their department to the end of their custom title.

## Proof Of Testing

<img width="552" height="247" alt="Screenshot 2026-07-14 084915" src="https://github.com/user-attachments/assets/9a810b46-87f4-4c0b-93f9-b9d8c37a9dfe" />
<img width="476" height="117" alt="Screenshot 2026-07-14 084928" src="https://github.com/user-attachments/assets/8d28f508-4829-40de-9430-227bea813cac" />

## Changelog

:cl:Lucky
fix: Fixed a bug where security officers with departments would not show their alternate titles.
/:cl:
