### PR TITLE
Add right-click to empty liquid containers into sinks

### DIFF
--- a/modular_zzplurt/code/game/objects/structures/water_structures/sink.dm
+++ b/modular_zzplurt/code/game/objects/structures/water_structures/sink.dm
@@ -1,0 +1,80 @@
+// Right-click a sink with anything that holds liquid to tip it out down the drain.
+// Left-click still fills/wets, so the two halves of the interaction mirror each other.
+
+/// How long emptying a container into a sink takes, per unit of reagent held.
+#define SINK_EMPTY_TIME_PER_UNIT (0.02 SECONDS)
+/// Emptying a container into a sink never takes longer than this, no matter how full it is.
+#define SINK_EMPTY_TIME_MAX (3 SECONDS)
+
+/**
+ * Returns TRUE if [tool] is holding liquid that can be tipped out into us.
+ *
+ * Anything you can normally pour or draw liquid out of qualifies. Absorbent janitorial
+ * items are allowed on top of that, since they hold reagents without any container flags
+ * but wringing them out into a sink is exactly what you'd expect to be able to do.
+ */
+/obj/structure/sink/proc/can_empty_into_drain(obj/item/tool)
+	if(isnull(tool?.reagents))
+		return FALSE
+	if(tool.is_drawable()) // Covers both DRAWABLE and DRAINABLE holders.
+		return TRUE
+	return istype(tool, /obj/item/mop) || istype(tool, /obj/item/towel)
+
+/obj/structure/sink/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
+
+	if(!can_empty_into_drain(held_item))
+		return .
+
+	context[SCREENTIP_CONTEXT_RMB] = "Empty into drain"
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/structure/sink/examine(mob/user)
+	. = ..()
+	. += span_notice("You could [EXAMINE_HINT("right-click")] it with a container to empty it down the drain.")
+
+/obj/structure/sink/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	if(!can_empty_into_drain(tool))
+		return ..()
+
+	if(busy)
+		to_chat(user, span_warning("Someone's already washing here!"))
+		return ITEM_INTERACT_BLOCKING
+
+	if(!tool.reagents.total_volume)
+		balloon_alert(user, "already empty!")
+		return ITEM_INTERACT_BLOCKING
+
+	var/empty_time = min(tool.reagents.total_volume * SINK_EMPTY_TIME_PER_UNIT, SINK_EMPTY_TIME_MAX)
+
+	user.visible_message(
+		span_notice("[user] starts emptying [tool] into [src]."),
+		span_notice("You start emptying [tool] into [src]..."),
+	)
+	playsound(src, 'sound/effects/slosh.ogg', 25, TRUE)
+
+	busy = TRUE
+	if(!do_after(user, empty_time, target = src))
+		busy = FALSE
+		return ITEM_INTERACT_BLOCKING
+	busy = FALSE
+
+	// The container could have been emptied, swapped or dropped while we were pouring.
+	if(QDELETED(tool) || !user.is_holding(tool))
+		return ITEM_INTERACT_BLOCKING
+	if(!tool.reagents.total_volume)
+		balloon_alert(user, "already empty!")
+		return ITEM_INTERACT_BLOCKING
+
+	user.log_message("emptied [tool] ([tool.reagents.get_reagent_log_string()]) into [src] at [AREACOORD(src)].", LOG_GAME)
+	tool.reagents.clear_reagents()
+	playsound(src, 'sound/machines/sink-faucet.ogg', 50)
+
+	user.visible_message(
+		span_notice("[user] empties [tool] into [src]."),
+		span_notice("You empty [tool] into [src], washing its contents down the drain."),
+	)
+	return ITEM_INTERACT_SUCCESS
+
+#undef SINK_EMPTY_TIME_PER_UNIT
+#undef SINK_EMPTY_TIME_MAX

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10412,6 +10412,7 @@
 #include "modular_zzplurt\code\game\objects\structures\crates_lockers\crates\cardboard.dm"
 #include "modular_zzplurt\code\game\objects\structures\crates_lockers\crates\critter.dm"
 #include "modular_zzplurt\code\game\objects\structures\crates_lockers\crates\secure.dm"
+#include "modular_zzplurt\code\game\objects\structures\water_structures\sink.dm"
 #include "modular_zzplurt\code\game\turf\open\floor\wood_floor.dm"
 #include "modular_zzplurt\code\modules\admin\admin_ticket_stats_panel.dm"
 #include "modular_zzplurt\code\modules\admin\chat_commands.dm"


### PR DESCRIPTION
## About The Pull Request

Sinks already fill containers on left-click, but there was no counterpart for emptying one out. Right-clicking a sink with anything that holds liquid now tips its contents down the drain.

Accepts anything `is_drawable()` — beakers, bottles, cups, buckets, rags, syringes, IV bags — plus mops and towels, which hold reagents without any container flags but are the obvious thing to wring out into a sink. Food is deliberately excluded, since it's `INJECTABLE` only.

Details:

- Reuses the sink's existing `busy` guard, so it can't race with someone washing
- Takes 0.02s per unit, capped at 3s (a 50u beaker is ~1s)
- Re-checks the container still exists and is still held after the `do_after`
- Writes a `LOG_GAME` entry recording who dumped what and where
- Adds an RMB screentip and an examine hint
- Applies to every sink subtype: kitchen, greyscale/wallframe, plasma fuel station, the zubbers sink basin, and the medieval standalone

Implemented as a modular override under `modular_zzplurt/` per the modularization handbook — no core sink file is touched. Left-click behaviour is unchanged.

Worth noting for reviewers: right-clicking a sink previously fell through to the same code as left-click (filling), since `item_interaction_secondary` defaults to `item_interaction`. Players with that muscle memory will now empty instead.

## Why It's Good For The Game

Filling a container at a sink is a left-click away, but emptying one meant dumping it on the floor or tracking down a disposal unit. This closes an obvious gap in an interaction players already know, and makes the two halves mirror each other.

The main tradeoff is that it makes ditching incriminating chemicals easier. That's mitigated by the timed `do_after` — you're stood there visibly pouring for up to three seconds — and by the `LOG_GAME` entry, which keeps it traceable after the fact.

## Proof Of Testing

<details>
<summary>
<img width="1920" height="1044" alt="image" src="https://github.com/user-attachments/assets/e938d78a-2246-4976-a211-341f4c1fb08f" />
</summary>

</details>

## Changelog

:cl:
add: You can now right-click a sink with any liquid-holding container - beakers, buckets, syringes, even mops and towels - to empty it down the drain.
/:cl:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
