### PR TITLE
feat: add custom SPLURT mob variants (#30)

### DIFF
--- a/modular_zzplurt/code/modules/mob/splurt_bounty_mobs.dm
+++ b/modular_zzplurt/code/modules/mob/splurt_bounty_mobs.dm
@@ -11,6 +11,7 @@
 	name = "docile funwolf"
 	desc = "A large, social wolf that can be befriended and cared for."
 	gold_core_spawnable = FRIENDLY_SPAWN
+	faction = list(FACTION_NEUTRAL)
 
 /mob/living/basic/mining/wolf/funwolf/female
 	name = "docile she-wolf"
@@ -26,6 +27,7 @@
 /mob/living/simple_animal/hostile/megafauna/wendigo/funwendigo
 	name = "docile wendigo"
 	desc = "A powerful wendigo variant configured as a friendly event spawn."
+	faction = list(FACTION_NEUTRAL)
 	gold_core_spawnable = FRIENDLY_SPAWN
 
 /mob/living/simple_animal/hostile/megafauna/wendigo/funwendigo/female

--- a/modular_zzplurt/code/modules/mob/splurt_bounty_mobs.dm
+++ b/modular_zzplurt/code/modules/mob/splurt_bounty_mobs.dm
@@ -1,0 +1,42 @@
+// Custom SPLURT mob variants for bounty #30.
+// These subtypes reuse the upstream mob implementations, including their AI,
+// attacks, loot, and lifecycle hooks.
+
+/mob/living/basic/mining/wolf/hostile
+	can_tame = FALSE
+	ai_controller = /datum/ai_controller/basic_controller/simple/simple_hostile
+	gold_core_spawnable = HOSTILE_SPAWN
+
+/mob/living/basic/mining/wolf/funwolf
+	name = "docile funwolf"
+	desc = "A large, social wolf that can be befriended and cared for."
+	gold_core_spawnable = FRIENDLY_SPAWN
+
+/mob/living/basic/mining/wolf/funwolf/female
+	name = "docile she-wolf"
+	gender = FEMALE
+
+/mob/living/basic/mining/wolf/funwolf/alpha
+	name = "alpha funwolf"
+	maxHealth = 520
+	health = 520
+	melee_damage_lower = 28
+	melee_damage_upper = 28
+
+/mob/living/simple_animal/hostile/megafauna/wendigo/funwendigo
+	name = "docile wendigo"
+	desc = "A powerful wendigo variant configured as a friendly event spawn."
+	gold_core_spawnable = FRIENDLY_SPAWN
+
+/mob/living/simple_animal/hostile/megafauna/wendigo/funwendigo/female
+	name = "docile she-wendigo"
+	gender = FEMALE
+
+/mob/living/simple_animal/hostile/megafauna/wendigo/funwendigo/alpha
+	name = "alpha wendigo"
+	maxHealth = 3200
+	health = 3200
+	melee_damage_lower = 55
+	melee_damage_upper = 55
+	gold_core_spawnable = HOSTILE_SPAWN
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10945,4 +10945,5 @@
 #include "modular_zzplurt\modules\Nanotrasen_Stuff\Nanotrasen_consultant\new_nanotrasen_consultant.dm"
 #include "modular_zzplurt\modules\Nanotrasen_Stuff\Nanotrasen_trainer\nanotrasen_crew_trainer.dm"
 #include "modular_zzplurt\modules\primitive_production\code\primitive.dm"
+#include "modular_zzplurt\code\modules\mob\splurt_bounty_mobs.dm"
 // END_INCLUDE


### PR DESCRIPTION
Closes #30

This adds spawnable custom wolf and wendigo variants while reusing the existing parent implementations for AI, attacks, loot, and lifecycle behavior.

Added variants:
- hostile wolf
- docile wolf, female wolf, and alpha wolf
- docile wendigo, female wendigo, and alpha wendigo

The change is limited to a new modular file plus its DME include. `git diff --check` passes. DreamMaker is not installed in this environment, so a full DM compilation was not run.