### PR TITLE
Removes steal AI objective

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -552,7 +552,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	return GLOB.main_supermatter_engine != null
 
 // Doesn't need item_owner = (JOB_AI) because this handily functions as a murder objective if there isn't one
-/datum/objective_item/steal/functionalai
+/* /datum/objective_item/steal/functionalai
 	name = "a functional AI"
 	targetitem = /obj/item/aicard
 	difficulty = 5
@@ -582,7 +582,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		return TRUE
 
 	return FALSE
-
+SPLURT Edit, Removes steal AI - as it is essentially soft RR for the AI. */
 /datum/objective_item/steal/blueprints
 	name = "the station blueprints"
 	targetitem = /obj/item/blueprints

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -550,7 +550,8 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 
 /datum/objective_item/steal/supermatter/target_exists()
 	return GLOB.main_supermatter_engine != null
-
+// Begin SPLURT edit removal - Stealing the AI is borderline RR
+/*
 // Doesn't need item_owner = (JOB_AI) because this handily functions as a murder objective if there isn't one
 /datum/objective_item/steal/functionalai
 	name = "a functional AI"
@@ -582,7 +583,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		return TRUE
 
 	return FALSE
-
+*/ //SPLURT edit removal end
 /datum/objective_item/steal/blueprints
 	name = "the station blueprints"
 	targetitem = /obj/item/blueprints

--- a/code/modules/antagonists/spy/spy_bounty.dm
+++ b/code/modules/antagonists/spy/spy_bounty.dm
@@ -235,7 +235,7 @@
 	VAR_FINAL/datum/objective_item/desired_item
 	/// Typecache of objective items that should not be selected.
 	var/static/list/blacklisted_item_types = typecacheof(list(
-		/datum/objective_item/steal/functionalai,
+		// /datum/objective_item/steal/functionalai, - SPLURT Removal.
 		/datum/objective_item/steal/nukedisc,
 	))
 

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -190,7 +190,8 @@
 		return UI_INTERACTIVE
 	. = ..()
 
-GAME_VERB_HIDDEN(/obj/item/mod/control/pre_equipped/protean, remove_modsuit, "Remove Assimilated Modsuit")
+/obj/item/mod/control/pre_equipped/protean/verb/remove_modsuit()
+	set name = "Remove Assimilated Modsuit"
 	var/obj/item/mod/core/protean/p_core = core
 	to_chat(usr, span_notice("You begin to pry at the [stored_modsuit] to seperate it."))
 	if(!do_after(usr, 5 SECONDS))

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -190,8 +190,7 @@
 		return UI_INTERACTIVE
 	. = ..()
 
-/obj/item/mod/control/pre_equipped/protean/verb/remove_modsuit()
-	set name = "Remove Assimilated Modsuit"
+GAME_VERB_HIDDEN(/obj/item/mod/control/pre_equipped/protean, remove_modsuit, "Remove Assimilated Modsuit")
 	var/obj/item/mod/core/protean/p_core = core
 	to_chat(usr, span_notice("You begin to pry at the [stored_modsuit] to seperate it."))
 	if(!do_after(usr, 5 SECONDS))


### PR DESCRIPTION
## About The Pull Request

This comments out the steal AI objective.
## Why It's Good For The Game

Imagine if as an antag I made an objective to kill a protean and then wear them for the rest of the shift. I think we'd all agree that would be against the rules- I'd probably get a note or worse. So why is a similar objective with a similar outcome to the victim allowed?
If you are 'stolen' as the AI you are basically forced to sit in someone's pocket/bag for whatever duration of the shift remains begging people that you pass by (assuming the traitor doesn't just hide in maints with you) to help free you.

## Changelog
:cl:
del: Removed steal AI

