### PR TITLE
Early upstream .38 truestrike buff pull(?)

### DIFF
--- a/modular_zzplurt/code/modules/modular_weapons/code/ammo.dm
+++ b/modular_zzplurt/code/modules/modular_weapons/code/ammo.dm
@@ -147,6 +147,11 @@
 /obj/projectile/bullet/c46x30mm/ap
 	armour_penetration = 45
 
+/obj/projectile/bullet/c38/match/true
+	damage = 20
+	ricochet_auto_aim_range = 4
+	armour_penetration = 35
+
 // PRIVATE SECURITY AR AMMO CODE
 
 /obj/item/ammo_box/magazine/c68


### PR DESCRIPTION
## About The Pull Request

Adds an override that adds the .38 truestrike buff changes from upstream, https://github.com/tgstation/tgstation/pull/97672. Just so we're not waiting such and such months for Bubber to eventually get around to merging it, and if they do (or don't) then override doesn't really change much and can be easily removed if need be.

## Why It's Good For The Game

I would read the original PRs reasoning behind it for a better understandning, but TLDR: Standard .38 ammunition was dealing more damage against standard armoured vests than the dedicated armour piercing rounds for that calibre. This is bad, especially considering truestrike is 'late' game tech.

## Proof Of Testing

It... Works. It's a number change. I've also gone ahead and tested the rounds itself. I forgot to grab screenshots. Please don't make me boot a server again and waste 5 minutes of my time... Please, please, please.

## Changelog

:cl:
balance: .38 Truestrike now does 20 damage and has better AP.
/:cl: