### PR TITLE
Stops Lone Operative from spawning on Extended or lowpop

### DIFF
--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -2,7 +2,6 @@
 #define LONEOP_DELAY 3
 
 /obj/item/disk/nuclear/unsecured_process(last_move)
-
 	//If there is no assigned captain, then don't run the event.
 	if(!SSjob || !SSjob.assigned_captain)
 		return

--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -9,7 +9,7 @@
 
 	/// SPLURT EDIT BEGIN
 	// if the storyteller is extended, don't run the event
-	if(istype(SSgamemode.storyteller, /datum/storyteller/extended))
+	if(!SSgamemode.can_inject_antags())
 		return
 
 	// if there's less than 50 active crew members, then don't run the event

--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -1,35 +1,20 @@
 #define GRACE_PERIOD 45 MINUTES
 #define LONEOP_DELAY 3
 
-/// SPLURT EDIT BEGIN
-/obj/item/disk/nuclear
-	var/admins_informed = FALSE // used to make sure the admins arent called repeatedly
-/// SPLURT EDIT END
-
 /obj/item/disk/nuclear/unsecured_process(last_move)
-	/// SPLURT EDIT BEGIN
 
 	//If there is no assigned captain, then don't run the event.
 	if(!SSjob || !SSjob.assigned_captain)
-		if(!admins_informed) /// SPLURT EDIT - adds a new one-time message to admins for this
-			message_admins("Lone Operative failed to spawn as there is no active Captain.")
-			admins_informed = TRUE
 		return
 
+	/// SPLURT EDIT BEGIN
 	// if the storyteller is extended, don't run the event
 	if(istype(SSgamemode.storyteller, /datum/storyteller/extended))
-		if(!admins_informed)
-			message_admins("Lone Operative failed to spawn as the storyteller is extended.")
-			admins_informed = TRUE
 		return
 
 	// if there's less than 50 active crew members, then don't run the event
 	if(SSgamemode.active_crew < 50)
-		if(!admins_informed)
-			message_admins("Lone Operative failed to spawn as there's less than 50 crew members.")
-			admins_informed = TRUE
 		return
-
 	/// SPLURT EDIT END
 
 	if(last_move < world.time - GRACE_PERIOD)

--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -1,10 +1,36 @@
 #define GRACE_PERIOD 45 MINUTES
 #define LONEOP_DELAY 3
 
+/// SPLURT EDIT BEGIN
+/obj/item/disk/nuclear
+	var/admins_informed = FALSE // used to make sure the admins arent called repeatedly
+/// SPLURT EDIT END
+
 /obj/item/disk/nuclear/unsecured_process(last_move)
+	/// SPLURT EDIT BEGIN
+
 	//If there is no assigned captain, then don't run the event.
 	if(!SSjob || !SSjob.assigned_captain)
+		if(!admins_informed) /// SPLURT EDIT - adds a new one-time message to admins for this
+			message_admins("Lone Operative failed to spawn as there is no active Captain.")
+			admins_informed = TRUE
 		return
+
+	// if the storyteller is extended, don't run the event
+	if(istype(SSgamemode.storyteller, /datum/storyteller/extended))
+		if(!admins_informed)
+			message_admins("Lone Operative failed to spawn as the storyteller is extended.")
+			admins_informed = TRUE
+		return
+
+	// if there's less than 50 active crew members, then don't run the event
+	if(SSgamemode.active_crew < 50)
+		if(!admins_informed)
+			message_admins("Lone Operative failed to spawn as there's less than 50 crew members.")
+			admins_informed = TRUE
+		return
+
+	/// SPLURT EDIT END
 
 	if(last_move < world.time - GRACE_PERIOD)
 		begin_nuclear_assault()

--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -7,7 +7,7 @@
 		return
 
 	/// SPLURT EDIT BEGIN
-	// if the storyteller is extended, don't run the event
+	// if the storyteller can't have antags, don't run the event
 	if(!SSgamemode.can_inject_antags())
 		return
 

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
@@ -2,3 +2,4 @@
 	population_max = null
 	votable = TRUE
 	storyteller_type = STORYTELLER_TYPE_CALM
+	antag_divisor = 0

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
@@ -16,6 +16,7 @@
 	name = "Freeform Chaos (OPFOR)"
 	desc = "Random events at a moderate pace and antagonists will be player generated."
 	welcome_text = span_bold(" (Open an OPFOR application if you're interested in becoming an antagonist for this round!)")
+	antag_divisor = 0
 
 	track_data = /datum/storyteller_data/tracks/medium/opfor
 


### PR DESCRIPTION

## About The Pull Request
Bubber in the upstream updated how Lone Operative spawns. This edit adds criteria so that it no longer spawns on Extended or below 50 pop, which was our old criteria for Lone Operative.
## Why It's Good For The Game
This matches Lone Operative with the criteria we had for it to spawn before the upstream.

## Proof Of Testing

<img width="488" height="42" alt="image" src="https://github.com/user-attachments/assets/f993a4b0-117c-4aea-bec0-9c74482b0589" />

[https://youtu.be/2unNevwqELc](https://youtu.be/2unNevwqELc) - Lone Operative happened immediately as I lowered the cooldown for testing purposes

## Changelog
:cl:Lucky
balance: Lone Operative can no longer spawn on Extended or with under 50 players on.
/:cl:
