### PR TITLE
(Early Upstream) Fixes a bug where examining Fleshmind cores gives incorrect points

### DIFF
--- a/modular_zubbers/code/game/gamemodes/fleshmind/fleshmind_structures.dm
+++ b/modular_zubbers/code/game/gamemodes/fleshmind/fleshmind_structures.dm
@@ -355,10 +355,11 @@
 
 /obj/structure/fleshmind/structure/core/examine(mob/user)
 	. = ..()
-	/// SPLURT EDIT START
-	/// Fixes a calculation bug with the examine code, was Level * Progress Required - Current Points
+
+	/// Last Level Up Points + the points needed to next level, default 300
+	/// typically this means per level it takes around 300 points to level up, may be a bit more if it levelled up fast
+
 	var/level_calculation = (our_controller.last_level_up_points + our_controller.level_up_progress_required) - our_controller.current_points
-	/// SPLURT EDIT END
 	/// round Cooldown Time / 10
 	var/time_calculation = round(COOLDOWN_TIMELEFT(our_controller, level_up_cooldown) / 10)
 
@@ -367,7 +368,7 @@
 			. += span_notice("Your GPS tracks to this thing!")
 		if(isobserver(user))
 			if(COOLDOWN_FINISHED(our_controller, level_up_cooldown) || level_calculation > 0)
-				. += "Level: [our_controller.level] | Progress to Next Level: [level_calculation]"
+				. += "Level: [our_controller.level] | Points to Next Level: [level_calculation]"
 			else
 				. += "Level: [our_controller.level] | Time to Next Level: [time_calculation] Seconds"
 

--- a/modular_zubbers/code/game/gamemodes/fleshmind/fleshmind_structures.dm
+++ b/modular_zubbers/code/game/gamemodes/fleshmind/fleshmind_structures.dm
@@ -355,8 +355,10 @@
 
 /obj/structure/fleshmind/structure/core/examine(mob/user)
 	. = ..()
-	/// Level * Progress Required - Current Points
-	var/level_calculation = (our_controller.level * our_controller.level_up_progress_required) - our_controller.current_points
+	/// SPLURT EDIT START
+	/// Fixes a calculation bug with the examine code, was Level * Progress Required - Current Points
+	var/level_calculation = (our_controller.last_level_up_points + our_controller.level_up_progress_required) - our_controller.current_points
+	/// SPLURT EDIT END
 	/// round Cooldown Time / 10
 	var/time_calculation = round(COOLDOWN_TIMELEFT(our_controller, level_up_cooldown) / 10)
 


### PR DESCRIPTION
## About The Pull Request

At this time, there is a bug with Fleshmind that causes examining its cores to give an incorrect number of points needed to level up. This is because the examine code uses the wrong math, doing level * 300 instead of last level up points + 300 which is the actual level up code. This pull request fixes the examine codes math and allows it to correctly calculate the points needed.

## Why It's Good For The Game

This provides a fix to the bug mentioned above, letting spectators and admins grab a correct amount of points needed for it to level up.

## Proof Of Testing

https://youtu.be/1J1Sc0cyc_A  

## Changelog

:cl:Lucky
fix: Fixed a bug where examining the fleshmind core gave an incorrect points needed to level up
/:cl: