### PR TITLE
Re-Enable heretic/acolyte roll for Chaplains

### DIFF
--- a/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
@@ -8,13 +8,11 @@
 /datum/heretic_knowledge/New()
 	. = ..()
 
-	/*
-*	SPLURT EDIT CHANGE - You can be a vampire, changeling chaplain and a traitor, so why not the one role that actually thematically fits with the whole religious stuff?
-*	/datum/round_event_control/antagonist/solo/heretic/New()
-*		protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
-*		. = ..()
-*	SPLURT EDIT END
-	*/
+	// replacing items with harder ones
+	for (var/atom/type as anything in required_atoms)
+		if (ispath(type, /obj/item/knife))
+			required_atoms -= type
+			required_atoms[/obj/item/knife/kitchen] = 1
 
 /datum/heretic_knowledge/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	. = ..()

--- a/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
@@ -8,11 +8,13 @@
 /datum/heretic_knowledge/New()
 	. = ..()
 
-	// replacing items with harder ones
-	for (var/atom/type as anything in required_atoms)
-		if (ispath(type, /obj/item/knife))
-			required_atoms -= type
-			required_atoms[/obj/item/knife/kitchen] = 1
+	/*
+*	SPLURT EDIT CHANGE - You can be a vampire, changeling chaplain and a traitor, so why not the one role that actually thematically fits with the whole religious stuff?
+*	/datum/round_event_control/antagonist/solo/heretic/New()
+*		protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
+*		. = ..()
+*	SPLURT EDIT END
+	*/
 
 /datum/heretic_knowledge/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	. = ..()

--- a/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
@@ -8,11 +8,15 @@
 /datum/heretic_knowledge/New()
 	. = ..()
 
-	// replacing items with harder ones
-	for (var/atom/type as anything in required_atoms)
-		if (ispath(type, /obj/item/knife))
-			required_atoms -= type
-			required_atoms[/obj/item/knife/kitchen] = 1
+/*
+* SPLURT EDIT CHANGE - It's subjective, but people had complained it was annoying.
+*	// replacing items with harder ones
+*	for (var/atom/type as anything in required_atoms)
+*		if (ispath(type, /obj/item/knife))
+*			required_atoms -= type
+*			required_atoms[/obj/item/knife/kitchen] = 1
+* SPLURT EDIT END
+*/
 
 /datum/heretic_knowledge/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	. = ..()

--- a/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/knowledge/heretic_knowledge.dm
@@ -8,15 +8,11 @@
 /datum/heretic_knowledge/New()
 	. = ..()
 
-/*
-* SPLURT EDIT CHANGE - It's subjective, but people had complained it was annoying.
-*	// replacing items with harder ones
-*	for (var/atom/type as anything in required_atoms)
-*		if (ispath(type, /obj/item/knife))
-*			required_atoms -= type
-*			required_atoms[/obj/item/knife/kitchen] = 1
-* SPLURT EDIT END
-*/
+	// replacing items with harder ones
+	for (var/atom/type as anything in required_atoms)
+		if (ispath(type, /obj/item/knife))
+			required_atoms -= type
+			required_atoms[/obj/item/knife/kitchen] = 1
 
 /datum/heretic_knowledge/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	. = ..()

--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -12,9 +12,13 @@
 
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG)
 
+/*
 /datum/round_event_control/antagonist/solo/heretic/New()
 	protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
 	. = ..()
+// You can be a vampire, changeling chaplain and a traitor, so why not the one role
+// that actually thematically fits with the whole religious stuff?
+*/
 
 #define TIME_CUTOFF 1.2 HOURS
 /datum/round_event_control/antagonist/solo/heretic/midround

--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -12,13 +12,13 @@
 
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG)
 
-/*
-/datum/round_event_control/antagonist/solo/heretic/New()
-	protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
-	. = ..()
-// You can be a vampire, changeling chaplain and a traitor, so why not the one role
-// that actually thematically fits with the whole religious stuff?
-*/
+	/*
+*	SPLURT EDIT CHANGE - You can be a vampire, changeling chaplain and a traitor, so why not the one role that actually thematically fits with the whole religious stuff?
+*	/datum/round_event_control/antagonist/solo/heretic/New()
+*		protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
+*		. = ..()
+*	SPLURT EDIT END
+	*/
 
 #define TIME_CUTOFF 1.2 HOURS
 /datum/round_event_control/antagonist/solo/heretic/midround

--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -12,13 +12,15 @@
 
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG)
 
-	/*
-*	SPLURT EDIT CHANGE - You can be a vampire, changeling chaplain and a traitor, so why not the one role that actually thematically fits with the whole religious stuff?
-*	/datum/round_event_control/antagonist/solo/heretic/New()
-*		protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
-*		. = ..()
-*	SPLURT EDIT END
-	*/
+
+
+/datum/round_event_control/antagonist/solo/heretic/New()
+/*
+* 	SPLURT EDIT CHANGE - You can be a vampire, changeling chaplain and a traitor, so why not the one role that actually thematically fits with the whole religious stuff?
+*	protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
+* 	SPLURT EDIT END
+*/
+	. = ..()
 
 #define TIME_CUTOFF 1.2 HOURS
 /datum/round_event_control/antagonist/solo/heretic/midround


### PR DESCRIPTION

## About The Pull Request
Comments out the code block that restricts chaplains from rolling heretic.

## Why It's Good For The Game
It's arguably a subjective change and a biased one on my end. My argument is that if you can be a vampire chaplain (who can literally burn in their own church), you should be able to become a heretic chaplain. Aside from that, I believe magic immunity can be gotten from different sources, like drinking silver? Holding a nullrod- the character trait, etc.

I also believe a heretical chaplain is quite thematic, and would make for interesting roleplay. (Imagine them turning their chapel into horrible ritual grounds for everyone to see)

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

I can't easily prove that it works since I'd need to roll the heretic naturally on a chaplain with enough players in the round, but I have compiled the code many times and gotten no errors.

## Changelog
:cl: Dragon Lee
add: The chaplain can now roll the heretic antagonist again.
/:cl:
