### PR TITLE
Fix Fancy Weather prefrences not being respected (Early upstream)

### DIFF
--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -120,7 +120,7 @@
 	if(!istype(mymob) || !mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/particle_weather))
 		return
 
-	SSweather.particle_planemasters += src
+	SSweather.particle_planemasters[src] = TRUE
 
 	// Lobby HUDs, we don't care about weather during init anyways
 	if(!SSmapping.initialized)
@@ -136,6 +136,9 @@
 
 /atom/movable/screen/plane_master/rendering_plate/particle_weather/proc/z_changed(datum/source, new_z)
 	SIGNAL_HANDLER
+
+	if(!SSweather.particle_planemasters[src])
+		return
 
 	if(!SSmapping.initialized)
 		return


### PR DESCRIPTION

## About The Pull Request
Early upstream of https://github.com/tgstation/tgstation/pull/97555
Fixes broken fancy particles weather setting
## Changelog
:cl:
fix: Fix fancy particles weather setting not working
/:cl:
