### PR TITLE
Fix sex borg - i mean secborg linking to ai

### DIFF
--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -44,6 +44,8 @@
 			continue
 		if(sync_target.connected_ai)
 			continue
+		if(sync_target.job == "Security Cyborg")
+			continue
 		sync_target.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
 		sync_target.set_connected_ai(ai_spawn)
 		log_combat(ai_spawn, sync_target, "synced cyborg [sync_target] to [ai_spawn] (AI spawn syncage)") // BUBBER EDIT - PUBLIC LOGS CLEANUP

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -44,8 +44,8 @@
 			continue
 		if(sync_target.connected_ai)
 			continue
-		if(sync_target.job == "Security Cyborg")
-			continue
+		if(sync_target.job == "Security Cyborg") // SPLURT Edit, prevents sec borgs being linked to late join AI
+			continue // SPLURT Edit, prevents sec borgs being linked to late join AI
 		sync_target.notify_ai(AI_NOTIFICATION_CYBORG_DISCONNECTED)
 		sync_target.set_connected_ai(ai_spawn)
 		log_combat(ai_spawn, sync_target, "synced cyborg [sync_target] to [ai_spawn] (AI spawn syncage)") // BUBBER EDIT - PUBLIC LOGS CLEANUP


### PR DESCRIPTION

## About The Pull Request

AI late join now checks if a cyborg's job is "Security Cyborg" and if so it breaks out of the if statement early, preventing AI sync- similar to emagged cyborgs or cyborgs that are already linked to an AI.

## Why It's Good For The Game

Fixes sex borg I mean sec borg, so they have to spend less time whining in ahelps about how they're linked to the AI and more time pounding me

## Proof Of Testing

I did actually test this shit, so trust me fam

## Changelog
:cl:
fix: Sec borg no longer gets linked to late join AI
/:cl:
