### PR TITLE
[TM this and remove once lawracks are in the game] Fixes Unique AI

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -26,7 +26,7 @@
 /obj/item/mmi/Initialize(mapload)
 	. = ..()
 	radio = new(src) //Spawns a radio inside the MMI.
-	laws.set_laws_config()
+	//laws.set_laws_config() - Splurt edit - Remove this when lawracks are included with an upstream
 
 /obj/item/mmi/Destroy()
 	set_mecha(null)


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Unique AI doesn't function because MMIs call law population before the station trait is initialized, there's almost certainly a better fix for this, but lawracks nukes this portion of the code anyway and will be here soon:tm:
## Proof Of Testing
it works, I had this TMed on bubber
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: unique AI gets unique laws
/:cl:
