### PR TITLE
Add blessed lobotomy + neurectomy behavior

### DIFF
--- a/code/modules/surgery/operations/operation_lobotomy.dm
+++ b/code/modules/surgery/operations/operation_lobotomy.dm
@@ -52,6 +52,12 @@
 	else if (organ.brainmob)
 		organ.brainmob.mind?.remove_antag_datum(/datum/antagonist/brainwashed)
 
+	// lucky's changes - the idea behind this is to add a version of neurectomies to the system because in the update they were completely removed
+	if (organ.owner?.reagents?.has_reagent(/datum/reagent/medicine/neurine)) // if neurine exists, it simulates the neurectomy by removing the chance of gaining a trauma from a lobotomy
+		if(organ.owner?.reagents?.has_reagent(/datum/reagent/water/holywater)) // if holy water + neurine exists, it heals soulbound traumas
+			organ.cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
+		return
+
 	if(!prob(75))
 		return
 

--- a/code/modules/surgery/operations/operation_lobotomy.dm
+++ b/code/modules/surgery/operations/operation_lobotomy.dm
@@ -52,11 +52,15 @@
 	else if (organ.brainmob)
 		organ.brainmob.mind?.remove_antag_datum(/datum/antagonist/brainwashed)
 
-	// SPLURT changes - the idea behind this is to add a version of neurectomies to the system because in the update they were completely removed
+	// SPLURT EDIT START
+
+	// the idea behind this is to add a version of neurectomies to the system because in the update they were completely removed
 	if (organ.owner?.reagents?.has_reagent(/datum/reagent/medicine/neurine)) // if neurine exists, it simulates the neurectomy by removing the chance of gaining a trauma from a lobotomy
 		if(organ.owner?.reagents?.has_reagent(/datum/reagent/water/holywater)) // if holy water + neurine exists, it heals soulbound traumas
 			organ.cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
 		return
+
+	// SPLURT EDIT END
 
 	if(!prob(75))
 		return

--- a/code/modules/surgery/operations/operation_lobotomy.dm
+++ b/code/modules/surgery/operations/operation_lobotomy.dm
@@ -52,7 +52,7 @@
 	else if (organ.brainmob)
 		organ.brainmob.mind?.remove_antag_datum(/datum/antagonist/brainwashed)
 
-	// lucky's changes - the idea behind this is to add a version of neurectomies to the system because in the update they were completely removed
+	// SPLURT changes - the idea behind this is to add a version of neurectomies to the system because in the update they were completely removed
 	if (organ.owner?.reagents?.has_reagent(/datum/reagent/medicine/neurine)) // if neurine exists, it simulates the neurectomy by removing the chance of gaining a trauma from a lobotomy
 		if(organ.owner?.reagents?.has_reagent(/datum/reagent/water/holywater)) // if holy water + neurine exists, it heals soulbound traumas
 			organ.cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)


### PR DESCRIPTION
## About The Pull Request

With the upstream merge, the ability to do blessed lobotomies and neurectomies was removed. This pull request creates a work-around and an option for medical in order to heal soulbound traumas and to perform a less risky lobotomy, which was the role neurectomy used to fill.
This pull request adds on a check that does the following things:
- If neurine is detected in the blood, it will not roll for a mental trauma to be randomly added.
- If neurine AND holy water is detected in the blood, it will cure soulbound traumas.

## Why It's Good For The Game

Our current SoP wants neurectomies to be done instead of lobotomies, however they do not exist anymore. This adds a function of that behavior back to give medical something extra they can add on to reduce the risk of lobotomies. In addition, this re-adds blessed lobotomies behavior, as currently blessed lobotomies do not exist, so there are very few ways to cure soul-bound traumas.

## Proof Of Testing

<img width="543" height="386" alt="Screenshot 2026-07-14 101803" src="https://github.com/user-attachments/assets/01586ec1-57b0-4f98-b14c-560112c50caa" />
<img width="557" height="376" alt="Screenshot 2026-07-14 101937" src="https://github.com/user-attachments/assets/5be4837c-6d24-451f-b14f-52ad4f38e135" />
<img width="497" height="203" alt="image" src="https://github.com/user-attachments/assets/8ea4555f-23f7-4d17-ac9f-abbb3c475b7b" />

## Changelog
:cl:Lucky
add: Blessed lobotomies can now be performed by performing a lobotomy with neurine and holy water in their blood. This will cure all soul-bound traumas in the patient.
change: If neurine is in the blood, lobotomies will no longer roll for a random trauma to be applied when performed.
/:cl: