### PR TITLE
Disable the destroy the AI objective

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -369,7 +369,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 /// Chance the traitor gets a kill objective. If this prob fails, they will get a steal objective instead.
 #define KILL_PROB 50
 /// If a kill objective is rolled, chance that it is to destroy the AI.
-#define DESTROY_AI_PROB(denominator) (100 / denominator)
+#define DESTROY_AI_PROB(denominator) 0 // SPLURT EDIT - no destroy AI objectives, was (100 / denominator)
 /// If the destroy AI objective doesn't roll, chance that we'll get a maroon instead. If this prob fails, they will get a generic assassinate objective instead.
 #define MAROON_PROB 0 // SPLURT EDIT - No more maroon objectives, from 30 > 0
 /// Probability that any job related objective is picked


### PR DESCRIPTION
## About The Pull Request

The 'destroy the AI' objective works as an effective round removal and tends to have a lot of complaints when it comes up. This would disable traitors from automatically being given this objective while allowing it to be admin assigned if it is wanted in the future.

## Why It's Good For The Game

Especially with the trouble that seems to happen basically every time we get someone that rolls this objective, it feels like it makes the most sense to just avoid having a round removal objective unless it's admin assigned.

## Proof Of Testing

Don't have a lot other than it doesn't roll... </3

## Changelog

:cl:Lucky
del: Traitors will no longer randomly get the 'destroy the AI' objective.
/:cl: