### PR TITLE
Fix edge case for iPod upload

### DIFF
--- a/modular_zzplurt/code/game/objects/items/ipod.dm
+++ b/modular_zzplurt/code/game/objects/items/ipod.dm
@@ -204,6 +204,13 @@ GLOBAL_VAR_INIT(ipod_last_play, 0) //last time of the last played track, to prev
 		return
 
 	lastfilechange = world.time
+	var/sound_length = SSsounds.get_sound_length(logged_filename) // this uses the rust-g library to check if file is valid
+	if(isnull(sound_length) || sound_length <= 20) // either an invalid file or 2 seconds or less, abort
+		to_chat(user, span_warning("The song codec was invalid, aborting!"))
+		user.log_message("uploaded an invalid song: [logged_filename]", LOG_GAME)
+		log_admin("[key_name(user)] attempted to upload an corrupted song to their headphones. The source filename was '[sanitize("[infile]")]'.")
+		fdel(logged_filename)
+		return
 	var/uploaded_song = file(logged_filename)
 	if(!uploaded_song || !fexists(uploaded_song))
 		to_chat(user, span_warning("Upload failed to finish, aborting!"))
@@ -213,13 +220,6 @@ GLOBAL_VAR_INIT(ipod_last_play, 0) //last time of the last played track, to prev
 		to_chat(user, span_warning("Upload failed to finish, aborting!"))
 		user.log_message("attempted to upload a song: [logged_filename]", LOG_GAME)
 		log_admin("[key_name(user)] attempted to upload an incomplete song to their headphones. The source filename was '[sanitize("[infile]")]'.")
-		fdel(logged_filename)
-		return
-	var/sound_length = SSsounds.get_sound_length(uploaded_song) // this uses the rust-g library to check if file is valid
-	if(isnull(sound_length) || sound_length <= 20) // either an invalid file or 2 seconds or less, abort
-		to_chat(user, span_warning("The song codec was invalid, aborting!"))
-		user.log_message("uploaded an invalid song: [logged_filename]", LOG_GAME)
-		log_admin("[key_name(user)] attempted to upload an corrupted song to their headphones. The source filename was '[sanitize("[infile]")]'.")
 		fdel(logged_filename)
 		return
 	if(loc != user) // headphones no longer on mob, abort

--- a/modular_zzplurt/code/game/objects/items/ipod.dm
+++ b/modular_zzplurt/code/game/objects/items/ipod.dm
@@ -177,7 +177,7 @@ GLOBAL_VAR_INIT(ipod_last_play, 0) //last time of the last played track, to prev
 		return
 	var/file_extension = LOWER_TEXT(copytext("[infile]", -4))
 	if(!(file_extension == ".ogg" || file_extension == ".mp3"))
-		to_chat(user, span_warning("File type must be OGG or MP3: [infile]"))
+		to_chat(user, span_warning("File type must be OGG or MP3: [sanitize("[infile]")]"))
 		return
 	var/filelength = length(infile)
 	if(radio_mode && filelength > 3242880) // radio broadcasting has a tighter file size limit


### PR DESCRIPTION
## About The Pull Request

This PR addresses a possible exploit with the iPod upload logic.

Rust-g first opens and parses the file before BYOND touch it - this is to ensure that it conforms to the expected audio codec, and it isn't targeting an BYOND exploit.

## Why It's Good For The Game

Fixes a possible exploit.

## Proof Of Testing

I've tested and confirmed that the behavior remains the same, except more robust handling for invalid files.

## Changelog

:cl:
fix: Sanity check iPod uploads before BYOND reads file
/:cl: