### PR TITLE
Makes "Remove Assimilated Modsuit" verb visible again

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -190,7 +190,8 @@
 		return UI_INTERACTIVE
 	. = ..()
 
-GAME_VERB_HIDDEN(/obj/item/mod/control/pre_equipped/protean, remove_modsuit, "Remove Assimilated Modsuit")
+/obj/item/mod/control/pre_equipped/protean/verb/remove_modsuit()
+	set name = "Remove Assimilated Modsuit"
 	var/obj/item/mod/core/protean/p_core = core
 	to_chat(usr, span_notice("You begin to pry at the [stored_modsuit] to seperate it."))
 	if(!do_after(usr, 5 SECONDS))


### PR DESCRIPTION
Let me preface this;
This is in **no way** adding a feature to the game.
This feature **already exists**, in order to use it you must type "Remove-Assimilated-Modsuit" in the command/verb bar
<img width="506" height="604" alt="image" src="https://github.com/user-attachments/assets/e876f1aa-519a-4d57-ac30-71e9a9d5e2eb" />

What his PR does is **readd** the ability to right click the protean control unit and remove assimilated modsuits that way.
## About The Pull Request

Reverts changes to protean_modsuit.dm by commit 0b070c1

The reason for this change isn't documented anywhere, and as far as I can tell it has made it extremely difficult to remove assimilated modsuits from proteans (as now you need esoteric knowledge in the form of typing hidden verbs into the chat bar in the bottom right)
## Why It's Good For The Game

You shouldn't need esoteric game knowledge to know how to unassimilate a protean from their modsuit 

## Proof Of Testing
Verb shows up when holding a protean modsuit and right clicking.
Verb does not show up for normal modsuits.
Verb does not show up when the protean is on the floor, you **must** hold them
<summary>Screenshots/Videos</summary>
<br/>Protean modsuit: <br/>
<img width="654" height="264" alt="image" src="https://github.com/user-attachments/assets/26ee7675-6c1d-44fa-8328-0f2ff4de8f0f" />
<br/>Modsuit: <br/>
<img width="486" height="206" alt="image" src="https://github.com/user-attachments/assets/60288c6b-1b41-487f-9f59-1c0399988ae9" />
<br/>Protean modsuit on floor<br/>
<img width="598" height="218" alt="image" src="https://github.com/user-attachments/assets/29d79db8-facf-4e68-8ef1-b2de396467bd" />
<br/>


## Bugs
There is one bug that I am aware of (it already exists when using the command/verb bar method) in which if you have your activate hand occupied when you unassimilate the protean the modsuit (**NOT THE PROTEAN**) is deleted<br/>
(i.e. if you have an elite protean modsuit, you have an empty hand as your active hand and unassimilate the modsuit you end up with an elite modsuit and a default protean modsuit **however** if you have something (anything) in your active hand when you do this the elite modsuit is deleted)<br/>
I am too much of a script kiddie to fix this, I'm pretty sure that you're not meant to be able to use the verb unless your active hand is empty (and swapping hands should cancel the do-after) but again, t**his bug already exists and exists with the current command/verb bar method** all this PR does is make the unassimilate modsuit verb visible so it's not esoteric knowledge.

## Changelog
:cl:
qol: Makes "Remove Assimilated Modsuit" a visible verb again
/:cl:
