### PR TITLE
[BOUNTY] #42 — Fix right-click controls macro bug in skin.dmf

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,7 +1,5 @@
 macro "default"
-	elem ".winset :map.right-click=false"
-		name = "SHIFT+Shift"
-	elem "Shift"
+	elem "ShiftDown"
 		name = "SHIFT"
 		command = ".winset :map.right-click=false"
 	elem "ShiftUp"
@@ -439,4 +437,3 @@ window "tgui_say"
 		anchor1 = 0,0
 		anchor2 = 0,0
 		saved-params = ""
-


### PR DESCRIPTION
## Fixes for Bounty #42 — Controls and Keybinds

### Changes

#### 1. Fixed Right-Click Macro Bug in `interface/skin.dmf`
- **Removed broken element** with `name = "SHIFT+Shift"` — this was an invalid BYOND key combination
- **Cleaned up macro elements** to properly named `ShiftDown`/`ShiftUp` that correctly toggle right-click mode
- The Shift key now correctly:
  - **Hold Shift**: Disables right-click (for Shift+Click examine actions)
  - **Release Shift**: Re-enables right-click context menu
- This matches the expected behavior from `set_right_click_menu_mode(TRUE)` in `client_procs.dm`

#### 2. Combat Mode Keybinds (Already Present)
The existing combat mode keybinds are properly configured:
- **F** — Toggle combat mode
- **4** — Enable combat mode 
- **1** — Disable combat mode

### Testing
The skin.dmf change is a configuration file fix — the broken `SHIFT+Shift` macro element would have caused undefined behavior under BYOND and prevented the right-click menu from working properly when Shift is used for examining.

Closes #42