### PR TITLE
Simplify knife requirements for Acolyte

### DIFF
--- a/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
@@ -8,11 +8,15 @@
 /datum/heretic_knowledge/New()
 	. = ..()
 
-	// replacing items with harder ones
-	for (var/atom/type as anything in required_atoms)
-		if (ispath(type, /obj/item/knife))
-			required_atoms -= type
-			required_atoms[/obj/item/knife/kitchen] = 1
+/*
+* SPLURT EDIT CHANGE - It's subjective, but people had complained it was annoying.
+*	// replacing items with harder ones
+*	for (var/atom/type as anything in required_atoms)
+*		if (ispath(type, /obj/item/knife))
+*			required_atoms -= type
+*			required_atoms[/obj/item/knife/kitchen] = 1
+* SPLURT EDIT END
+*/
 
 /datum/heretic_knowledge/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This is a quality of life change. Comments out a block of code that forced heretics to get kitchen knives instead of everything under/obj/item/knife (so shivs and such.)

## Why It's Good For The Game

It forced heretics to all go through the kitchen if they wanted their kopesh, which is silly.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="550" height="405" alt="image" src="https://github.com/user-attachments/assets/f8505d39-4375-4958-af5d-66bc51a421b3" />
<img width="543" height="396" alt="image" src="https://github.com/user-attachments/assets/04109bef-cc35-40fe-99b2-d05f36c13e06" />

</details>

## Changelog
:cl: Dragon Lee
qol: the heretic blade ritual can now use knives other than the kitchen knife
/:cl:
