### PR TITLE
Add new alternative "Head of S..." job titles

### DIFF
--- a/modular_zzplurt/code/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_zzplurt/code/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -4,6 +4,7 @@
 		"Automated Station Control",
 		"Central Station System",
 		"Automatic Station Operator",
+		"Head of Silicons",
 		"Automated Voyeur",
 	)
 	LAZYADD(alt_titles, extra_titles)
@@ -18,6 +19,7 @@
 		"Consul",
 		"Cuntpitain",
 		"Senator",
+		"Head of Station",
 		"Station Director",
 		"Station Governor",
 		"Station Master",
@@ -36,6 +38,7 @@
 		"Magos",
 		"Master Architect",
 		"Power Plant Director",
+		"Head of Supermatter",
 		"Project Manager",
 	)
 	LAZYADD(alt_titles, extra_titles)
@@ -51,6 +54,7 @@
 		"Head Of Stations Pets",
 		"Headgiver To Personnel",
 		"Headpat Of Personnel",
+		"Head of Service",
 		"Human Resources",
 		"Personnel Coordinator",
 		"Personnel Manager",
@@ -95,6 +99,7 @@
 		"Lead Developer",
 		"Research Manager",
 		"Science Administrator",
+		"Head of Science",
 		"Sex Research Director",
 	)
 	LAZYADD(alt_titles, extra_titles)
@@ -104,6 +109,7 @@
 	var/list/extra_titles = list(
 		"Chief Heal Slut",
 		"Chief Heal Stud",
+		"Head of Surgery",
 		"Healing Fleshlight Master",
 		"Healing Fleshlight Mistress",
 		"Top Doctor",


### PR DESCRIPTION
Adds HOS, HOS, HOS, HOS, HOS, and HOS alt job titles.
## About The Pull Request

Adds HOS, HOS, HOS, HOS, HOS, and HOS alt job titles.
Did not have to add a HOS job title to QM or HOS due to both already having one. (Head of Supply and Head of Security)

## Why It's Good For The Game

HOS and HOS please report to bridge, the HOS just died and bridge was bombed. HOS set us to amber. HOS, the HOS needs you to order some guns. HOS set Security Officers to priority. HOS please make sure the HOS is revived in ample time.

## Changelog
:cl:
add: HOS alt job title for Chief Engineer
add: HOS alt job title for Research Director
add: HOS alt job title for AI
add: HOS alt job title for Captain
add: HOS alt job title for Head of Personnel
add: HOS alt job title for Chief Medical Officer
/:cl:
