### PR TITLE
Add SPLURT wendigo and restore deathclaw lewd behavior

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -376,6 +376,7 @@
 #include "~skyrat\proteans.dm"
 // SKYRAT EDIT END
 // SPLURT EDIT START
+#include "~splurt\custom_mobs.dm"
 #include "~splurt\underwear_items.dm"
 // SPLURT EDIT END
 // END_INCLUDE

--- a/code/modules/unit_tests/~splurt/custom_mobs.dm
+++ b/code/modules/unit_tests/~splurt/custom_mobs.dm
@@ -1,0 +1,70 @@
+/datum/unit_test/splurt_custom_mobs
+
+/datum/unit_test/splurt_custom_mobs/Run()
+	var/list/custom_mob_types = list(
+		/mob/living/basic/deathclaw,
+		/mob/living/basic/deathclaw/hostile,
+		/mob/living/basic/deathclaw/hostile/alphaclaw,
+		/mob/living/basic/deathclaw/funclaw,
+		/mob/living/basic/deathclaw/funclaw/femclaw,
+		/mob/living/basic/deathclaw/funclaw/femclaw/mommyclaw,
+		/mob/living/basic/werewolf,
+		/mob/living/basic/werewolf/hostile,
+		/mob/living/basic/werewolf/hostile/icewolf,
+		/mob/living/basic/werewolf/hostile/alphawolf,
+		/mob/living/basic/werewolf/funwolf,
+		/mob/living/basic/werewolf/funwolf/alpha,
+		/mob/living/basic/werewolf/funwolf/bitch,
+		/mob/living/basic/werewolf/funwolf/mosley,
+		/mob/living/basic/werewolf/funwolf/hellhound,
+		/mob/living/basic/werewolf/funwolf/hellhound/loona,
+		/mob/living/basic/wendigo,
+		/mob/living/basic/wendigo/hostile
+	)
+	for(var/mob_type in custom_mob_types)
+		var/icon_file = initial(mob_type:icon)
+		var/list/available_states = icon_states(icon_file, 1)
+		var/living_state = initial(mob_type:icon_living)
+		if(!living_state)
+			living_state = initial(mob_type:icon_state)
+		var/dead_state = initial(mob_type:icon_dead)
+		TEST_ASSERT(living_state in available_states, "[mob_type] has missing living icon state '[living_state]'.")
+		if(dead_state)
+			TEST_ASSERT(dead_state in available_states, "[mob_type] has missing dead icon state '[dead_state]'.")
+
+	var/mob/living/basic/deathclaw/funclaw/funclaw = allocate(/mob/living/basic/deathclaw/funclaw)
+	var/mob/living/basic/deathclaw/hostile/alphaclaw/alphaclaw = allocate(/mob/living/basic/deathclaw/hostile/alphaclaw)
+	var/mob/living/basic/deathclaw/funclaw/femclaw/femclaw = allocate(/mob/living/basic/deathclaw/funclaw/femclaw)
+	var/mob/living/basic/werewolf/funwolf/funwolf = allocate(/mob/living/basic/werewolf/funwolf)
+	var/mob/living/basic/wendigo/wendigo = allocate(/mob/living/basic/wendigo)
+	var/datum/interaction/lewd/knotting_check = allocate(/datum/interaction/lewd)
+
+	TEST_ASSERT(funclaw.has_penis(), "The docile Funclaw should expose its simulated penis to interactions.")
+	TEST_ASSERT(funwolf.has_penis(), "The docile werewolf should preserve its existing simulated penis.")
+	TEST_ASSERT(wendigo.has_penis(), "The custom wendigo should expose its legacy simulated penis.")
+	TEST_ASSERT(wendigo.has_anus(), "The custom wendigo should expose its legacy simulated anus.")
+	TEST_ASSERT(wendigo.has_breasts(), "The custom wendigo should expose its legacy simulated breasts.")
+	TEST_ASSERT(wendigo.has_belly(), "The custom wendigo should expose its legacy simulated belly.")
+	TEST_ASSERT(!wendigo.has_vagina(), "The custom wendigo should not gain anatomy absent from the original mob.")
+	TEST_ASSERT(wendigo.simulated_genitals[ORGAN_SLOT_BUTT], "The custom wendigo should expose its legacy simulated butt.")
+	TEST_ASSERT(HAS_TRAIT(wendigo, TRAIT_SNOWSTORM_IMMUNE), "The custom wendigo should retain its cold-weather adaptation.")
+
+	TEST_ASSERT(knotting_check.knot_penis_type(funclaw), "Funclaws should be eligible for knotting interactions.")
+	TEST_ASSERT(knotting_check.knot_penis_type(alphaclaw), "Alpha Funclaws should be eligible for knotting interactions.")
+	TEST_ASSERT(knotting_check.knot_penis_type(funwolf), "Werewolves should remain eligible for knotting interactions.")
+	TEST_ASSERT(!knotting_check.knot_penis_type(femclaw), "Variants without a penis should not be eligible for knotting interactions.")
+
+	funclaw.set_arousal(AROUSAL_LOW)
+	TEST_ASSERT_EQUAL(funclaw.icon_state, "newclaw_cocked", "Arousal should unsheathe a Funclaw.")
+	TEST_ASSERT_EQUAL(funclaw.icon_living, "newclaw_cocked", "A Funclaw should preserve its unsheathed sprite across appearance refreshes.")
+	funclaw.set_arousal(AROUSAL_MINIMUM)
+	TEST_ASSERT_EQUAL(funclaw.icon_state, "newclaw", "A Funclaw should resheathe at zero arousal.")
+	TEST_ASSERT_EQUAL(funclaw.icon_living, "newclaw", "A Funclaw should preserve its sheathed sprite across appearance refreshes.")
+
+	alphaclaw.set_arousal(AROUSAL_LOW)
+	TEST_ASSERT_EQUAL(alphaclaw.icon_state, "alphaclaw_cocked", "Arousal should unsheathe an Alpha Funclaw.")
+	alphaclaw.set_arousal(AROUSAL_MINIMUM)
+	TEST_ASSERT_EQUAL(alphaclaw.icon_state, "alphaclaw", "An Alpha Funclaw should resheathe at zero arousal.")
+
+	femclaw.set_arousal(AROUSAL_LOW)
+	TEST_ASSERT_EQUAL(femclaw.icon_state, "femclaw", "Arousal should not replace a female Funclaw with a male sprite.")

--- a/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/knotting/knotting_logic.dm
+++ b/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/knotting/knotting_logic.dm
@@ -62,9 +62,8 @@
 		if(borg.icon_state in knotty_borgs)
 			return TRUE
 		return FALSE
-	// Need a way to see if a non-carbon/non-cyborg mob's penis has a knot
-	// For now, the only non-carbon/non-cyborg mobs with a penis are funclaws and werewolves so return true for just werewolves
-	if(istype(user, /mob/living/basic/werewolf))
+	// Canine and deathclaw basic mobs use simulated genitals, so their knot cannot be read from an organ datum.
+	if(istype(user, /mob/living/basic/werewolf) || istype(user, /mob/living/basic/deathclaw))
 		return TRUE
 	return FALSE
 

--- a/modular_zzplurt/code/modules/mob/funclaw.dm
+++ b/modular_zzplurt/code/modules/mob/funclaw.dm
@@ -25,62 +25,61 @@
 	faction = list("deathclaw")
 	unsuitable_atmos_damage = 5
 	gold_core_spawnable = HOSTILE_SPAWN
-	//Someone other than me is gonna have to give the mobs lewd stuff. -Evan
-	/*
-	var/charging = FALSE
-	var/has_penis = FALSE
-	var/has_butt = FALSE
-	var/has_breasts = FALSE
-	var/has_vagina = FALSE
-	*/
+	/// Resting sprite for deathclaw variants with a sheath animation.
+	var/sheathed_icon_state
+	/// Aroused sprite for deathclaw variants with a sheath animation.
+	var/aroused_icon_state
 
 /mob/living/basic/deathclaw/Initialize(mapload)
 	. = ..()
 
+/mob/living/basic/deathclaw/set_arousal(amount)
+	. = ..()
+	update_arousal_icon_state()
+
+/// Keeps the living icon in sync so revival and other appearance refreshes preserve the sheath state.
+/mob/living/basic/deathclaw/proc/update_arousal_icon_state()
+	if(!sheathed_icon_state || !aroused_icon_state || stat == DEAD)
+		return
+	var/desired_icon_state = arousal > AROUSAL_MINIMUM ? aroused_icon_state : sheathed_icon_state
+	if(icon_living == desired_icon_state)
+		return
+	icon_living = desired_icon_state
+	icon_state = desired_icon_state
+	if(arousal > AROUSAL_MINIMUM)
+		visible_message(span_lewd("[src]'s cock unsheathes."))
+	else
+		visible_message(span_lewd("[src]'s cock retracts into its sheath."))
+
 /mob/living/basic/deathclaw/hostile
 	icon_state = "newclaw"
+	icon_living = "newclaw"
 	ai_controller = /datum/ai_controller/basic_controller/simple/simple_hostile
-	/*
-	var/base_state = "newclaw"
-	var/cock_state = "newclaw_cocked"
-	var/cock_shown = FALSE
-	*/
+	sheathed_icon_state = "newclaw"
+	aroused_icon_state = "newclaw_cocked"
+	simulated_genitals = list(
+		ORGAN_SLOT_PENIS = TRUE,
+		ORGAN_SLOT_ANUS = TRUE
+	)
 
 /mob/living/basic/deathclaw/hostile/alphaclaw
 	name = "Alpha Funclaw"
 	icon_state = "alphaclaw"
+	icon_living = "alphaclaw"
 	ai_controller = /datum/ai_controller/basic_controller/simple/simple_hostile_obstacles
-	//base_state = "alphaclaw"
-	//cock_state = "alphaclaw_cocked"
+	sheathed_icon_state = "alphaclaw"
+	aroused_icon_state = "alphaclaw_cocked"
 
 /mob/living/basic/deathclaw/hostile/death()
 	..()
 	gib()
 
-/*
-/mob/living/basic/hostile/deathclaw/funclaw/gentle/newclaw/proc/show_cock()
-	if (cock_shown)
-		return
-	cock_shown = TRUE
-	icon_state = cock_state
-	visible_message("<font color=purple><b>\The [src]</b>'s cock unsheathes.</font>")
-
-/mob/living/basic/hostile/deathclaw/funclaw/gentle/newclaw/proc/hide_cock()
-	if (!cock_shown)
-		return
-	cock_shown = FALSE
-	icon_state = base_state
-	visible_message("<font color=purple><b>\The [src]</b>'s cock slowly retracts back into its sheath.</font>")
-
-/mob/living/basic/hostile/deathclaw/funclaw/gentle/newclaw/handle_post_sex(amount, orifice, mob/living/partner)
-	..()
-	if (lust > 0)
-		show_cock()
-	else
-		hide_cock()
-*/
 /mob/living/basic/deathclaw/funclaw/
 	name = "Docile Deathclaw"
