### PR TITLE
Adds the denied stat to the denied opfor reports stats

### DIFF
--- a/modular_zubbers/code/controllers/subsystem/ticker.dm
+++ b/modular_zubbers/code/controllers/subsystem/ticker.dm
@@ -104,7 +104,7 @@
 /datum/controller/subsystem/ticker/proc/opfor_report()
 	var/list/result = list()
 
-	result += "<span class='header'>Opposing Force Report - <span class='greentext header'>Approved: [LAZYLEN(SSopposing_force.approved_applications)]</span>, <span class='redtext header'>Denied: [LAZYLEN(SSopposing_force.submitted_applications)]</span></span><br>"
+	result += "<span class='header'>Opposing Force Report - <span class='greentext header'>Approved: [LAZYLEN(SSopposing_force.approved_applications)]</span>, <span class='redtext header'>Denied: [LAZYLEN(SSopposing_force.submitted_applications)+LAZYLEN(SSopposing_force.unsubmitted_applications)]</span></span><br>"
 
 	if(!SSopposing_force.approved_applications.len)
 		result += span_red("No applications were approved.")


### PR DESCRIPTION

## About The Pull Request
Adds denied applications to stat. Missed since this is very hard to test locally without the ability to approve/deny your own applications.
## Why It's Good For The Game
Fixes: #1182
## Changelog
:cl:
fix: Denied opfor stat not showing all the denied apps
/:cl:
