### PR TITLE
Adds Armadyne and Missing stuff to the security drobe

### DIFF
--- a/modular_zzplurt/code/game/objects/items/storage/garment.dm
+++ b/modular_zzplurt/code/game/objects/items/storage/garment.dm
@@ -65,6 +65,7 @@
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/clothing/head/hats/warden(src)
 	new /obj/item/clothing/head/hats/warden/red(src)
+	new /obj/item/clothing/head/beret/sec/splurt/warden(src)
 	new /obj/item/clothing/head/hats/warden/drill(src)
 	new /obj/item/clothing/head/security_garrison/warden(src)
 	new /obj/item/clothing/mask/gas/sechailer(src)

--- a/modular_zzplurt/code/modules/vending/multisec.dm
+++ b/modular_zzplurt/code/modules/vending/multisec.dm
@@ -84,7 +84,6 @@
 					/obj/item/clothing/under/rank/security/viro/officer/skirt = 6,
 					/obj/item/clothing/under/rank/security/viro/officer/formal = 6,
 					/obj/item/clothing/under/rank/security/viro/officer/bodysuit = 6,
-					/obj/item/clothing/suit/armor/vest/secwintercoat = 6,
 					/obj/item/clothing/suit/armor/vest/viro = 6,
 					/obj/item/clothing/suit/armor/vest/viro/heavy = 6,
 					/obj/item/clothing/suit/armor/vest/viro/leatherjacket = 6,

--- a/modular_zzplurt/code/modules/vending/multisec.dm
+++ b/modular_zzplurt/code/modules/vending/multisec.dm
@@ -7,6 +7,7 @@
 				/obj/item/storage/backpack/satchel/sec = 6,
 				/obj/item/storage/backpack/messenger/sec = 6,
 				/obj/item/storage/backpack/duffelbag/sec = 6,
+				/obj/item/clothing/under/rank/security/camo = 6,
 				/obj/item/clothing/under/rank/security/splurt/officer = 6,
 				/obj/item/clothing/under/rank/security/splurt/officer/skirt = 6,
 				/obj/item/clothing/under/rank/security/splurt/officer/suit = 6,
@@ -61,6 +62,20 @@
 			)
 		),
 		list(
+			"name" = "Armadyne",
+			"icon" = "star",
+			"products" = list(
+					/obj/item/clothing/under/rank/security/peacekeeper/armadyne/tactical = 6,
+					/obj/item/clothing/under/rank/security/peacekeeper/armadyne = 6,
+					/obj/item/clothing/suit/armor/vest/peacekeeper/armadyne = 6,
+					/obj/item/clothing/suit/armor/vest/peacekeeper/armadyne/armor = 6,
+					/obj/item/clothing/shoes/jackboots/peacekeeper/armadyne = 6,
+					/obj/item/clothing/gloves/combat/peacekeeper/armadyne = 6,
+					/obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper/armadyne = 3,
+					/obj/item/clothing/head/beret/sec/peacekeeper/armadyne = 6,
+			),
+		),
+		list(
 			"name" = "Viro",
 			"icon" = "vest",
 			"products" = list(
@@ -74,6 +89,7 @@
 					/obj/item/clothing/suit/armor/vest/viro/heavy = 6,
 					/obj/item/clothing/suit/armor/vest/viro/leatherjacket = 6,
 					/obj/item/clothing/suit/armor/vest/viro/softshell = 6,
+					/obj/item/clothing/head/helmet/viro = 6,
 					/obj/item/clothing/head/sec/viro = 6,
 					/obj/item/clothing/head/sec/viro/beanie = 6,
 			),


### PR DESCRIPTION

## About The Pull Request

Adds missing items, and Armadyne back to the drobe and garment bags.

## Why It's Good For The Game

It was a bit of a mistake to miss these when I did make the PR at first.

## Proof Of Testing

It's just a tiny bit of code.

</details>

## Changelog
:cl:
add: Armadyne clothing, Warden beret, and Virosec helmet to their corresponding spots.
/:cl:
