### PR TITLE
Edit the name of the Freeform Storyteller

### DIFF
--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
@@ -14,7 +14,7 @@
 
 /datum/storyteller/medium/opfor
 	name = "Freeform Chaos (Events/No Antag Rolls)"
-	desc = "Random events at a moderate pace and antagonists come from space or player generation (OPFORs) rather than from inside the crew.."
+	desc = "Random events at a moderate pace and antagonists come from space or player generation (OPFORs) rather than from inside the crew."
 	welcome_text = span_bold("We must set aside our differences, and work with our fellow nations, all united towards one goal: the complete and utter annihilation of the godless Belgians.")
 
 	track_data = /datum/storyteller_data/tracks/medium/opfor

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
@@ -13,9 +13,9 @@
 	storyteller_type = STORYTELLER_TYPE_INTENSE
 
 /datum/storyteller/medium/opfor
-	name = "Freeform Chaos (OPFOR)"
-	desc = "Random events at a moderate pace and antagonists will be player generated."
-	welcome_text = span_bold(" (Open an OPFOR application if you're interested in becoming an antagonist for this round!)")
+	name = "Freeform Chaos (Events/No Antag Rolls)"
+	desc = "Random events at a moderate pace and antagonists come from space or player generation (OPFORs) rather than from inside the crew.."
+	welcome_text = span_bold("We must set aside our differences, and work with our fellow nations, all united towards one goal: the complete and utter annihilation of the godless Belgians.")
 
 	track_data = /datum/storyteller_data/tracks/medium/opfor
 

--- a/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
+++ b/modular_zzplurt/code/modules/storyteller/storytellers/tellers/storyteller_2_medium.dm
@@ -14,7 +14,7 @@
 
 /datum/storyteller/medium/opfor
 	name = "Freeform Chaos (Events/No Antag Rolls)"
-	desc = "Random events at a moderate pace and antagonists come from space or player generation (OPFORs) rather than from inside the crew."
+	desc = "Random events at a moderate pace and antagonists come from space or player generation (OPFORs) rather than from random generation."
 	welcome_text = span_bold("We must set aside our differences, and work with our fellow nations, all united towards one goal: the complete and utter annihilation of the godless Belgians.")
 
 	track_data = /datum/storyteller_data/tracks/medium/opfor


### PR DESCRIPTION

## About The Pull Request
A lot of misunderstandings came from the initial naming of the Freeform Chaos storyteller because of the 'OPFOR' inclusion. The intention of the suggestion that had large support was for Extended+, but there's been a lot of confusion of admins not being present or pressing events because of the 'OPFOR' title. This pull request changes it cosmetically to try and clarify the storyteller's initial intent of not having crewset events and instead focusing on random events.
## Why It's Good For The Game
There's a lot of confusion around this storyteller right now and people were frustrated admins weren't present or causing more chaos in a round because of the OPFOR title specifically. Renaming it a little like this would help with that confusion. I'm fine with the text of it being changed too, I think it could just use less emphasis on the 'OPFOR' title.

## Proof Of Testing
To Be Added

## Changelog
:cl:Lucky
change: The Freeform Chaos (OPFOR) storyteller has been renamed to Freeform Chaos (Events/No Antags).
/:cl: