### PR TITLE
Fixes Cursekins and Lycans being able to pick Entombed quirk (Early upstream)

### DIFF
--- a/modular_zzplurt/code/datums/quirks/neutral_quirks/entombed.dm
+++ b/modular_zzplurt/code/datums/quirks/neutral_quirks/entombed.dm
@@ -1,0 +1,3 @@
+//override of override, this shit is hellish
+/datum/quirk/equipping/entombed
+	species_blacklist = list(SPECIES_PROTEAN, SPECIES_LYCAN, SPECIES_CURSEKIN)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10677,6 +10677,7 @@
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\cum_plus.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\cum_sniff.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\cursed_blood.dm"
+#include "modular_zzplurt\code\datums\quirks\neutral_quirks\entombed.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\excitable.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\fluid_infuser.dm"
 #include "modular_zzplurt\code\datums\quirks\neutral_quirks\gargoyle.dm"


### PR DESCRIPTION

## About The Pull Request

This PR overrides the blacklist of Entombed quirk to also include Lycans and Cursekins as this quirk enables them to duplicate the modsuit and that they really shouldn't be compatible with any cybernetic. Also it appears that they were blacklisted before but protean override forgot about them.
## Why It's Good For The Game

Exploits bad 💥 
## Proof Of Testing

Ran it, works as intended with no relevant runtimes
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Lycans and Cursekins are once again blacklisted from Entombed quirk
/:cl:
