### PR TITLE
Adjusted character size logic

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -1148,3 +1148,11 @@ GLOBAL_LIST_INIT(regal_rat_minion_commands, list(
 	/datum/pet_command/follow,
 	/datum/pet_command/attack/mouse
 ))
+
+/// utillity function to check is both legs are missing from a mob
+/proc/get_legs_missing(mob/living/target)
+	return target.get_bodypart(BODY_ZONE_L_LEG) == null && target.get_bodypart(BODY_ZONE_R_LEG) == null
+
+/// utillity function to check is both arms are missing from a mob
+/proc/get_arms_missing(mob/living/target)
+	return target.get_bodypart(BODY_ZONE_L_ARM) == null && target.get_bodypart(BODY_ZONE_R_ARM) == null

--- a/code/__DEFINES/~~~splurt_defines/sizecode.dm
+++ b/code/__DEFINES/~~~splurt_defines/sizecode.dm
@@ -34,6 +34,25 @@
 		return target.size_multiplier
 
 /*
+ * # get_size_modified(mob/living/target)
+ * Grabs the size of your critter. Same as above, but applies a reduction of 40% if both legs are missing
+*/
+/proc/get_size_modified(mob/living/target)
+	if(!target)
+		CRASH("get_size(NULL) was called")
+	if(!istype(target))
+		CRASH("get_size() called with an invalid target, only use this for /mob/living!")
+	var/datum/dna/has_dna = target.has_dna()
+	if(ishuman(target) && has_dna)
+		if(get_legs_missing(target))
+			return has_dna.features["body_size"] * 0.6
+		else
+			return has_dna.features["body_size"]
+	else
+		return target.size_multiplier
+
+
+/*
  * # COMPARE_SIZES(mob/living/user, mob/living/target)
  * Returns how bigger or smaller the target is in comparison to user
  * Example:
@@ -44,3 +63,15 @@
  * - target = /mob/living
 */
 #define COMPARE_SIZES(user, target) abs((get_size(user) / get_size(target)))
+
+/*
+ * # COMPARE_SIZES_MODIFIED(mob/living/user, mob/living/target)
+ * Returns how bigger or smaller the target is in comparison to user keeping missing legs in mind
+ * Example:
+ * - user = 2, target = 1, result = 0.5
+ * - user = 1, target = 2, result = 2
+ * Args:
+ * - user = /mob/living
+ * - target = /mob/living
+*/
+#define COMPARE_SIZES_MODIFIED(user, target) abs((get_size_modified(user) / get_size_modified(target)))

--- a/code/__DEFINES/~~~splurt_defines/sizecode.dm
+++ b/code/__DEFINES/~~~splurt_defines/sizecode.dm
@@ -22,29 +22,14 @@
  * Now, please don't tell me your creature has a dna but it's very snowflakey, then i say you should rewrite your mob
  * instead of touching this file.
 */
-/proc/get_size(mob/living/target)
+/proc/get_size(mob/living/target, var/size_includes_limbloss = FALSE)
 	if(!target)
 		CRASH("get_size(NULL) was called")
 	if(!istype(target))
 		CRASH("get_size() called with an invalid target, only use this for /mob/living!")
 	var/datum/dna/has_dna = target.has_dna()
 	if(ishuman(target) && has_dna)
-		return has_dna.features["body_size"]
-	else
-		return target.size_multiplier
-
-/*
- * # get_size_modified(mob/living/target)
- * Grabs the size of your critter. Same as above, but applies a reduction of 40% if both legs are missing
-*/
-/proc/get_size_modified(mob/living/target)
-	if(!target)
-		CRASH("get_size(NULL) was called")
-	if(!istype(target))
-		CRASH("get_size() called with an invalid target, only use this for /mob/living!")
-	var/datum/dna/has_dna = target.has_dna()
-	if(ishuman(target) && has_dna)
-		if(get_legs_missing(target))
+		if(size_includes_limbloss && get_legs_missing(target))
 			return has_dna.features["body_size"] * 0.6
 		else
 			return has_dna.features["body_size"]
@@ -74,4 +59,4 @@
  * - user = /mob/living
  * - target = /mob/living
 */
-#define COMPARE_SIZES_MODIFIED(user, target) abs((get_size_modified(user) / get_size_modified(target)))
+#define COMPARE_SIZES_WITH_LIMBLOSS(user, target) abs((get_size(user, TRUE) / get_size(target, TRUE)))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -263,7 +263,7 @@
 		return FALSE
 
 	// If the buckle requires restraints, make sure the target is actually restrained.
-	if(buckle_requires_restraints && !HAS_TRAIT(target, TRAIT_RESTRAINED))
+	if(buckle_requires_restraints && !HAS_TRAIT(target, TRAIT_RESTRAINED) && !get_arms_missing(target))
 		return FALSE
 
 	//If buckling is forbidden for the target, cancel

--- a/modular_zzplurt/code/datums/components/bellyriding.dm
+++ b/modular_zzplurt/code/datums/components/bellyriding.dm
@@ -155,7 +155,7 @@
 	if(current_victim)
 		to_chat(user, span_warning("There's someone already strapped to your belly!"))
 		return FALSE
-	if(!victim.handcuffed || !victim.legcuffed)
+	if((!victim.handcuffed && !get_arms_missing(victim)) || (!victim.legcuffed && !get_legs_missing(victim)))
 		to_chat(user, span_warning("[victim] needs to be both handcuffed and legcuffed!"))
 		return FALSE
 

--- a/modular_zzplurt/code/datums/elements/holder_micro.dm
+++ b/modular_zzplurt/code/datums/elements/holder_micro.dm
@@ -62,7 +62,7 @@
 		to_chat(user, span_warning("You can't pick yourself up."))
 		source.balloon_alert(user, "cannot pick yourself!")
 		return FALSE
-	if(COMPARE_SIZES(user, source) < 2.0)
+	if(COMPARE_SIZES_MODIFIED(user, source) < 2.0)
 		to_chat(user, span_warning("They're too big to pick up!"))
 		source.balloon_alert(user, "too big to pick up!")
 		return FALSE
@@ -77,7 +77,7 @@
 	source.visible_message(span_warning("[user] starts picking up [source]."), \
 					span_userdanger("[user] starts picking you up!"))
 	source.balloon_alert(user, "picking up")
-	var/time_required = COMPARE_SIZES(source, user) * 4 SECONDS //Scale how fast the pickup will be depending on size difference
+	var/time_required = COMPARE_SIZES_MODIFIED(source, user) * 4 SECONDS //Scale how fast the pickup will be depending on size difference
 	if(!do_after(user, time_required, source))
 		return FALSE
 

--- a/modular_zzplurt/code/datums/elements/holder_micro.dm
+++ b/modular_zzplurt/code/datums/elements/holder_micro.dm
@@ -15,7 +15,7 @@
 	var/obj/item/mob_holder/holder = micro.loc
 	if(istype(holder))
 		var/mob/living/living = get_atom_on_turf(micro.loc, /mob/living)
-		if(living && (COMPARE_SIZES(living, micro)) < 2.0)
+		if(living && (COMPARE_SIZES_WITH_LIMBLOSS(living, micro)) < 2.0)
 			living.visible_message(span_warning("\The [living] drops [micro] as [micro.p_they()] grow\s too big to carry."),
 								span_warning("You drop \The [living] as [living.p_they()] grow\s too big to carry."))
 			holder.release()
@@ -23,7 +23,7 @@
 			holder.release()
 
 /datum/element/mob_holder/micro/on_examine(mob/living/source, mob/user, list/examine_list)
-	if(ishuman(user) && !istype(source.loc, /obj/item/mob_holder) && (COMPARE_SIZES(user, source)) >= 2.0)
+	if(ishuman(user) && !istype(source.loc, /obj/item/mob_holder) && (COMPARE_SIZES_WITH_LIMBLOSS(user, source)) >= 2.0)
 		examine_list += span_notice("Looks like [source.p_they(FALSE)] can be picked up using <b>Alt+Click and grab intent</b>!")
 
 /// Do not inherit from /mob_holder, interactions are different.
@@ -62,7 +62,7 @@
 		to_chat(user, span_warning("You can't pick yourself up."))
 		source.balloon_alert(user, "cannot pick yourself!")
 		return FALSE
-	if(COMPARE_SIZES_MODIFIED(user, source) < 2.0)
+	if(COMPARE_SIZES_WITH_LIMBLOSS(user, source) < 2.0)
 		to_chat(user, span_warning("They're too big to pick up!"))
 		source.balloon_alert(user, "too big to pick up!")
 		return FALSE
@@ -77,7 +77,7 @@
 	source.visible_message(span_warning("[user] starts picking up [source]."), \
 					span_userdanger("[user] starts picking you up!"))
 	source.balloon_alert(user, "picking up")
-	var/time_required = COMPARE_SIZES_MODIFIED(source, user) * 4 SECONDS //Scale how fast the pickup will be depending on size difference
+	var/time_required = COMPARE_SIZES_WITH_LIMBLOSS(source, user) * 4 SECONDS //Scale how fast the pickup will be depending on size difference
 	if(!do_after(user, time_required, source))
 		return FALSE
 

--- a/modular_zzplurt/code/modules/mob/living/carbon/examine.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/examine.dm
@@ -4,11 +4,12 @@
 	var/t_He = p_They()
 
 	//Approximate character height based on current sprite scale
-	var/dispSize = round(12*get_size(src)) // gets the character's sprite size percent and converts it to the nearest half foot
+	var/dispSize = round(12*get_size_modified(src)) // gets the character's sprite size percent and converts it to the nearest half foot
+	var/dispSizeMetric = round(183*get_size_modified(src)); // gets the character's sprite size percent and converts it to the nearest cm
 	if(dispSize % 2) // returns 1 or 0. 1 meaning the height is not exact and the code below will execute, 0 meaning the height is exact and the else will trigger.
 		dispSize = dispSize - 1 //makes it even
 		dispSize = dispSize / 2 //rounds it out
-		. += "[t_He] appear\s to be around [dispSize] and a half feet tall."
+		. += "[t_He] appear\s to be around [dispSize] and a half feet ([dispSizeMetric]cm) tall."
 	else
 		dispSize = dispSize / 2
-		. += "[t_He] appear\s to be around [dispSize] feet tall."
+		. += "[t_He] appear\s to be around [dispSize] feet ([dispSizeMetric]cm) tall."

--- a/modular_zzplurt/code/modules/mob/living/carbon/examine.dm
+++ b/modular_zzplurt/code/modules/mob/living/carbon/examine.dm
@@ -4,8 +4,8 @@
 	var/t_He = p_They()
 
 	//Approximate character height based on current sprite scale
-	var/dispSize = round(12*get_size_modified(src)) // gets the character's sprite size percent and converts it to the nearest half foot
-	var/dispSizeMetric = round(183*get_size_modified(src)); // gets the character's sprite size percent and converts it to the nearest cm
+	var/dispSize = round(12*get_size(src, TRUE)) // gets the character's sprite size percent and converts it to the nearest half foot
+	var/dispSizeMetric = round(183*get_size(src, TRUE)); // gets the character's sprite size percent and converts it to the nearest cm
 	if(dispSize % 2) // returns 1 or 0. 1 meaning the height is not exact and the code below will execute, 0 meaning the height is exact and the else will trigger.
 		dispSize = dispSize - 1 //makes it even
 		dispSize = dispSize / 2 //rounds it out


### PR DESCRIPTION

## About The Pull Request

This PR contains changes that take a character's missing limbs into account in some cases.
If both Legs are missing, the calculated size is 60% of the original.
These changes are applied in the examine text, the ability to be buckled when handcuffs are required, but arms are missing, the belly riding functionality of the dual harness, which normally requires hand and leg cuffs, and the pickup ability of bigger characters.
Additionally, I added the metric size display for characters after the imperial units.

Changes:
- Added Sizecode function that factors in lost legs in the size calculation
- Added Comparison function that keeps the new size calculation in mind
- Added missing arms to be considered to being restrained when buckling
- Added the same as above + legs for the intent of bellyriding
- Added the new size check in case of picking up small enough people into the inventory
- Added new size logic and metric display in the humanoid examine screen
## Why It's Good For The Game

The requirements for hand and legcuffs for certain actions are understandable, but having to put limbs back into place if they were missing before to have specific actions work is cumbersome. Also, from an immersion perspective, missing limbs are restrained, as they are not usable.
The examine text change makes it easier to visualize the size difference between certain characters with these conditions. Additionally, the inclusion of metric units in the examine text will make it easier for everyone to grasp the immediate size of characters.
The changes for the size diff pickup will allow people who are above average height to pick up people of average height if the conditions are met.
This will overall improve immersion and give Characters with modular limbs and such an easier time to engage or be engaged with certain functions, and allows for more funny scenes in my personal opinion :D
## Proof Of Testing

Tested it on a local server.

<img width="651" height="248" alt="Screenshot 2026-07-15 192240" src="https://github.com/user-attachments/assets/150fa52d-ab52-4815-b3c1-5eee606504a8" />

<img width="651" height="271" alt="Screenshot 2026-07-15 192323" src="https://github.com/user-attachments/assets/e3443563-949c-4146-bf28-9ca9b7f5179b" />

## Changelog

:cl:
add: metric size display on the examine text
tweak: size calculation now considers missing legs with a 40% reduction
tweak: actions that require hand or leg cuffs now also function if both limbs are missing
/:cl:
