### PR TITLE
Add silicon headshot examine

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/silicon/examine.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/silicon/examine.dm
@@ -26,3 +26,15 @@
 			. += span_notice("<b>They look different than usual:</b> [temporary_flavor_text]")
 		else
 			. += span_notice("<b>They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
+
+/mob/living/silicon/get_chat_examine_headshot(mob/user)
+	if(!client?.prefs || !user?.client?.prefs)
+		return null
+	if(!user.client.prefs.read_preference(/datum/preference/toggle/chat_examine_headshot))
+		return null
+
+	var/headshot = client.prefs.read_preference(/datum/preference/text/headshot/silicon)
+	if(!length(headshot))
+		return null
+
+	return "<div class='chat_headshot_top chat_headshot_frame'>[chat_headshot(html_encode(headshot))]</div>"


### PR DESCRIPTION

## About The Pull Request
Add cyborg examine headshot picture
Mirrors https://github.com/Bubberstation/Bubberstation/pull/6129
## Why It's Good For The Game
Humans have it but why not cyborgs?
Fixes: #1129
## Proof Of Testing
<img width="437" height="174" alt="image" src="https://github.com/user-attachments/assets/62257b1d-61c0-4a81-8ab4-59ef3df0ce02" />


## Changelog
:cl:
fix: Cyborg headshot not showing in examine.
/:cl:
