### PR TITLE
Removes the ritual objective from wizard

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/summons.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/summons.dm
@@ -2,7 +2,6 @@
 /// How much threat we need to let these rituals happen on dynamic
 #define MINIMUM_THREAT_FOR_RITUALS 98
 
-/* SPLURT EDIT START - makes ghosts not buyable lazy style
 /datum/spellbook_entry/summon/ghosts
 	name = "Summon Ghosts"
 	desc = "Spook the crew out by making them see dead people. \
@@ -14,7 +13,6 @@
 	summon_ghosts(user)
 	playsound(get_turf(user), 'sound/effects/ghost2.ogg', 50, TRUE)
 	return ..()
-SPLURT EDIT END */
 
 /datum/spellbook_entry/summon/guns
 	name = "Summon Guns"

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -120,8 +120,8 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 
 /// Initialises the grand ritual action for this mob
 /datum/antagonist/wizard/proc/assign_ritual()
-	ritual = new(src)
-	RegisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE, PROC_REF(on_ritual_complete))
+	// ritual = new(src) // SPLURT EDIT - No ritual quest
+	// RegisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE, PROC_REF(on_ritual_complete)) // SPLURT EDIT - No ritual quest
 
 /datum/antagonist/wizard/proc/send_to_lair()
 	// And now we ensure that its loaded

--- a/tgui/packages/tgui/interfaces/AntagInfoWizard.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoWizard.tsx
@@ -82,9 +82,9 @@ export const AntagInfoWizard = (props) => {
                     }
                   />
                 </Stack.Item>
-                <Stack.Item>
-                  <RitualPrintout ritual={ritual} />
-                </Stack.Item>
+{/*                <Stack.Item> // SPLURT EDIT: No rituals */}
+{/*                  <RitualPrintout ritual={ritual} /> // SPLURT EDIT: No rituals */}
+{/*                </Stack.Item> // SPLURT EDIT: No rituals */}
                 {/* SKYRAT EDIT ADDITION START */}
                 <Stack.Item>
                   <Rules />


### PR DESCRIPTION

## About The Pull Request
Ritual rune events and finales too disruptive. Was asked to disable.

@MosleyTheMalO @toastewoofs Might also consider these settings in game_options.txt which control whether the wizard can mess with events/summon guns/spells to everyone.

<img width="694" height="106" alt="image" src="https://github.com/user-attachments/assets/e0ef8619-059a-4dd3-82f7-2da0e74953e1" />

## Why It's Good For The Game
Less intense wizard antics

## Proof Of Testing
Tested locally

## Changelog
:cl:
del: Removes wizard ritual objective
/:cl:
