### PR TITLE
Add permit legality text to gun examine

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -195,6 +195,9 @@
 		else
 			. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
 
+	if(item_flags & NEEDS_PERMIT)
+		. += span_notice("Legal status: Green/Blue alert requires a valid permit or Security authorization to openly possess or carry this weapon; Amber/Red/Delta alert requires following current Security or Command orders.")
+
 	var/healthpercent = (atom_integrity/max_integrity) * 100
 	switch(healthpercent)
 		if(60 to 95)


### PR DESCRIPTION
## About
Adds a concise legal-status line to gun examine text for weapons marked with `NEEDS_PERMIT`.

This covers the requested alarm-state flavor for guns in #1104:
- Green/Blue: valid permit or Security authorization required
- Amber/Red/Delta: follow current Security or Command orders

## Notes
The implementation reuses the existing `NEEDS_PERMIT` item flag instead of adding per-gun duplicated text, so guns that opt out of that flag will not show the warning.

## Testing
- Not run locally: this environment could not finish cloning the full BYOND codebase, so this PR was prepared as a small API-based patch and reviewed via GitHub compare diff.