+	icon_state = "newclaw"
+	icon_living = "newclaw"
+	sheathed_icon_state = "newclaw"
+	aroused_icon_state = "newclaw_cocked"
 	simulated_genitals = list(
 		ORGAN_SLOT_PENIS = TRUE,
 		ORGAN_SLOT_ANUS = TRUE
@@ -89,12 +88,15 @@
 
 /mob/living/basic/deathclaw/funclaw/femclaw
 	icon_state = "femclaw"
+	icon_living = "femclaw"
 	gender = FEMALE
 	name = "Docile Breasted Funclaw"
 	desc = "She's large and in charge."
 	maxHealth = 400
 	health = 400
 	armour_penetration = 45
+	sheathed_icon_state = null
+	aroused_icon_state = null
 	simulated_genitals = list(
 		ORGAN_SLOT_PENIS = FALSE,
 		ORGAN_SLOT_ANUS = TRUE,
@@ -104,6 +106,7 @@
 
 /mob/living/basic/deathclaw/funclaw/femclaw/mommyclaw
 	icon_state = "mommyclaw"
+	icon_living = "mommyclaw"
 	desc = "A machine that turns her victim's pelv<b>is</b> into pelv<b>was</b>."
 	name = "Mommy Funclaw"
 	maxHealth = 1000

--- a/modular_zzplurt/code/modules/mob/wendigo.dm
+++ b/modular_zzplurt/code/modules/mob/wendigo.dm
@@ -1,0 +1,42 @@
+/// SPLURT's custom wendigo, originally implemented by MosleyTheMalO and Comicao1.
+/// Adapted from VENUS Station's snowflake carbon mob to the current basic mob and simulated genital systems.
+/mob/living/basic/wendigo
+	name = "wendigo"
+	desc = "A towering horned creature adapted to the cold, with an imposing frame and an unnervingly intelligent gaze."
+	icon = 'modular_zzplurt/icons/mobs/wendigo.dmi'
+	icon_state = "reference"
+	icon_living = "reference"
+	icon_dead = "reference"
+	basic_mob_flags = FLIP_ON_DEATH
+	gender = FEMALE
+	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST)
+	ai_controller = /datum/ai_controller/basic_controller
+	speak_emote = list("growls", "snorts")
+	attack_verb_continuous = "claws"
+	attack_verb_simple = "claw"
+	attack_sound = 'sound/effects/magic/demon_attack1.ogg'
+	attack_vis_effect = ATTACK_EFFECT_CLAW
+	maxHealth = 200
+	health = 200
+	melee_damage_lower = 15
+	melee_damage_upper = 20
+	obj_damage = 20
+	see_in_dark = 8
+	faction = list("wendigo")
+	unsuitable_atmos_damage = 5
+	gold_core_spawnable = FRIENDLY_SPAWN
+	simulated_genitals = list(
+		ORGAN_SLOT_PENIS = TRUE,
+		ORGAN_SLOT_ANUS = TRUE,
+		ORGAN_SLOT_BREASTS = TRUE,
+		ORGAN_SLOT_BELLY = TRUE,
+		ORGAN_SLOT_BUTT = TRUE
+	)
+
+/mob/living/basic/wendigo/Initialize(mapload)
+	. = ..()
+	add_traits(list(TRAIT_SNOWSTORM_IMMUNE), INNATE_TRAIT)
+
+/mob/living/basic/wendigo/hostile
+	ai_controller = /datum/ai_controller/basic_controller/simple/simple_hostile
+	gold_core_spawnable = HOSTILE_SPAWN

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -11075,6 +11075,7 @@
 #include "modular_zzplurt\code\modules\mob\funclaw.dm"
 #include "modular_zzplurt\code\modules\mob\mob.dm"
 #include "modular_zzplurt\code\modules\mob\mob_update_icons.dm"
+#include "modular_zzplurt\code\modules\mob\wendigo.dm"
 #include "modular_zzplurt\code\modules\mob\werewolves.dm"
 #include "modular_zzplurt\code\modules\mob\dead\new_player\new_player.dm"
 #include "modular_zzplurt\code\modules\mob\dead\new_player\title_screen_html.dm"


### PR DESCRIPTION
Closes #30

## About The Pull Request

The current codebase already contains the werewolf and deathclaw families brought over under #76. The remaining bounty work was the missing lewd behavior on deathclaws and the absent SPLURT wendigo.

This PR:

- adds friendly and hostile `/mob/living/basic/wendigo` types using the original wendigo sprite already present in the repository;
- represents the legacy wendigo anatomy through the current `simulated_genitals` system and retains its cold-weather immunity;
- gives docile and hostile deathclaws their intended simulated anatomy and restores knotting eligibility;
- drives the existing deathclaw sheath/unsheathed sprites from the current arousal value while keeping `icon_living` synchronized for appearance refreshes and revival;
- adds a unit test covering every existing deathclaw, werewolf, and wendigo icon state, plus anatomy, knotting, sheath transitions, female sprite safety, and cold immunity.

The wendigo is intentionally implemented as a current `basic` mob. Porting the old custom carbon type would also port a bespoke HUD, bodypart and organ stack that duplicates systems which have changed substantially since the rebase. The old autonomous sexual AI was not carried over; interactions remain under the current interaction and consent systems.

Port attribution: the wendigo behavior is adapted from the original SPLURT implementation in [VENUS Station](https://github.com/Just-Sim/VENUS-Station-SimDev/tree/ed48aedae66d638e8790b85d54456fa9ae401624/modular_splurt/code/modules/antagonists/wendigo), originally implemented by MosleyTheMalO with later work by Comicao1 and Tsurupeta. The existing wendigo DMI in this repository is reused unchanged.

## Why It's Good For The Game

This completes the part of the bounty that was not already covered by #76 without duplicating existing wolves or inventing cosmetic subtypes. It restores the intended interaction behavior to Funclaws and makes the original horned wendigo usable again through systems maintainers already support.

Using a regular basic mob keeps AI, lifecycle behavior, gold-core spawning, and interaction anatomy consistent with the rest of the rebased code. The focused implementation is easier to review and maintain than reviving the old snowflake carbon hierarchy.

## Proof Of Testing

- `/Users/MAC/.cargo/bin/dreamchecker`: `Found 0 diagnostics`
- `/opt/homebrew/bin/bash tools/ci/check_grep.sh`: `No errors found using rg!`
- `tools/build/build.sh dm-maps-include`: passed
- `git diff --check`: passed

The new BYOND unit test is included in `_unit_tests.dm`, but a BYOND runtime/test server is not available on the local macOS environment, so I could not honestly claim a local runtime unit-test pass or an in-game screenshot. CI should execute the runtime coverage.

<details>
<summary>Screenshots/Videos</summary>

Existing wendigo `reference` state, one frame in all four directions (sprite-sheet extraction, not an in-game screenshot):

![Wendigo reference sprite](https://raw.githubusercontent.com/metloub/S.P.L.U.R.T-tg/592b376daf510091e14dbbbdd16627607c36bd20/.github/pr-assets/bounty-30/wendigo-reference.png)

</details>

## Changelog

:cl: metloub
add: Added friendly and hostile SPLURT wendigos to gold slime mob spawning.
fix: Deathclaws now expose their intended interaction anatomy and support knotting.
image: Deathclaw sheath sprites now follow their arousal state.
/:cl:
