### PR TITLE
Add opposing force stats to report

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/roundend.dm
+++ b/modular_skyrat/modules/opposing_force/code/roundend.dm
@@ -1,7 +1,7 @@
 /datum/controller/subsystem/ticker/proc/opfor_report()
 	var/list/result = list()
 
-	result += "<span class='header'>Opposing Force Report - <span style='color: green;'>Approved: [LAZYLEN(SSopposing_force.approved_applications)]</span>, <span style='color: red;'>Submitted: [LAZYLEN(SSopposing_force.submitted_applications)]</span></span><br>" // SPLURT EDIT - Add info about number of applications
+	result += "<span class='header'>Opposing Force Report - <span class='greentext header'>Approved: [LAZYLEN(SSopposing_force.approved_applications)]</span>, <span class='redtext header'>Submitted: [LAZYLEN(SSopposing_force.submitted_applications)]</span></span><br>" // SPLURT EDIT - Add info about number of applications
 
 	if(!SSopposing_force.approved_applications.len)
 		result += span_red("No applications were approved.")

--- a/modular_skyrat/modules/opposing_force/code/roundend.dm
+++ b/modular_skyrat/modules/opposing_force/code/roundend.dm
@@ -1,7 +1,7 @@
 /datum/controller/subsystem/ticker/proc/opfor_report()
 	var/list/result = list()
 
-	result += "<span class='header'>Opposing Force Report - <span class='greentext header'>Approved: [LAZYLEN(SSopposing_force.approved_applications)]</span>, <span class='redtext header'>Submitted: [LAZYLEN(SSopposing_force.submitted_applications)]</span></span><br>" // SPLURT EDIT - Add info about number of applications
+	result += "<span class='header'>Opposing Force Report - <span class='greentext header'>Approved: [LAZYLEN(SSopposing_force.approved_applications)]</span>, <span class='redtext header'>Denied: [LAZYLEN(SSopposing_force.submitted_applications)]</span></span><br>" // SPLURT EDIT - Add info about number of applications
 
 	if(!SSopposing_force.approved_applications.len)
 		result += span_red("No applications were approved.")

--- a/modular_skyrat/modules/opposing_force/code/roundend.dm
+++ b/modular_skyrat/modules/opposing_force/code/roundend.dm
@@ -1,7 +1,7 @@
 /datum/controller/subsystem/ticker/proc/opfor_report()
 	var/list/result = list()
 
-	result += "<span class='header'>Opposing Force Report:</span><br>"
+	result += "<span class='header'>Opposing Force Report - <span style='color: green;'>Approved: [LAZYLEN(SSopposing_force.approved_applications)]</span>, <span style='color: red;'>Submitted: [LAZYLEN(SSopposing_force.submitted_applications)]</span></span><br>" // SPLURT EDIT - Add info about number of applications
 
 	if(!SSopposing_force.approved_applications.len)
 		result += span_red("No applications were approved.")

--- a/modular_zzplurt/code/modules/storyteller/event_defines/major/major_overrides.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/major/major_overrides.dm
@@ -52,3 +52,5 @@
 /datum/round_event_control/morph
 	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY, TAG_MEDIUM, TAG_OPFOR_ONLY)
 
+/datum/round_event_control/fleshmind
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_CHAOTIC, TAG_MEDIUM)

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
@@ -1,4 +1,4 @@
 /datum/storyteller/extended
 	population_max = null
 	votable = TRUE
-	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_EXTENDED
+	storyteller_type = STORYTELLER_TYPE_CALM

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
@@ -1,4 +1,4 @@
 /datum/storyteller/extended
 	population_max = null
 	votable = TRUE
-	storyteller_type = STORYTELLER_TYPE_EXTENDED
+	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_EXTENDED

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
@@ -37,7 +37,7 @@
 // 		TAG_OPFOR_ONLY = 0
 // 	)
 // 	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_OPFOR_ONLY
-
-/datum/storyteller_data/tracks/chill/opfor
-	threshold_crewset = INFINITY
-	threshold_ghostset = INFINITY
+//
+// /datum/storyteller_data/tracks/chill/opfor
+//	threshold_crewset = INFINITY
+//	threshold_ghostset = INFINITY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
@@ -16,27 +16,27 @@
 		TAG_HIGH = 0
 	)
 	antag_divisor = 32
