### PR TITLE
Make Acolytes spawn less often and at a higher minimum player count

### DIFF
--- a/modular_zzplurt/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -1,4 +1,4 @@
 /datum/round_event_control/antagonist/solo/heretic
-	weight = 3
+	weight = 4
 	min_players = 35
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG, TAG_MEDIUM)

--- a/modular_zzplurt/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zzplurt/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -1,2 +1,4 @@
 /datum/round_event_control/antagonist/solo/heretic
+	weight = 3
+	min_players = 35
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG, TAG_MEDIUM)


### PR DESCRIPTION

## About The Pull Request
This pull request modifies the acolyte override in order to increase its minimum player count from 20 to 35, and lower its weight from 6 to 3.
## Why It's Good For The Game

Acolytes have been happening almost every medium+ chaos round and are an antagonist that generally changes the entire flow of the round around it. If we are going to keep it as a crewset antagonist (which honestly it kind of feels like it should be a major event rather than crewset at this rate), it'll keep things interesting if they are less seen with how often they happen across a 3 hour round, especially if acolytes are still such a loud antagonist that have a lot of the round revolve around them.
## Proof Of Testing

<img width="1097" height="122" alt="image" src="https://github.com/user-attachments/assets/ec52442f-58a9-4145-b36f-d9e0f6a6450d" />

## Changelog
:cl:Lucky
balance: Acolytes now need 35 players in order to spawn, and have had their weight reduced to 3.
/:cl:
