### PR TITLE
Revert "Add blessed lobotomy + neurectomy behavior"

### DIFF
--- a/code/modules/surgery/operations/operation_lobotomy.dm
+++ b/code/modules/surgery/operations/operation_lobotomy.dm
@@ -52,16 +52,6 @@
 	else if (organ.brainmob)
 		organ.brainmob.mind?.remove_antag_datum(/datum/antagonist/brainwashed)
 
-	// SPLURT EDIT START
-
-	// the idea behind this is to add a version of neurectomies to the system because in the update they were completely removed
-	if (organ.owner?.reagents?.has_reagent(/datum/reagent/medicine/neurine)) // if neurine exists, it simulates the neurectomy by removing the chance of gaining a trauma from a lobotomy
-		if(organ.owner?.reagents?.has_reagent(/datum/reagent/water/holywater)) // if holy water + neurine exists, it heals soulbound traumas
-			organ.cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
-		return
-
-	// SPLURT EDIT END
-
 	if(!prob(75))
 		return
 


### PR DESCRIPTION
Pull request #1078 was written by me as a temporary fix to there being no surgical way to cure soulbound traumas anymore. As of the latest upstream update, there is now a built in way created by Bubber to do these (neurectomies and blessed neurectomies are their own surgery), so this edit to the lobotomy code is an inferior version of it! I'm making this pull request to revert my prior edits since they're no longer needed.