-	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_ANTAGS
+	storyteller_type = STORYTELLER_TYPE_CALM
 
-/datum/storyteller/low/opfor
-	name = /datum/storyteller/low::name + " with Opfor Antags"
-	desc = /datum/storyteller/low::desc + " (use opfor to become an antag!)"
-	welcome_text = /datum/storyteller/low::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round!)")
-
-	track_data = /datum/storyteller_data/tracks/chill/opfor
-
-	guarantees_roundstart_crewset = FALSE
-
-	tag_multipliers = list(
-		TAG_COMBAT = 0.3,
-		TAG_DESTRUCTIVE = 0.3,
-		TAG_CHAOTIC = 0.1,
-		TAG_LOW = 1,
-		TAG_MEDIUM = 0,
-		TAG_HIGH = 0,
-		TAG_OPFOR_ONLY = 0
-	)
-	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_OPFOR_ONLY
+// /datum/storyteller/low/opfor
+// 	name = /datum/storyteller/low::name + " with Opfor Antags"
+// 	desc = /datum/storyteller/low::desc + " (use opfor to become an antag!)"
+// 	welcome_text = /datum/storyteller/low::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round!)")
+//
+// 	track_data = /datum/storyteller_data/tracks/chill/opfor
+//
+// 	guarantees_roundstart_crewset = FALSE
+//
+// 	tag_multipliers = list(
+// 		TAG_COMBAT = 0.3,
+// 		TAG_DESTRUCTIVE = 0.3,
+// 		TAG_CHAOTIC = 0.1,
+// 		TAG_LOW = 1,
+// 		TAG_MEDIUM = 0,
+// 		TAG_HIGH = 0,
+// 		TAG_OPFOR_ONLY = 0
+// 	)
+// 	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_OPFOR_ONLY
 
 /datum/storyteller_data/tracks/chill/opfor
 	threshold_crewset = INFINITY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_1_low.dm
@@ -19,9 +19,9 @@
 	storyteller_type = STORYTELLER_TYPE_CALM | STORYTELLER_TYPE_ANTAGS
 
 /datum/storyteller/low/opfor
-	name = /datum/storyteller/low::name + " (OPFOR)"
-	desc = /datum/storyteller/low::desc + " (antags are OPFOR-only)"
-	welcome_text = /datum/storyteller/low::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round)")
+	name = /datum/storyteller/low::name + " with Opfor Antags"
+	desc = /datum/storyteller/low::desc + " (use opfor to become an antag!)"
+	welcome_text = /datum/storyteller/low::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round!)")
 
 	track_data = /datum/storyteller_data/tracks/chill/opfor
 
@@ -40,3 +40,4 @@
 
 /datum/storyteller_data/tracks/chill/opfor
 	threshold_crewset = INFINITY
+	threshold_ghostset = INFINITY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
@@ -13,9 +13,9 @@
 	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_ANTAGS
 
 /datum/storyteller/medium/opfor
-	name = /datum/storyteller/medium::name + " (OPFOR)"
-	desc = /datum/storyteller/medium::desc + " (antags are OPFOR-only)"
-	welcome_text = /datum/storyteller/medium::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round)")
+	name = /datum/storyteller/medium::name + " with Opfor Antags"
+	desc = /datum/storyteller/medium::desc + " (use opfor to become an antag!)"
+	welcome_text = /datum/storyteller/medium::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round!)")
 
 	track_data = /datum/storyteller_data/tracks/medium/opfor
 
@@ -31,3 +31,4 @@
 
 /datum/storyteller_data/tracks/medium/opfor
 	threshold_crewset = INFINITY
+	threshold_ghostset = INFINITY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
@@ -10,12 +10,12 @@
 		TAG_MEDIUM = 1,
 		TAG_HIGH = 0
 		)
-	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_ANTAGS
+	storyteller_type = STORYTELLER_TYPE_INTENSE
 
 /datum/storyteller/medium/opfor
-	name = /datum/storyteller/medium::name + " with Opfor Antags"
-	desc = /datum/storyteller/medium::desc + " (use opfor to become an antag!)"
-	welcome_text = /datum/storyteller/medium::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round!)")
+	name = "Freeform Chaos (OPFOR)"
+	desc = "Random events at a moderate pace and antagonists will be player generated."
+	welcome_text = span_bold(" (Open an OPFOR application if you're interested in becoming an antagonist for this round!)")
 
 	track_data = /datum/storyteller_data/tracks/medium/opfor
 
@@ -27,7 +27,7 @@
 		TAG_HIGH = 0,
 		TAG_OPFOR_ONLY = 0
 	)
-	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_OPFOR_ONLY
+	storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE
 
 /datum/storyteller_data/tracks/medium/opfor
 	threshold_crewset = INFINITY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
@@ -38,7 +38,7 @@
 // 		TAG_HIGH = 1,
 // 		TAG_OPFOR_ONLY = 0
 // 	)
-
-/datum/storyteller_data/tracks/gamer/opfor
-	threshold_crewset = INFINITY
-	threshold_ghostset = INFINITY
+//
+// /datum/storyteller_data/tracks/gamer/opfor
+// 	threshold_crewset = INFINITY
+// 	threshold_ghostset = INFINITY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
@@ -19,9 +19,9 @@
 	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_ANTAGS
 
 /datum/storyteller/high/opfor
-	name = /datum/storyteller/high::name + " (OPFOR)"
-	desc = /datum/storyteller/high::desc + " (antags are OPFOR-only)"
-	welcome_text = /datum/storyteller/high::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round)")
+	name = /datum/storyteller/high::name + " with Opfor Antags"
+	desc = /datum/storyteller/high::desc + " (use opfor to become an antag!)"
+	welcome_text = /datum/storyteller/high::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round!)")
 
 	track_data = /datum/storyteller_data/tracks/gamer/opfor
 
@@ -41,3 +41,4 @@
 
 /datum/storyteller_data/tracks/gamer/opfor
 	threshold_crewset = INFINITY
+	threshold_ghostset = INFINITY

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_3_high.dm
@@ -16,28 +16,28 @@
 	)
 
 	antag_divisor = 5
-	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_ANTAGS
+	storyteller_type = STORYTELLER_TYPE_INTENSE
 
-/datum/storyteller/high/opfor
-	name = /datum/storyteller/high::name + " with Opfor Antags"
-	desc = /datum/storyteller/high::desc + " (use opfor to become an antag!)"
-	welcome_text = /datum/storyteller/high::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round!)")
-
-	track_data = /datum/storyteller_data/tracks/gamer/opfor
-
-	guarantees_roundstart_crewset = FALSE
-
-	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_OPFOR_ONLY
-
-	tag_multipliers = list(
-		TAG_COMBAT = 1.4,
-		TAG_DESTRUCTIVE = 0.7,
-		TAG_CHAOTIC = 1.3,
-		TAG_LOW = 1,
-		TAG_MEDIUM = 1,
-		TAG_HIGH = 1,
-		TAG_OPFOR_ONLY = 0
-	)
+// /datum/storyteller/high/opfor
+// 	name = /datum/storyteller/high::name + " with Opfor Antags"
+// 	desc = /datum/storyteller/high::desc + " (use opfor to become an antag!)"
+// 	welcome_text = /datum/storyteller/high::welcome_text + span_bold(" (Open an OPFOR application if you're interested in becoming an antag for this round!)")
+//
+// 	track_data = /datum/storyteller_data/tracks/gamer/opfor
+//
+// 	guarantees_roundstart_crewset = FALSE
+//
+// 	storyteller_type = STORYTELLER_TYPE_INTENSE | STORYTELLER_TYPE_OPFOR_ONLY
+//
+// 	tag_multipliers = list(
+// 		TAG_COMBAT = 1.4,
+// 		TAG_DESTRUCTIVE = 0.7,
+// 		TAG_CHAOTIC = 1.3,
+// 		TAG_LOW = 1,
+// 		TAG_MEDIUM = 1,
+// 		TAG_HIGH = 1,
+// 		TAG_OPFOR_ONLY = 0
+// 	)
 
 /datum/storyteller_data/tracks/gamer/opfor
 	threshold_crewset = INFINITY


### PR DESCRIPTION

## About The Pull Request
Adds some end round info regarding opfors to the opfor report.
Closes: #1099
## Why It's Good For The Game
More clarity on opfor usage
## Proof Of Testing

<img width="790" height="609" alt="image" src="https://github.com/user-attachments/assets/9f2c46e1-362c-4f08-b17b-625d3769cd64" />


## Changelog
:cl:
qol: Add opfor stats to the end round report
/:cl:
