### PR TITLE
Fixes ash resistance quirk not functioning

### DIFF
--- a/modular_zzplurt/code/datums/weather/weather_types/ash_storm.dm
+++ b/modular_zzplurt/code/datums/weather/weather_types/ash_storm.dm
@@ -1,5 +1,5 @@
 // Lavaland ash storms
-/datum/weather/ash_storm/weather_act_mob(mob/living/victim)
+/datum/weather/particle/ash_storm/weather_act_mob(mob/living/victim)
 	// Check for resistance quirk
 	if(HAS_TRAIT(victim, TRAIT_ASHRESISTANCE))
 		// Do stamina damage instead


### PR DESCRIPTION

## About The Pull Request

Fixes ash storm damaging carbons even if they have the ash resistance quirk due to outdated path of ash resistance part of code. As such, should also resolve #1141.
## Why It's Good For The Game

Bugs bad 🐛
## Proof Of Testing
Runs as intended, no relevant runtimes spotted.
<details>
<summary>Screenshots/Videos</summary>
<img width="425" height="516" alt="image" src="https://github.com/user-attachments/assets/a8427be5-b92a-4086-8441-7d38d54b4a98" />

</details>

## Changelog
:cl:
fix: You can now resist against ash storm with ash resistance quirk once again.
/:cl:
